### PR TITLE
Lower Contributor requirement to Navigator and Fix Discord Role Priority

### DIFF
--- a/Backend/SorobanSecurityPortalApi/Models/ViewModels/TokenModel.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/ViewModels/TokenModel.cs
@@ -45,11 +45,15 @@ namespace SorobanSecurityPortalApi.Models.ViewModels
         public bool IsNavigator() => this.IsActive() && this.Roles.Contains("1082353855041392731");
         // Tier 1
         public bool IsPathfinder() => this.IsActive() && this.Roles.Contains("1082357854926807111");
+        // SCF Project
+        public bool IsScfProject() => this.IsActive() && this.Roles.Contains("1082358910805090367");
+
         public StellarDevelopersGuildRole GetRole()
         {
             if (this.IsPilot()) return StellarDevelopersGuildRole.Pilot;
             if (this.IsNavigator()) return StellarDevelopersGuildRole.Navigator;
             if (this.IsPathfinder()) return StellarDevelopersGuildRole.Pathfinder;
+            if (this.IsScfProject()) return StellarDevelopersGuildRole.ScfProject;
             return StellarDevelopersGuildRole.None; // Default role
         }
     }
@@ -59,6 +63,7 @@ namespace SorobanSecurityPortalApi.Models.ViewModels
         None = 0,
         Pilot = 1,
         Navigator = 2,
-        Pathfinder = 3
+        Pathfinder = 3,
+        ScfProject = 4
     }
 }

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ConnectService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ConnectService.cs
@@ -115,10 +115,8 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             if (login == null)
             {
                 login = await _loginProcessor.GetByEmail(extendedTokenModel.Email);
-                var userRole = GetRoleFromDiscordGuild(extendedTokenModel);
                 if (login != null)
                 {
-                    var updated = false;
                     if (!login.ConnectedAccounts!.Any(ca => ca.ServiceName == "Discord" && ca.AccountId == extendedTokenModel.Email))
                     {
                         login.ConnectedAccounts!.Add(new ConnectedAccountModel
@@ -126,15 +124,6 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
                             ServiceName = "Discord",
                             AccountId = extendedTokenModel.Email
                         });
-                        updated = true;
-                    }
-                    if (userRole > login.Role)
-                    {
-                        login.Role = userRole;
-                        updated = true;
-                    }
-                    if (updated)
-                    {
                         await _loginProcessor.Update(login);
                     }
                 }
@@ -145,7 +134,7 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
                         Login = extendedTokenModel.Email,
                         Email = extendedTokenModel.Email,
                         FullName = extendedTokenModel.Name,
-                        Role = userRole,
+                        Role = RoleEnum.User,
                         LoginType = LoginTypeEnum.SsoDiscord,
                         IsEnabled = true,
                         Created = DateTime.UtcNow,
@@ -155,6 +144,14 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
                             : null
                     });
                 }
+            }
+
+            // Sync role from Discord on every login
+            var userRole = GetRoleFromDiscordGuild(extendedTokenModel);
+            if (userRole > login.Role)
+            {
+                login.Role = userRole;
+                await _loginProcessor.Update(login);
             }
 
             // Sync avatar from SSO on every login, unless user has manually set their avatar
@@ -484,18 +481,22 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             {
                 return RoleEnum.User;
             }
+
+            if (extendedTokenModel.GuildMemberInfo.IsPilot())
+            {
+                return RoleEnum.Moderator;
+            }
+
+            if (extendedTokenModel.GuildMemberInfo.IsNavigator())
+            {
+                return RoleEnum.Contributor;
+            }
+
             if (extendedTokenModel.GuildMemberInfo.IsPathfinder())
             {
                 return RoleEnum.User;
             }
-            else if (extendedTokenModel.GuildMemberInfo.IsNavigator())
-            {
-                return RoleEnum.Contributor;
-            }
-            else if (extendedTokenModel.GuildMemberInfo.IsPilot())
-            {
-                return RoleEnum.Moderator;
-            }
+
             return RoleEnum.User;
         }
 

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ConnectService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ConnectService.cs
@@ -111,6 +111,7 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             bool isOfflineMode,
             LoginProcessViewModel loginProcessViewModel)
         {
+            var userRole = GetRoleFromDiscordGuild(extendedTokenModel);
             var login = await _loginProcessor.GetByLogin(extendedTokenModel.Email, LoginTypeEnum.SsoDiscord);
             if (login == null)
             {
@@ -134,7 +135,7 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
                         Login = extendedTokenModel.Email,
                         Email = extendedTokenModel.Email,
                         FullName = extendedTokenModel.Name,
-                        Role = RoleEnum.User,
+                        Role = userRole,
                         LoginType = LoginTypeEnum.SsoDiscord,
                         IsEnabled = true,
                         Created = DateTime.UtcNow,
@@ -146,8 +147,7 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
                 }
             }
 
-            // Sync role from Discord on every login
-            var userRole = GetRoleFromDiscordGuild(extendedTokenModel);
+            // Sync role from Discord on every login if it's higher
             if (userRole > login.Role)
             {
                 login.Role = userRole;
@@ -481,15 +481,16 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             {
                 return RoleEnum.User;
             }
-            if (extendedTokenModel.GuildMemberInfo.IsPilot() || 
-                extendedTokenModel.GuildMemberInfo.IsNavigator() || 
+
+            if (extendedTokenModel.GuildMemberInfo.IsPilot())
+            {
+                return RoleEnum.Moderator;
+            }
+
+            if (extendedTokenModel.GuildMemberInfo.IsNavigator() ||
                 extendedTokenModel.GuildMemberInfo.IsScfProject())
             {
                 return RoleEnum.Contributor;
-            }
-            else if (extendedTokenModel.GuildMemberInfo.IsPathfinder())
-            {
-                return RoleEnum.User;
             }
 
             return RoleEnum.User;

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ConnectService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ConnectService.cs
@@ -481,18 +481,13 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             {
                 return RoleEnum.User;
             }
-
-            if (extendedTokenModel.GuildMemberInfo.IsPilot())
-            {
-                return RoleEnum.Moderator;
-            }
-
-            if (extendedTokenModel.GuildMemberInfo.IsNavigator())
+            if (extendedTokenModel.GuildMemberInfo.IsPilot() || 
+                extendedTokenModel.GuildMemberInfo.IsNavigator() || 
+                extendedTokenModel.GuildMemberInfo.IsScfProject())
             {
                 return RoleEnum.Contributor;
             }
-
-            if (extendedTokenModel.GuildMemberInfo.IsPathfinder())
+            else if (extendedTokenModel.GuildMemberInfo.IsPathfinder())
             {
                 return RoleEnum.User;
             }

--- a/UI/src/features/pages/regular/home/roles-info.tsx
+++ b/UI/src/features/pages/regular/home/roles-info.tsx
@@ -12,28 +12,28 @@ export const RolesInfo: FC<RolesInfoProps> = ({ isCompact = false }) => {
   const navigate = useNavigate();
   const { isAuthenticated, userName, isAdmin, isModerator, isContributor } = useAppAuth();
 
-    const rolesData = [
-        {
-            name: "Guest",
-            permissions: ["read"],
-            description: "Readonly access is available for everyone"
-        },
-        {
-            name: "User (logged in)",
-            permissions: ["read", "download"],
-            description: "Authorized users can download reports in the PDF format"
-        },
-        {
-            name: "Contributor",
-            permissions: ["read", "download", "create"],
-            description: "Contributors are SCF Navigators, Pilots and SCF Projects (see the handbook) or those who expressed interest in contributing"
-        },
-        {
-            name: "Moderator",
-            permissions: ["read", "download", "create", "approve"],
-            description: "Granted manually to active community members who are looking after the content integrity and quality"
-        }
-    ];
+  const rolesData = [
+    {
+      name: "Guest",
+      permissions: ["read"],
+      description: "Readonly access is available for everyone",
+    },
+    {
+      name: "User (logged in)",
+      permissions: ["read", "download"],
+      description: "Authorized users can download reports in the PDF format",
+    },
+    {
+      name: "Contributor",
+      permissions: ["read", "download", "create"],
+      description: "Contributors are SCF Navigators and SCF Projects (see the handbook) or those who expressed interest in contributing",
+    },
+    {
+      name: "Moderator",
+      permissions: ["read", "download", "create", "approve"],
+      description: "Granted to SCF Pilots and active community members who are looking after the content integrity and quality",
+    },
+  ];
 
   const getUserPermissions = () => {
     if (isAdmin || isModerator) {

--- a/UI/src/features/pages/regular/home/roles-info.tsx
+++ b/UI/src/features/pages/regular/home/roles-info.tsx
@@ -12,29 +12,28 @@ export const RolesInfo: FC<RolesInfoProps> = ({ isCompact = false }) => {
   const navigate = useNavigate();
   const { isAuthenticated, userName, isAdmin, isModerator, isContributor } = useAppAuth();
 
-  const rolesData = [
-    {
-      name: "Guest",
-      permissions: ["read"],
-      description: "Readonly access is available for everyone",
-    },
-    {
-      name: "User (logged in)",
-      permissions: ["read", "download"],
-      description: "Authorized users can download reports in the PDF format",
-    },
-    {
-      name: "Contributor",
-      permissions: ["read", "download", "create"],
-      description: "Contributors are Pilots (see the handbook) or those who expressed interest in contributing",
-    },
-    {
-      name: "Moderator",
-      permissions: ["read", "download", "create", "approve"],
-      description:
-        "Granted manually to active community members who are looking after the content integrity and quality",
-    },
-  ];
+    const rolesData = [
+        {
+            name: "Guest",
+            permissions: ["read"],
+            description: "Readonly access is available for everyone"
+        },
+        {
+            name: "User (logged in)",
+            permissions: ["read", "download"],
+            description: "Authorized users can download reports in the PDF format"
+        },
+        {
+            name: "Contributor",
+            permissions: ["read", "download", "create"],
+            description: "Contributors are SCF Navigators, Pilots and SCF Projects (see the handbook) or those who expressed interest in contributing"
+        },
+        {
+            name: "Moderator",
+            permissions: ["read", "download", "create", "approve"],
+            description: "Granted manually to active community members who are looking after the content integrity and quality"
+        }
+    ];
 
   const getUserPermissions = () => {
     if (isAdmin || isModerator) {


### PR DESCRIPTION
The point of this commit is to allow for  navigators to be able to interact with the portal more. In the future I want to look at using the "SCF Project" role as well so that individual project maintainers can add their own project, companies and audit reports (still requires approval of course)



This was AI generated FYI. please check changes thoroughly. 

  This commit updates the Discord role mapping logic to lower the requirement for the Contributor role (permissions to create/edit reports and vulnerabilities) from Pilot to Navigator.

  During implementation, a logical bug was identified in the role priority checking order that would have prevented this change from working correctly for users with multiple roles. This
  PR addresses both the requirement change and the underlying logic flaw.

  Key Changes

  1. Lowered Permissions Threshold
   * Mapped the Navigator role from the Stellar Developers Discord to RoleEnum.Contributor (200).
   * Pilots retain RoleEnum.Moderator (300) status, which encompasses all contributor permissions.

  2. Fixed Role Priority Bug (Critical)
   * Refactored GetRoleFromDiscordGuild to check roles in descending order of seniority (Pilot > Navigator > Pathfinder).
   * Previous Behavior: The code checked for IsPathfinder first. Since most Pilots/Navigators also hold the Pathfinder role, the system would often default them to RoleEnum.User
                                                                                                                                                     
  Verification Results
   - [x] Verified role mapping constants in TokenModel.cs.
   - [x] Verified RoleAuthorize attributes in ReportsController and VulnerabilitiesController to ensure they correctly reference the Contributor enum.
   - [x] Manual logic review of the priority stack to ensure no overlap issues.