### PR TITLE
 users to access a vulnerabilities edit page from the vuln dedicated page view

### DIFF
--- a/UI/src/features/pages/regular/vulnerabilities/vulnerability-card.tsx
+++ b/UI/src/features/pages/regular/vulnerabilities/vulnerability-card.tsx
@@ -135,7 +135,10 @@ export const VulnerabilityCard: FC<VulnerabilityCardProps> = ({
                                         <IconButton
                                             size="large"
                                             title="Edit"
-                                            onClick={(e) => { e.stopPropagation(); navigate(`/admin/vulnerabilities/edit?vulnerabilityId=${selectedVulnerability.id}`); }}
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                navigate(`/admin/vulnerabilities/edit?vulnerabilityId=${selectedVulnerability.id}`);
+                                            }}
                                         >
                                             <EditIcon fontSize="inherit" />
                                         </IconButton>


### PR DESCRIPTION
This PR introduces a direct "Edit this entry"  button on individual vulnerability detail pages. Currently, contributors must manually navigate through the admin dashboard, filter, and search to find the correct entry. This change streamlines the contribution workflow by providing a direct link to the administrative edit interface.

Changes
Added Edit Button: A new button has been added to the Vulnerability detail view (e.g., /vulnerability/[id]).

Conditional Rendering: The button is configured to display only for users with admin or contributor permissions (where applicable).

Dynamic Routing: The button dynamically links to the admin edit path: https://sorobansecurity.com/admin/vulnerabilities/edit?vulnerabilityId=[id].