### PR TITLE
Add edit entry button to vulnerability details page (#47)

### DIFF
--- a/UI/src/features/pages/regular/vulnerability-details/vulnerability-details.tsx
+++ b/UI/src/features/pages/regular/vulnerability-details/vulnerability-details.tsx
@@ -16,6 +16,7 @@ import {
   Dashboard,
   BugReport,
   Person,
+  Edit,
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import { useVulnerabilityDetails } from './hooks/vulnerability-details.hook';
@@ -39,7 +40,7 @@ import { getSeverityColor } from '../../../../utils/color-utils';
 
 export const VulnerabilityDetails: FC = () => {
   const navigate = useNavigate();
-  const { isAuthenticated } = useAppAuth();
+  const { isAuthenticated, canEdit } = useAppAuth();
   const { themeMode } = useAppTheme();
 
   const {
@@ -124,6 +125,17 @@ export const VulnerabilityDetails: FC = () => {
                   isBookmarked={isBookmarked(vulnerabilityId, BookmarkType.Vulnerability)}
                   onToggle={toggleBookmark}
                 />
+              )}
+              {canEdit && (
+                <Button
+                  variant="outlined"
+                  size="small"
+                  startIcon={<Edit />}
+                  onClick={() => navigate(`/admin/vulnerabilities/edit?vulnerabilityId=${vulnerabilityId}`)}
+                  sx={{ ml: 1 }}
+                >
+                  Edit this entry
+                </Button>
               )}
             </Box>
 


### PR DESCRIPTION
pr close #47 

 Added an "Edit this entry" button to the vulnerability details page header. The button is only
  visible to users with edit permissions (Admin, Moderator, or Contributor) and links directly
  to the admin edit page for that vulnerability
  (/admin/vulnerabilities/edit?vulnerabilityId=<id>), eliminating the need to navigate through
  the admin panel to find and edit a specific entry.
  
  File changed: UI/src/features/pages/regular/vulnerability-details/vulnerability-details.tsx