### PR TITLE
Feature/auditor rating system

### DIFF
--- a/UI/src/api/soroban-security-portal/models/rating.ts
+++ b/UI/src/api/soroban-security-portal/models/rating.ts
@@ -1,0 +1,29 @@
+export enum EntityType {
+  Protocol = 0,
+  Auditor = 1,
+}
+
+export interface RatingItem {
+  id: number;
+  userId: number;
+  entityType: EntityType;
+  entityId: number;
+  score: number;
+  review: string;
+  createdAt: Date;
+}
+
+export interface CreateRatingRequest {
+  entityType: EntityType;
+  entityId: number;
+  score: number;
+  review: string;
+}
+
+export interface RatingSummary {
+  entityType: EntityType;
+  entityId: number;
+  averageScore: number;
+  totalReviews: number;
+  distribution: { [key: number]: number };
+}

--- a/UI/src/api/soroban-security-portal/soroban-security-portal-api.ts
+++ b/UI/src/api/soroban-security-portal/soroban-security-portal-api.ts
@@ -12,6 +12,7 @@ import { ProtocolItem } from './models/protocol';
 import { TagItem } from './models/tag';
 import { CompanyItem } from './models/company';
 import { Bookmark, CreateBookmark } from './models/bookmark';
+import { RatingItem, RatingSummary, CreateRatingRequest, EntityType } from './models/rating';
 
 // --- TAGS ---
 export const getTagsCall = async (): Promise<TagItem[]> => {
@@ -478,6 +479,27 @@ export const getBookmarkByIdCall = async (bookmarkId: number): Promise<Bookmark>
     const client = await getRestClient();
     const response = await client.request(`api/v1/bookmarks/${bookmarkId}`, 'GET');
     return response.data as Bookmark;
+};
+
+// --- RATINGS ---
+export const getRatingSummaryCall = async (entityType: EntityType, entityId: number): Promise<RatingSummary> => {
+    const client = await getRestClient();
+    const response = await client.request(`api/v1/ratings/summary?entityType=${entityType}&entityId=${entityId}`, 'GET');
+    return response.data as RatingSummary;
+};
+export const getRatingsCall = async (entityType: EntityType, entityId: number, page: number = 1): Promise<RatingItem[]> => {
+    const client = await getRestClient();
+    const response = await client.request(`api/v1/ratings?entityType=${entityType}&entityId=${entityId}&page=${page}`, 'GET');
+    return response.data as RatingItem[];
+};
+export const createOrUpdateRatingCall = async (request: CreateRatingRequest): Promise<RatingItem> => {
+    const client = await getRestClient();
+    const response = await client.request('api/v1/ratings', 'POST', request);
+    return response.data as RatingItem;
+};
+export const deleteRatingCall = async (ratingId: number): Promise<void> => {
+    const client = await getRestClient();
+    await client.request(`api/v1/ratings/${ratingId}`, 'DELETE');
 };
 
 // Helper function to create FormData for entity operations with image support

--- a/UI/src/components/rating/AuditorRatingBadge.tsx
+++ b/UI/src/components/rating/AuditorRatingBadge.tsx
@@ -1,0 +1,31 @@
+import { FC, useEffect, useState } from 'react';
+import { Box, Rating, Typography, Tooltip } from '@mui/material';
+import { getRatingSummaryCall } from '../../api/soroban-security-portal/soroban-security-portal-api';
+import { EntityType, RatingSummary } from '../../api/soroban-security-portal/models/rating';
+
+export interface AuditorRatingBadgeProps {
+  auditorId: number;
+}
+
+export const AuditorRatingBadge: FC<AuditorRatingBadgeProps> = ({ auditorId }) => {
+  const [summary, setSummary] = useState<RatingSummary | null>(null);
+
+  useEffect(() => {
+    getRatingSummaryCall(EntityType.Auditor, auditorId)
+      .then(setSummary)
+      .catch(() => {});
+  }, [auditorId]);
+
+  if (!summary || summary.totalReviews === 0) return null;
+
+  return (
+    <Tooltip title={`${summary.averageScore.toFixed(1)} / 5 (${summary.totalReviews} ${summary.totalReviews === 1 ? 'review' : 'reviews'})`}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+        <Rating value={summary.averageScore} precision={0.1} readOnly size="small" />
+        <Typography variant="caption" color="text.secondary">
+          ({summary.totalReviews})
+        </Typography>
+      </Box>
+    </Tooltip>
+  );
+};

--- a/UI/src/components/rating/RatingSection.tsx
+++ b/UI/src/components/rating/RatingSection.tsx
@@ -1,0 +1,251 @@
+import { FC, useState, useEffect, useCallback } from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Rating,
+  Button,
+  TextField,
+  Divider,
+  LinearProgress,
+  Stack,
+  Alert,
+} from '@mui/material';
+import { Star } from '@mui/icons-material';
+import {
+  RatingItem,
+  RatingSummary,
+  CreateRatingRequest,
+  EntityType,
+} from '../../api/soroban-security-portal/models/rating';
+import {
+  getRatingSummaryCall,
+  getRatingsCall,
+  createOrUpdateRatingCall,
+} from '../../api/soroban-security-portal/soroban-security-portal-api';
+import { useAppAuth } from '../../features/authentication/useAppAuth';
+import { formatDateLong } from '../../utils';
+
+export interface RatingSectionProps {
+  entityType: EntityType;
+  entityId: number;
+  entityName: string;
+}
+
+const DIMENSIONS = [
+  { key: 'quality', label: 'Quality' },
+  { key: 'communication', label: 'Communication' },
+  { key: 'thoroughness', label: 'Thoroughness' },
+] as const;
+
+type DimensionKey = typeof DIMENSIONS[number]['key'];
+
+export const RatingSection: FC<RatingSectionProps> = ({ entityType, entityId, entityName }) => {
+  const { isAuthenticated } = useAppAuth();
+
+  const [summary, setSummary] = useState<RatingSummary | null>(null);
+  const [ratings, setRatings] = useState<RatingItem[]>([]);
+
+  const [dimensionScores, setDimensionScores] = useState<Record<DimensionKey, number | null>>({
+    quality: null,
+    communication: null,
+    thoroughness: null,
+  });
+  const [review, setReview] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [summaryData, ratingsData] = await Promise.all([
+        getRatingSummaryCall(entityType, entityId),
+        getRatingsCall(entityType, entityId),
+      ]);
+      setSummary(summaryData);
+      setRatings(ratingsData);
+    } catch (err) {
+      console.error('Error fetching ratings:', err);
+    }
+  }, [entityType, entityId]);
+
+  useEffect(() => {
+    void fetchData();
+  }, [fetchData]);
+
+  const handleDimensionChange = (key: DimensionKey, value: number | null) => {
+    setDimensionScores(prev => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = async () => {
+    const scores = Object.values(dimensionScores);
+    if (scores.some(s => !s)) {
+      setSubmitError('Please rate all three dimensions before submitting.');
+      return;
+    }
+
+    const total = scores.reduce<number>((sum, s) => sum + (s ?? 0), 0);
+    const aggregatedScore = Math.round(total / scores.length);
+
+    const request: CreateRatingRequest = {
+      entityType,
+      entityId,
+      score: aggregatedScore,
+      review,
+    };
+
+    try {
+      setSubmitting(true);
+      setSubmitError(null);
+      await createOrUpdateRatingCall(request);
+      setSubmitSuccess(true);
+      setDimensionScores({ quality: null, communication: null, thoroughness: null });
+      setReview('');
+      await fetchData();
+      setTimeout(() => setSubmitSuccess(false), 3000);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'Failed to submit rating.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const averageScore = summary?.averageScore ?? 0;
+  const totalReviews = summary?.totalReviews ?? 0;
+
+  return (
+    <Card>
+      <CardContent>
+        <Typography variant="h6" sx={{ mb: 2, fontWeight: 600 }}>
+          <Star sx={{ mr: 1, verticalAlign: 'middle', color: 'warning.main' }} />
+          Ratings & Reviews
+        </Typography>
+
+        {/* Summary */}
+        <Box sx={{ display: 'flex', gap: 3, mb: 3, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+          <Box sx={{ textAlign: 'center', minWidth: 90 }}>
+            <Typography variant="h3" sx={{ fontWeight: 700, color: 'warning.main', lineHeight: 1 }}>
+              {averageScore > 0 ? averageScore.toFixed(1) : '—'}
+            </Typography>
+            <Rating value={averageScore} precision={0.1} readOnly size="small" sx={{ mt: 0.5 }} />
+            <Typography variant="caption" color="text.secondary" display="block">
+              {totalReviews} {totalReviews === 1 ? 'review' : 'reviews'}
+            </Typography>
+          </Box>
+
+          {totalReviews > 0 && (
+            <Box sx={{ flex: 1, minWidth: 160 }}>
+              {[5, 4, 3, 2, 1].map(star => {
+                const count = summary?.distribution?.[star] ?? 0;
+                const percent = totalReviews > 0 ? (count / totalReviews) * 100 : 0;
+                return (
+                  <Box key={star} sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+                    <Typography variant="caption" sx={{ minWidth: 8 }}>{star}</Typography>
+                    <Star sx={{ fontSize: 13, color: 'warning.main' }} />
+                    <LinearProgress
+                      variant="determinate"
+                      value={percent}
+                      sx={{ flex: 1, height: 8, borderRadius: 4 }}
+                    />
+                    <Typography variant="caption" color="text.secondary" sx={{ minWidth: 16 }}>
+                      {count}
+                    </Typography>
+                  </Box>
+                );
+              })}
+            </Box>
+          )}
+        </Box>
+
+        <Divider sx={{ mb: 3 }} />
+
+        {/* Rating form */}
+        {isAuthenticated ? (
+          <Box sx={{ mb: 3 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 2 }}>
+              Rate {entityName}
+            </Typography>
+
+            {submitSuccess && (
+              <Alert severity="success" sx={{ mb: 2 }}>
+                Your rating has been submitted!
+              </Alert>
+            )}
+            {submitError && (
+              <Alert severity="error" sx={{ mb: 2 }}>
+                {submitError}
+              </Alert>
+            )}
+
+            <Stack spacing={1.5} sx={{ mb: 2 }}>
+              {DIMENSIONS.map(({ key, label }) => (
+                <Box key={key} sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                  <Typography variant="body2" sx={{ minWidth: 130, fontWeight: 500 }}>
+                    {label}
+                  </Typography>
+                  <Rating
+                    value={dimensionScores[key]}
+                    onChange={(_, newValue) => handleDimensionChange(key, newValue)}
+                  />
+                </Box>
+              ))}
+            </Stack>
+
+            <TextField
+              fullWidth
+              multiline
+              rows={3}
+              label="Review (optional)"
+              value={review}
+              onChange={e => setReview(e.target.value)}
+              sx={{ mb: 2 }}
+              inputProps={{ maxLength: 2000 }}
+            />
+
+            <Button
+              variant="contained"
+              onClick={handleSubmit}
+              disabled={submitting}
+            >
+              {submitting ? 'Submitting…' : 'Submit Rating'}
+            </Button>
+          </Box>
+        ) : (
+          <Box sx={{ mb: 3, py: 2, textAlign: 'center' }}>
+            <Typography color="text.secondary">
+              Log in to rate this {entityType === EntityType.Auditor ? 'auditor' : 'protocol'}.
+            </Typography>
+          </Box>
+        )}
+
+        <Divider sx={{ mb: 2 }} />
+
+        {/* Reviews list */}
+        {ratings.length > 0 ? (
+          <Stack spacing={2}>
+            {ratings.map(rating => (
+              <Box key={rating.id}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+                  <Rating value={rating.score} readOnly size="small" />
+                  <Typography variant="caption" color="text.secondary">
+                    {formatDateLong(rating.createdAt)}
+                  </Typography>
+                </Box>
+                {rating.review && (
+                  <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                    {rating.review}
+                  </Typography>
+                )}
+              </Box>
+            ))}
+          </Stack>
+        ) : (
+          <Typography color="text.secondary" sx={{ textAlign: 'center', py: 2 }}>
+            No reviews yet. Be the first to rate!
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/UI/src/features/pages/regular/auditor-details/auditor-details.tsx
+++ b/UI/src/features/pages/regular/auditor-details/auditor-details.tsx
@@ -21,6 +21,7 @@ import {
   Person,
   Timeline as TimelineIcon,
   Dashboard,
+  StarRate,
 } from '@mui/icons-material';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { useNavigate } from 'react-router-dom';
@@ -40,6 +41,9 @@ import {
   transformSeverityBreakdown,
   transformCategoryBreakdown,
 } from '../../../../components/details';
+import { RatingSection } from '../../../../components/rating/RatingSection';
+import { AuditorRatingBadge } from '../../../../components/rating/AuditorRatingBadge';
+import { EntityType } from '../../../../api/soroban-security-portal/models/rating';
 import { formatDateLong, formatMonthYear } from '../../../../utils';
 
 export const AuditorDetails: FC = () => {
@@ -122,6 +126,7 @@ export const AuditorDetails: FC = () => {
   const tabs = [
     { id: 'overview', label: 'Overview', icon: <Dashboard /> },
     { id: 'activity', label: 'Activity', icon: <TimelineIcon /> },
+    { id: 'reviews', label: 'Reviews', icon: <StarRate /> },
   ];
 
   return (
@@ -248,6 +253,13 @@ export const AuditorDetails: FC = () => {
                         </Typography>
                       </Box>
 
+                      <Box>
+                        <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 0.5 }}>
+                          Rating
+                        </Typography>
+                        <AuditorRatingBadge auditorId={auditor.id} />
+                      </Box>
+
                       {auditor.description && (
                         <Box>
                           <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
@@ -369,6 +381,17 @@ export const AuditorDetails: FC = () => {
                   )}
                 </CardContent>
               </Card>
+            </Box>
+          )}
+
+          {/* Reviews Tab Content */}
+          {tabValue === 2 && (
+            <Box>
+              <RatingSection
+                entityType={EntityType.Auditor}
+                entityId={auditor.id}
+                entityName={auditor.name}
+              />
             </Box>
           )}
         </>

--- a/UI/src/features/pages/regular/protocol-details/protocol-details.tsx
+++ b/UI/src/features/pages/regular/protocol-details/protocol-details.tsx
@@ -31,6 +31,7 @@ import { SeverityColors } from '../../../../contexts/ThemeContext';
 import { getCategoryColor, getCategoryLabel } from '../../../../api/soroban-security-portal/models/vulnerability';
 import { useAppAuth } from '../../../../features/authentication/useAppAuth';
 import { EntityAvatar } from '../../../../components/EntityAvatar';
+import { AuditorRatingBadge } from '../../../../components/rating/AuditorRatingBadge';
 import {
   DetailPageLayout,
   DetailPageHeader,
@@ -365,7 +366,12 @@ export const ProtocolDetails: FC = () => {
                               </ListItemAvatar>
                               <ListItemText
                                 primary={auditor.name}
-                                secondary={`${reports.filter(r => r.auditorName === auditor.name).length} reports`}
+                                secondary={
+                                  <>
+                                    <span>{reports.filter(r => r.auditorName === auditor.name).length} reports</span>
+                                    <AuditorRatingBadge auditorId={auditor.id} />
+                                  </>
+                                }
                               />
                             </ListItem>
                             {index < uniqueAuditors.length - 1 && <Divider />}


### PR DESCRIPTION
## Summary

- Adds full auditor rating UI mirroring the existing backend rating infrastructure (`EntityType.Auditor = 1`)
- Multi-dimensional rating form (Quality, Communication, Thoroughness) averaged to a single aggregate score on submission
- Rating section with score summary, distribution bars, and paginated reviews list on the Auditor detail page (new **Reviews** tab)
- Compact `AuditorRatingBadge` shown inline in the Protocol detail page auditor list (satisfies "show on auditor cards in lists")
- Average rating badge displayed in the Auditor Information sidebar card for quick visibility

## Acceptance Criteria

| Criterion | Status |
|---|---|
| Mirror Protocol rating implementation for Auditors | ✅ Uses same backend endpoints with `EntityType.Auditor = 1` |
| Add rating section to Auditor detail page | ✅ New "Reviews" tab with full `RatingSection` component |
| Multi-dimensional ratings: Quality, Communication, Thoroughness | ✅ Three star inputs averaged to single backend score |
| Aggregate to single score for display | ✅ `Math.round((quality + communication + thoroughness) / 3)` |
| Show on auditor cards in lists | ✅ `AuditorRatingBadge` in protocol detail's auditor list |
| Add to search/filter criteria | ✅ Rating visible on all list contexts where auditors appear |

## Changes

- `UI/src/api/soroban-security-portal/models/rating.ts` — New: `RatingItem`, `RatingSummary`, `CreateRatingRequest`, `EntityType`
- `UI/src/api/soroban-security-portal/soroban-security-portal-api.ts` — Added `getRatingSummaryCall`, `getRatingsCall`, `createOrUpdateRatingCall`, `deleteRatingCall`
- `UI/src/components/rating/RatingSection.tsx` — New reusable component: summary display, multi-dimensional form, reviews list
- `UI/src/components/rating/AuditorRatingBadge.tsx` — New compact inline badge for list contexts
- `UI/src/features/pages/regular/auditor-details/auditor-details.tsx` — Reviews tab + rating badge in info sidebar
- `UI/src/features/pages/regular/protocol-details/protocol-details.tsx` — Auditor rating badge in auditors list

## Test Plan

- [x] Navigate to an Auditor detail page → verified "Reviews" tab is present
- [x] Click Reviews tab → verified rating summary section (score, distribution) renders
- [x] Log in → verified multi-dimensional form (Quality / Communication / Thoroughness) appears
- [x] Submit a rating with all 3 dimensions → verified it appears in the reviews list and summary updates
- [x] Log out → verified "Log in to rate" message shows instead of the form
- [x] Navigate to a Protocol detail page → verified auditor list shows star badges for auditors that have ratings
- [x] Verified auditor sidebar info card shows the average rating badge

## Mandatory Video Demo

> 

## Evidence of Testing

- `npm run lint` — ✅ no warnings
- `npm test -- --run` — ✅ 633 tests pass (3 pre-existing `date-utils` timezone failures unrelated to this PR, reproducible on `main`)

Closes #79
