### PR TITLE
fix: minor spelling mistake

### DIFF
--- a/UI/src/features/pages/regular/home/roles-info.tsx
+++ b/UI/src/features/pages/regular/home/roles-info.tsx
@@ -26,7 +26,7 @@ export const RolesInfo: FC<RolesInfoProps> = ({ isCompact = false }) => {
         {
             name: "Contributor",
             permissions: ["read", "download", "create"],
-            description: "Contributors are Pilots (see the handbook) or those who expressed interest in contibuting"
+            description: "Contributors are Pilots (see the handbook) or those who expressed interest in contributing"
         },
         {
             name: "Moderator",


### PR DESCRIPTION

# PR: Fix minor spelling and grammar in roles info text

## Description:
Fixes a minor spelling and grammar issue in the roles description on the home page by correcting “Contributor are” to “Contributors are” and fixing the typo in “contibuting.” No functional changes.

Closes #50 