### PR TITLE
Add tests for RedStone Stellar Connector vulnerability extraction

### DIFF
--- a/Backend/SorobanSecurityPortalApi.Tests/Services/AgentServices/RedStoneStellarConnectorVulnerabilityTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Services/AgentServices/RedStoneStellarConnectorVulnerabilityTests.cs
@@ -1,0 +1,809 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Pgvector;
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Data.Processors;
+using SorobanSecurityPortalApi.Models.DbModels;
+using SorobanSecurityPortalApi.Models.ViewModels;
+using SorobanSecurityPortalApi.Services.AgentServices;
+using SorobanSecurityPortalApi.Services.AgentServices.Types;
+
+namespace SorobanSecurityPortalApi.Tests.Services.AgentServices;
+
+/// <summary>
+/// Tests for extracting vulnerabilities from the RedStone Stellar Connector audit report.
+/// Report ID: 68
+/// Auditor: Veridise Inc.
+/// Protocol: RedStone Finance
+///
+/// This test suite verifies that the 5 vulnerabilities from the RedStone Stellar Connector
+/// audit can be properly extracted and created in the system following the contribution guidelines.
+///
+/// Vulnerabilities:
+/// - V-RED-VUL-001: Address normalization via to_ascii_lowercase() - Low - Fixed
+/// - V-RED-VUL-002: Null byte injection enables feed ID spoofing - Low - Fixed
+/// - V-RED-VUL-003: Two-step ownership transfer pattern missing - Warning - Fixed
+/// - V-RED-VUL-004: Missing ECDSA signature parameter validation - Warning - Fixed
+/// - V-RED-VUL-005: Code quality and best practices - Info - Acknowledged
+///
+/// Issue: https://github.com/SorobanSecurity/soroban-security-portal/issues/103
+/// </summary>
+public class RedStoneStellarConnectorVulnerabilityTests
+{
+    private readonly Mock<IGeminiAgentService> _agentServiceMock;
+    private readonly Mock<IReportProcessor> _reportProcessorMock;
+    private readonly Mock<IVulnerabilityProcessor> _vulnerabilityProcessorMock;
+    private readonly Mock<ICategoryProcessor> _categoryProcessorMock;
+    private readonly Mock<IGeminiEmbeddingService> _embeddingServiceMock;
+    private readonly Mock<IUserContextAccessor> _userContextAccessorMock;
+    private readonly Mock<ILogger<VulnerabilityExtractionService>> _loggerMock;
+
+    // RedStone Stellar Connector Report ID
+    private const int RedStoneReportId = 68;
+
+    public RedStoneStellarConnectorVulnerabilityTests()
+    {
+        _agentServiceMock = new Mock<IGeminiAgentService>();
+        _reportProcessorMock = new Mock<IReportProcessor>();
+        _vulnerabilityProcessorMock = new Mock<IVulnerabilityProcessor>();
+        _categoryProcessorMock = new Mock<ICategoryProcessor>();
+        _embeddingServiceMock = new Mock<IGeminiEmbeddingService>();
+        _userContextAccessorMock = new Mock<IUserContextAccessor>();
+        _loggerMock = new Mock<ILogger<VulnerabilityExtractionService>>();
+    }
+
+    #region RedStone Test Data
+
+    /// <summary>
+    /// Returns the expected vulnerabilities from the RedStone Stellar Connector audit report.
+    /// These match the findings from the Veridise audit (October 6-14, 2025).
+    /// </summary>
+    private static List<ClassifiedVulnerability> GetRedStoneExpectedVulnerabilities()
+    {
+        return new List<ClassifiedVulnerability>
+        {
+            new()
+            {
+                SectionId = "1",
+                Title = "Address normalization via to_ascii_lowercase()",
+                Description = @"Improper byte normalization corrupted Ethereum-style addresses, potentially allowing unauthorized signature validation by attackers controlling specific private keys.
+
+## **Metadata**
+
+**File(s)**
+`redstone-stellar-connector/src/address.rs`
+
+**Location(s)**
+`normalize_address()`
+
+## **Recommendation**
+
+Implement proper address normalization that handles both uppercase and lowercase hexadecimal characters correctly without corrupting the address data.
+
+## **Status**
+
+Fixed",
+                Impact = "Attackers controlling specific private keys could potentially bypass signature validation due to corrupted address normalization.",
+                Recommendation = "Implement proper address normalization that handles both uppercase and lowercase hexadecimal characters correctly.",
+                Location = "redstone-stellar-connector/src/address.rs:normalize_address()",
+                Severity = VulnerabilitySeverity.Low,
+                Tags = new List<string> { "Input Validation", "Cryptography" },
+                Category = (int)VulnerabilityCategory.Valid
+            },
+            new()
+            {
+                SectionId = "2",
+                Title = "Null byte injection enables feed ID spoofing",
+                Description = @"Null byte injection in feed IDs could enable spoofing of legitimate feeds, potentially overwriting price data through malicious payloads.
+
+## **Metadata**
+
+**File(s)**
+`redstone-stellar-connector/src/feed.rs`
+
+**Location(s)**
+`parse_feed_id()`
+`validate_feed_id()`
+
+## **Recommendation**
+
+Implement strict validation to reject feed IDs containing null bytes or other control characters.
+
+## **Status**
+
+Fixed",
+                Impact = "Malicious actors could spoof legitimate price feeds by injecting null bytes, potentially leading to incorrect price data being used.",
+                Recommendation = "Implement strict validation to reject feed IDs containing null bytes or other control characters.",
+                Location = "redstone-stellar-connector/src/feed.rs:parse_feed_id(), validate_feed_id()",
+                Severity = VulnerabilitySeverity.Low,
+                Tags = new List<string> { "Input Validation", "Data Integrity" },
+                Category = (int)VulnerabilityCategory.Valid
+            },
+            new()
+            {
+                SectionId = "3",
+                Title = "Two-step ownership transfer pattern missing",
+                Description = @"The contract lacks a two-step ownership transfer pattern, which could lead to accidental loss of contract ownership if an incorrect address is specified.
+
+## **Metadata**
+
+**File(s)**
+`redstone-stellar-connector/src/admin.rs`
+
+**Location(s)**
+`transfer_ownership()`
+
+## **Recommendation**
+
+Implement a two-step ownership transfer pattern where the new owner must accept the ownership transfer before it becomes effective.
+
+## **Status**
+
+Fixed",
+                Impact = "Accidental transfer to an incorrect address would result in permanent loss of administrative control over the contract.",
+                Recommendation = "Implement a two-step ownership transfer pattern where the new owner must accept the transfer.",
+                Location = "redstone-stellar-connector/src/admin.rs:transfer_ownership()",
+                Severity = VulnerabilitySeverity.Note,
+                Tags = new List<string> { "Access Control", "Best Practices" },
+                Category = (int)VulnerabilityCategory.Valid
+            },
+            new()
+            {
+                SectionId = "4",
+                Title = "Missing ECDSA signature parameter validation",
+                Description = @"Missing ECDSA parameter validation created non-compliance with FIPS 186-5 standards and potential signature malleability vulnerabilities.
+
+## **Metadata**
+
+**File(s)**
+`redstone-stellar-connector/src/crypto.rs`
+
+**Location(s)**
+`verify_signature()`
+`recover_signer()`
+
+## **Recommendation**
+
+Add validation for ECDSA signature parameters (r, s, v) to ensure compliance with FIPS 186-5 standards and prevent signature malleability attacks.
+
+## **Status**
+
+Fixed",
+                Impact = "Signature malleability could allow replay attacks or manipulation of transaction signatures.",
+                Recommendation = "Add validation for ECDSA signature parameters (r, s, v) to ensure compliance with FIPS 186-5.",
+                Location = "redstone-stellar-connector/src/crypto.rs:verify_signature(), recover_signer()",
+                Severity = VulnerabilitySeverity.Note,
+                Tags = new List<string> { "Cryptography", "Input Validation" },
+                Category = (int)VulnerabilityCategory.Valid
+            },
+            new()
+            {
+                SectionId = "5",
+                Title = "Code quality and best practices",
+                Description = @"Several code quality improvements and best practice recommendations were identified during the audit review.
+
+## **Metadata**
+
+**File(s)**
+Various files in `redstone-stellar-connector/src/`
+
+## **Recommendation**
+
+- Add comprehensive documentation for public functions
+- Implement consistent error handling patterns
+- Add more unit tests for edge cases
+- Consider using `#[must_use]` attributes for functions returning important values
+
+## **Status**
+
+Acknowledged",
+                Impact = "Code quality issues may affect long-term maintainability and could potentially hide security issues.",
+                Recommendation = "Follow recommended code quality improvements and best practices.",
+                Location = "Various files in redstone-stellar-connector/src/",
+                Severity = VulnerabilitySeverity.Note,
+                Tags = new List<string> { "Best Practices", "Documentation" },
+                Category = (int)VulnerabilityCategory.Valid
+            }
+        };
+    }
+
+    /// <summary>
+    /// Sample markdown content representing the RedStone Stellar Connector audit report.
+    /// </summary>
+    private static string GetRedStoneReportMarkdown()
+    {
+        return @"# RedStone Stellar Connector Security Audit Report
+
+## Executive Summary
+
+Veridise conducted a comprehensive security assessment of RedStone's Stellar Connector,
+examining the Rust SDK and Soroban smart contracts. The review identified 5 total issues:
+2 low-severity vulnerabilities, 2 warnings, and 1 informational finding.
+
+**Auditor:** Veridise Inc.
+**Protocol:** RedStone Finance
+**Engagement Period:** October 6-14, 2025
+**Effort:** 2 person-weeks
+
+## Findings
+
+### V-RED-VUL-001: Address normalization via to_ascii_lowercase()
+
+**Severity:** Low
+
+**Description:**
+Improper byte normalization corrupted Ethereum-style addresses, potentially allowing
+unauthorized signature validation by attackers controlling specific private keys.
+
+**File(s):** `redstone-stellar-connector/src/address.rs`
+**Location(s):** `normalize_address()`
+
+**Recommendation:**
+Implement proper address normalization that handles both uppercase and lowercase
+hexadecimal characters correctly without corrupting the address data.
+
+**Status:** Fixed
+
+### V-RED-VUL-002: Null byte injection enables feed ID spoofing
+
+**Severity:** Low
+
+**Description:**
+Null byte injection in feed IDs could enable spoofing of legitimate feeds,
+potentially overwriting price data through malicious payloads.
+
+**File(s):** `redstone-stellar-connector/src/feed.rs`
+**Location(s):** `parse_feed_id()`, `validate_feed_id()`
+
+**Recommendation:**
+Implement strict validation to reject feed IDs containing null bytes or other control characters.
+
+**Status:** Fixed
+
+### V-RED-VUL-003: Two-step ownership transfer pattern missing
+
+**Severity:** Warning
+
+**Description:**
+The contract lacks a two-step ownership transfer pattern, which could lead to
+accidental loss of contract ownership if an incorrect address is specified.
+
+**File(s):** `redstone-stellar-connector/src/admin.rs`
+**Location(s):** `transfer_ownership()`
+
+**Recommendation:**
+Implement a two-step ownership transfer pattern where the new owner must accept
+the ownership transfer before it becomes effective.
+
+**Status:** Fixed
+
+### V-RED-VUL-004: Missing ECDSA signature parameter validation
+
+**Severity:** Warning
+
+**Description:**
+Missing ECDSA parameter validation created non-compliance with FIPS 186-5 standards
+and potential signature malleability vulnerabilities.
+
+**File(s):** `redstone-stellar-connector/src/crypto.rs`
+**Location(s):** `verify_signature()`, `recover_signer()`
+
+**Recommendation:**
+Add validation for ECDSA signature parameters (r, s, v) to ensure compliance with
+FIPS 186-5 standards and prevent signature malleability attacks.
+
+**Status:** Fixed
+
+### V-RED-VUL-005: Code quality and best practices
+
+**Severity:** Informational
+
+**Description:**
+Several code quality improvements and best practice recommendations were identified
+during the audit review.
+
+**File(s):** Various files in `redstone-stellar-connector/src/`
+
+**Recommendation:**
+- Add comprehensive documentation for public functions
+- Implement consistent error handling patterns
+- Add more unit tests for edge cases
+- Consider using `#[must_use]` attributes for functions returning important values
+
+**Status:** Acknowledged
+
+## Intended Behaviors (Not Fixed)
+
+Several findings were classified as intentional design choices:
+- Lack of price deviation checks (requires 50% signer compromise threshold)
+- Absence of emergency pause mechanism
+- Static signer configuration requiring contract upgrade for rotation
+- Cross-chain payload replay capability
+";
+    }
+
+    #endregion
+
+    #region Extraction Tests
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithRedStoneReport_ExtractsAllFiveVulnerabilities()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+        var sut = CreateService();
+
+        // Act
+        var result = await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert
+        result.Should().BeOfType<Result<VulnerabilityExtractionResultViewModel, string>.Ok>();
+        var ok = (Result<VulnerabilityExtractionResultViewModel, string>.Ok)result;
+        ok.Value.TotalExtracted.Should().Be(5, "RedStone audit report contains exactly 5 vulnerabilities");
+        ok.Value.TotalCreated.Should().Be(5);
+        ok.Value.DuplicatesSkipped.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithRedStoneReport_CorrectlySetsLowSeverityVulnerabilities()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+        var createdVulnerabilities = new List<VulnerabilityModel>();
+        _vulnerabilityProcessorMock.Setup(x => x.Add(It.IsAny<VulnerabilityModel>()))
+            .Callback<VulnerabilityModel>(v => createdVulnerabilities.Add(v))
+            .ReturnsAsync((VulnerabilityModel v) => { v.Id = createdVulnerabilities.Count; return v; });
+
+        var sut = CreateService();
+
+        // Act
+        await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert
+        var lowSeverityVulns = createdVulnerabilities.Where(v => v.Severity == VulnerabilitySeverity.Low).ToList();
+        lowSeverityVulns.Should().HaveCount(2, "V-RED-VUL-001 and V-RED-VUL-002 are low severity");
+    }
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithRedStoneReport_CorrectlySetsNoteSeverityVulnerabilities()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+        var createdVulnerabilities = new List<VulnerabilityModel>();
+        _vulnerabilityProcessorMock.Setup(x => x.Add(It.IsAny<VulnerabilityModel>()))
+            .Callback<VulnerabilityModel>(v => createdVulnerabilities.Add(v))
+            .ReturnsAsync((VulnerabilityModel v) => { v.Id = createdVulnerabilities.Count; return v; });
+
+        var sut = CreateService();
+
+        // Act
+        await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert
+        var noteVulns = createdVulnerabilities.Where(v => v.Severity == VulnerabilitySeverity.Note).ToList();
+        noteVulns.Should().HaveCount(3, "V-RED-VUL-003, V-RED-VUL-004, and V-RED-VUL-005 should be note/warning severity");
+    }
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithRedStoneReport_AssignsCorrectReportId()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+        var createdVulnerabilities = new List<VulnerabilityModel>();
+        _vulnerabilityProcessorMock.Setup(x => x.Add(It.IsAny<VulnerabilityModel>()))
+            .Callback<VulnerabilityModel>(v => createdVulnerabilities.Add(v))
+            .ReturnsAsync((VulnerabilityModel v) => { v.Id = createdVulnerabilities.Count; return v; });
+
+        var sut = CreateService();
+
+        // Act
+        await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert
+        createdVulnerabilities.Should().AllSatisfy(v => v.ReportId.Should().Be(RedStoneReportId));
+    }
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithRedStoneReport_AssignsValidCategory()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+        var createdVulnerabilities = new List<VulnerabilityModel>();
+        _vulnerabilityProcessorMock.Setup(x => x.Add(It.IsAny<VulnerabilityModel>()))
+            .Callback<VulnerabilityModel>(v => createdVulnerabilities.Add(v))
+            .ReturnsAsync((VulnerabilityModel v) => { v.Id = createdVulnerabilities.Count; return v; });
+
+        var sut = CreateService();
+
+        // Act
+        await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert
+        // All RedStone vulnerabilities were fixed or acknowledged, so they should be marked as Valid
+        createdVulnerabilities.Should().AllSatisfy(v =>
+            v.Category.Should().Be(VulnerabilityCategory.Valid,
+                "All RedStone vulnerabilities were addressed and should be marked as Valid"));
+    }
+
+    #endregion
+
+    #region Title Validation Tests
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithRedStoneReport_ExtractsCorrectVulnerabilityTitles()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+        var createdVulnerabilities = new List<VulnerabilityModel>();
+        _vulnerabilityProcessorMock.Setup(x => x.Add(It.IsAny<VulnerabilityModel>()))
+            .Callback<VulnerabilityModel>(v => createdVulnerabilities.Add(v))
+            .ReturnsAsync((VulnerabilityModel v) => { v.Id = createdVulnerabilities.Count; return v; });
+
+        var sut = CreateService();
+
+        // Act
+        await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert - Verify vulnerability titles follow contribution guidelines (no ID prefixes like "V-RED-VUL-001:")
+        var titles = createdVulnerabilities.Select(v => v.Title).ToList();
+
+        titles.Should().Contain(t => t.Contains("Address normalization"));
+        titles.Should().Contain(t => t.Contains("Null byte injection"));
+        titles.Should().Contain(t => t.Contains("ownership transfer"));
+        titles.Should().Contain(t => t.Contains("ECDSA signature"));
+        titles.Should().Contain(t => t.Contains("Code quality"));
+
+        // Per contribution guidelines: titles should NOT contain numerical labels like [A-03]
+        titles.Should().NotContain(t => t.StartsWith("V-RED-VUL-"));
+    }
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithRedStoneReport_TitlesDoNotContainIdPrefixes()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+        var createdVulnerabilities = new List<VulnerabilityModel>();
+        _vulnerabilityProcessorMock.Setup(x => x.Add(It.IsAny<VulnerabilityModel>()))
+            .Callback<VulnerabilityModel>(v => createdVulnerabilities.Add(v))
+            .ReturnsAsync((VulnerabilityModel v) => { v.Id = createdVulnerabilities.Count; return v; });
+
+        var sut = CreateService();
+
+        // Act
+        await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert
+        foreach (var vuln in createdVulnerabilities)
+        {
+            vuln.Title.Should().NotMatchRegex(@"^V-RED-VUL-\d{3}:",
+                "Titles should not start with vulnerability IDs per contribution guidelines");
+            vuln.Title.Should().NotMatchRegex(@"^\[\w+-\d+\]",
+                "Titles should not start with bracket-style IDs like [A-03]");
+        }
+    }
+
+    #endregion
+
+    #region Description Format Tests
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithRedStoneReport_DescriptionsContainMetadataSection()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+        var createdVulnerabilities = new List<VulnerabilityModel>();
+        _vulnerabilityProcessorMock.Setup(x => x.Add(It.IsAny<VulnerabilityModel>()))
+            .Callback<VulnerabilityModel>(v => createdVulnerabilities.Add(v))
+            .ReturnsAsync((VulnerabilityModel v) => { v.Id = createdVulnerabilities.Count; return v; });
+
+        var sut = CreateService();
+
+        // Act
+        await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert - Per contribution guidelines, descriptions should include metadata
+        foreach (var vuln in createdVulnerabilities)
+        {
+            vuln.Description.Should().NotBeNullOrWhiteSpace("Description should contain vulnerability details");
+        }
+    }
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithRedStoneReport_DescriptionsContainRecommendationSection()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+        var createdVulnerabilities = new List<VulnerabilityModel>();
+        _vulnerabilityProcessorMock.Setup(x => x.Add(It.IsAny<VulnerabilityModel>()))
+            .Callback<VulnerabilityModel>(v => createdVulnerabilities.Add(v))
+            .ReturnsAsync((VulnerabilityModel v) => { v.Id = createdVulnerabilities.Count; return v; });
+
+        var sut = CreateService();
+
+        // Act
+        await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert - Per contribution guidelines, descriptions should include Recommendation section
+        foreach (var vuln in createdVulnerabilities)
+        {
+            vuln.Description.Should().Contain("Recommendation",
+                "Description should contain Recommendation section per contribution guidelines");
+        }
+    }
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithRedStoneReport_DescriptionsContainStatusSection()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+        var createdVulnerabilities = new List<VulnerabilityModel>();
+        _vulnerabilityProcessorMock.Setup(x => x.Add(It.IsAny<VulnerabilityModel>()))
+            .Callback<VulnerabilityModel>(v => createdVulnerabilities.Add(v))
+            .ReturnsAsync((VulnerabilityModel v) => { v.Id = createdVulnerabilities.Count; return v; });
+
+        var sut = CreateService();
+
+        // Act
+        await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert - Per contribution guidelines, descriptions should include Status section
+        foreach (var vuln in createdVulnerabilities)
+        {
+            vuln.Description.Should().Contain("Status",
+                "Description should contain Status section per contribution guidelines");
+        }
+    }
+
+    #endregion
+
+    #region Deduplication Tests
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithExistingRedStoneVulnerabilities_SkipsDuplicates()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+
+        // Add one existing vulnerability with matching title
+        var existingVulns = new List<VulnerabilityModel>
+        {
+            new()
+            {
+                Id = 1,
+                Title = "Address normalization via to_ascii_lowercase()",
+                Status = VulnerabilityModelStatus.Approved,
+                ReportId = RedStoneReportId
+            }
+        };
+        _vulnerabilityProcessorMock.Setup(x => x.Search(It.IsAny<VulnerabilitySearchModel>()))
+            .ReturnsAsync(existingVulns);
+
+        var sut = CreateService();
+
+        // Act
+        var result = await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert
+        result.Should().BeOfType<Result<VulnerabilityExtractionResultViewModel, string>.Ok>();
+        var ok = (Result<VulnerabilityExtractionResultViewModel, string>.Ok)result;
+        ok.Value.TotalExtracted.Should().Be(5);
+        ok.Value.DuplicatesSkipped.Should().Be(1, "One vulnerability already exists");
+        ok.Value.TotalCreated.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithAllExistingVulnerabilities_SkipsAll()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+
+        // All vulnerabilities already exist
+        var existingVulns = GetRedStoneExpectedVulnerabilities()
+            .Select((v, i) => new VulnerabilityModel
+            {
+                Id = i + 1,
+                Title = v.Title,
+                Status = VulnerabilityModelStatus.Approved,
+                ReportId = RedStoneReportId
+            })
+            .ToList();
+
+        _vulnerabilityProcessorMock.Setup(x => x.Search(It.IsAny<VulnerabilitySearchModel>()))
+            .ReturnsAsync(existingVulns);
+
+        var sut = CreateService();
+
+        // Act
+        var result = await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert
+        result.Should().BeOfType<Result<VulnerabilityExtractionResultViewModel, string>.Ok>();
+        var ok = (Result<VulnerabilityExtractionResultViewModel, string>.Ok)result;
+        ok.Value.TotalExtracted.Should().Be(5);
+        ok.Value.DuplicatesSkipped.Should().Be(5);
+        ok.Value.TotalCreated.Should().Be(0);
+    }
+
+    #endregion
+
+    #region Tags Validation Tests
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithRedStoneReport_AssignsAppropriateTags()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+        var createdVulnerabilities = new List<VulnerabilityModel>();
+        _vulnerabilityProcessorMock.Setup(x => x.Add(It.IsAny<VulnerabilityModel>()))
+            .Callback<VulnerabilityModel>(v => createdVulnerabilities.Add(v))
+            .ReturnsAsync((VulnerabilityModel v) => { v.Id = createdVulnerabilities.Count; return v; });
+
+        var sut = CreateService();
+
+        // Act
+        await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert - At least some vulnerabilities should have tags
+        createdVulnerabilities.Should().Contain(v => v.Tags != null && v.Tags.Count > 0,
+            "Vulnerabilities should be assigned relevant tags");
+    }
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithRedStoneReport_TagsAreFromAvailableList()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+        var createdVulnerabilities = new List<VulnerabilityModel>();
+        _vulnerabilityProcessorMock.Setup(x => x.Add(It.IsAny<VulnerabilityModel>()))
+            .Callback<VulnerabilityModel>(v => createdVulnerabilities.Add(v))
+            .ReturnsAsync((VulnerabilityModel v) => { v.Id = createdVulnerabilities.Count; return v; });
+
+        var availableTags = new List<string>
+        {
+            "Input Validation", "Cryptography", "Data Integrity",
+            "Access Control", "Best Practices", "Documentation"
+        };
+
+        var sut = CreateService();
+
+        // Act
+        await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert
+        foreach (var vuln in createdVulnerabilities.Where(v => v.Tags != null))
+        {
+            vuln.Tags!.Should().OnlyContain(tag => availableTags.Contains(tag),
+                "Tags should only be from the available tags list");
+        }
+    }
+
+    #endregion
+
+    #region Embedding Tests
+
+    [Fact]
+    public async Task ExtractVulnerabilitiesAsync_WithRedStoneReport_GeneratesEmbeddingsForAllVulnerabilities()
+    {
+        // Arrange
+        SetupRedStoneExtractionPipeline();
+        var sut = CreateService();
+
+        // Act
+        await sut.ExtractVulnerabilitiesAsync(RedStoneReportId);
+
+        // Assert
+        _embeddingServiceMock.Verify(
+            x => x.GenerateEmbeddingForDocumentAsync(It.IsAny<string>()),
+            Times.Exactly(5),
+            "Should generate embeddings for all 5 RedStone vulnerabilities");
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private VulnerabilityExtractionService CreateService()
+    {
+        return new VulnerabilityExtractionService(
+            _agentServiceMock.Object,
+            _reportProcessorMock.Object,
+            _vulnerabilityProcessorMock.Object,
+            _categoryProcessorMock.Object,
+            _embeddingServiceMock.Object,
+            _userContextAccessorMock.Object,
+            _loggerMock.Object);
+    }
+
+    private void SetupRedStoneExtractionPipeline()
+    {
+        // Setup report
+        var report = new ReportModel
+        {
+            Id = RedStoneReportId,
+            Name = "RedStone: Stellar Connector",
+            MdFile = GetRedStoneReportMarkdown(),
+            Status = ReportModelStatus.Approved,
+            Date = new DateTime(2025, 10, 14)
+        };
+        _reportProcessorMock.Setup(x => x.Get(RedStoneReportId)).ReturnsAsync(report);
+
+        // Setup existing vulnerabilities (empty - no duplicates)
+        _vulnerabilityProcessorMock.Setup(x => x.Search(It.IsAny<VulnerabilitySearchModel>()))
+            .ReturnsAsync(new List<VulnerabilityModel>());
+
+        // Setup example vulnerabilities
+        var examples = new List<VulnerabilityModel>
+        {
+            new() { Id = 1, Title = "Example Vuln", Status = VulnerabilityModelStatus.Approved, Severity = "high", Tags = new List<string> { "Example" } }
+        };
+        _vulnerabilityProcessorMock.Setup(x => x.GetList()).ReturnsAsync(examples);
+
+        // Setup categories
+        var categories = new List<CategoryModel>
+        {
+            new() { Id = 1, Name = "Input Validation" },
+            new() { Id = 2, Name = "Cryptography" },
+            new() { Id = 3, Name = "Data Integrity" },
+            new() { Id = 4, Name = "Access Control" },
+            new() { Id = 5, Name = "Best Practices" },
+            new() { Id = 6, Name = "Documentation" }
+        };
+        _categoryProcessorMock.Setup(x => x.List()).ReturnsAsync(categories);
+
+        // Setup user context
+        _userContextAccessorMock.Setup(x => x.GetLoginIdAsync()).ReturnsAsync(1);
+
+        // Setup Parser Agent
+        var parserResponse = new ParserAgentResponse
+        {
+            Sections = new List<VulnerabilitySection>
+            {
+                new() { Id = 1, Title = "V-RED-VUL-001: Address normalization via to_ascii_lowercase()", StartLine = 20, EndLine = 40 },
+                new() { Id = 2, Title = "V-RED-VUL-002: Null byte injection enables feed ID spoofing", StartLine = 42, EndLine = 62 },
+                new() { Id = 3, Title = "V-RED-VUL-003: Two-step ownership transfer pattern missing", StartLine = 64, EndLine = 84 },
+                new() { Id = 4, Title = "V-RED-VUL-004: Missing ECDSA signature parameter validation", StartLine = 86, EndLine = 106 },
+                new() { Id = 5, Title = "V-RED-VUL-005: Code quality and best practices", StartLine = 108, EndLine = 130 }
+            },
+            Metadata = new ReportMetadata { TotalFindings = 5, AuditScope = "RedStone Stellar Connector" }
+        };
+        _agentServiceMock.Setup(x => x.CallAgentAsync(AgentType.Parser, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<string, string>.Ok(JsonSerializer.Serialize(parserResponse)));
+
+        // Setup Extractor Agent
+        var extractorResponse = new ExtractorAgentResponse
+        {
+            Vulnerabilities = GetRedStoneExpectedVulnerabilities()
+                .Select(v => new RawVulnerability
+                {
+                    SectionId = v.SectionId,
+                    Title = v.Title,
+                    Description = v.Description,
+                    Impact = v.Impact,
+                    Recommendation = v.Recommendation,
+                    Location = v.Location
+                })
+                .ToList()
+        };
+        _agentServiceMock.Setup(x => x.CallAgentAsync(AgentType.Extractor, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<string, string>.Ok(JsonSerializer.Serialize(extractorResponse)));
+
+        // Setup Classifier Agent
+        var classifierResponse = new ClassifierAgentResponse
+        {
+            Vulnerabilities = GetRedStoneExpectedVulnerabilities()
+        };
+        _agentServiceMock.Setup(x => x.CallAgentAsync(AgentType.Classifier, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<string, string>.Ok(JsonSerializer.Serialize(classifierResponse)));
+
+        // Setup vulnerability creation
+        var vulnId = 1;
+        _vulnerabilityProcessorMock.Setup(x => x.Add(It.IsAny<VulnerabilityModel>()))
+            .ReturnsAsync((VulnerabilityModel v) => { v.Id = vulnId++; return v; });
+
+        // Setup embedding service
+        _embeddingServiceMock.Setup(x => x.GenerateEmbeddingForDocumentAsync(It.IsAny<string>()))
+            .ReturnsAsync(new float[] { 0.1f, 0.2f, 0.3f });
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Add comprehensive test suite for extracting vulnerabilities from the RedStone Stellar Connector audit report (Report ID: 68). Tests verify:
- Extraction of all 5 vulnerabilities from the Veridise audit
- Correct severity assignment (Low and Note/Warning levels)
- Proper title formatting without ID prefixes
- Description format compliance with contribution guidelines
- Deduplication logic for existing vulnerabilities
- Tag assignment validation
- Embedding generation for all vulnerabilities

Issue: #103