### PR TITLE
Fix the issues raised in the recent code reviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,4 +139,3 @@ dist
 !.github
 !.dockerignore
 !.eslintrc.cjs
-!README.md

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ dist
 !.github
 !.dockerignore
 !.eslintrc.cjs
+
+# Local kubeconfig used for ad-hoc cluster access — never commit (contains credentials)
+kubeconfig.temp

--- a/Backend/SorobanSecurityPortalApi.Tests/Controllers/ModerationControllerTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Controllers/ModerationControllerTests.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Controllers;
+using SorobanSecurityPortalApi.Models.ViewModels;
+using SorobanSecurityPortalApi.Services.ControllersServices;
+using Xunit;
+
+namespace SorobanSecurityPortalApi.Tests.Controllers
+{
+    public class ContentFlagControllerTests
+    {
+        private readonly Mock<IContentFlagService> _serviceMock = new();
+        private readonly ContentFlagController _controller;
+
+        public ContentFlagControllerTests()
+        {
+            _controller = new ContentFlagController(_serviceMock.Object);
+        }
+
+        [Fact]
+        public async Task Flag_ServiceReturnsOk_Returns200Ok()
+        {
+            var request = new FlagContentRequest { ContentType = "rating", ContentId = 1, Reason = "spam" };
+            _serviceMock.Setup(s => s.Flag(request))
+                .ReturnsAsync(new Result<bool, string>.Ok(true));
+
+            var result = await _controller.Flag(request);
+
+            result.Should().BeOfType<OkObjectResult>();
+        }
+
+        [Fact]
+        public async Task Flag_ServiceReturnsContentNotFound_Returns404()
+        {
+            var request = new FlagContentRequest { ContentType = "rating", ContentId = 99, Reason = "spam" };
+            _serviceMock.Setup(s => s.Flag(request))
+                .ReturnsAsync(new Result<bool, string>.Err("Content not found"));
+
+            var result = await _controller.Flag(request);
+
+            result.Should().BeOfType<NotFoundObjectResult>();
+        }
+
+        [Fact]
+        public async Task Flag_ServiceReturnsAlreadyFlagged_Returns409Conflict()
+        {
+            var request = new FlagContentRequest { ContentType = "rating", ContentId = 1, Reason = "spam" };
+            _serviceMock.Setup(s => s.Flag(request))
+                .ReturnsAsync(new Result<bool, string>.Err("Already flagged"));
+
+            var result = await _controller.Flag(request);
+
+            result.Should().BeOfType<ConflictObjectResult>();
+        }
+
+        [Fact]
+        public async Task Flag_ServiceReturnsOtherError_Returns400BadRequest()
+        {
+            var request = new FlagContentRequest { ContentType = "invalid-type", ContentId = 1, Reason = "spam" };
+            _serviceMock.Setup(s => s.Flag(request))
+                .ReturnsAsync(new Result<bool, string>.Err("Invalid content type"));
+
+            var result = await _controller.Flag(request);
+
+            result.Should().BeOfType<BadRequestObjectResult>();
+        }
+    }
+
+    public class ModerationControllerTests
+    {
+        private readonly Mock<IModerationService> _serviceMock = new();
+        private readonly ModerationController _controller;
+
+        public ModerationControllerTests()
+        {
+            _controller = new ModerationController(_serviceMock.Object);
+        }
+
+        [Fact]
+        public async Task Action_ServiceReturnsOk_Returns200Ok()
+        {
+            var request = new ModerationActionRequest { ContentType = "rating", ContentId = 1, Action = "approve" };
+            _serviceMock.Setup(s => s.TakeAction(request))
+                .ReturnsAsync(new Result<bool, string>.Ok(true));
+
+            var result = await _controller.Action(request);
+
+            result.Should().BeOfType<OkObjectResult>();
+        }
+
+        [Fact]
+        public async Task Action_ServiceReturnsErr_Returns400BadRequest()
+        {
+            var request = new ModerationActionRequest { ContentType = "rating", ContentId = 1, Action = "invalid" };
+            _serviceMock.Setup(s => s.TakeAction(request))
+                .ReturnsAsync(new Result<bool, string>.Err("Invalid action"));
+
+            var result = await _controller.Action(request);
+
+            var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+            badRequest.Value.Should().Be("Invalid action");
+        }
+
+        [Fact]
+        public async Task Queue_ReturnsOkWithServiceList()
+        {
+            var queue = new List<FlaggedContentViewModel>
+            {
+                new() { Id = "rating:1", ContentType = "rating", Status = "pending" },
+                new() { Id = "rating:2", ContentType = "rating", Status = "pending" }
+            };
+            _serviceMock.Setup(s => s.GetQueue("pending", null, 1, 20))
+                .ReturnsAsync(queue);
+
+            var result = await _controller.Queue("pending", null, 1);
+
+            var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().BeSameAs(queue);
+        }
+
+        [Fact]
+        public async Task Stats_ReturnsOkWithStats()
+        {
+            var stats = new ModerationStatsViewModel { QueueSize = 5, ActionsToday = 2, ActionsThisWeek = 10, ActionsThisMonth = 40 };
+            _serviceMock.Setup(s => s.GetStats()).ReturnsAsync(stats);
+
+            var result = await _controller.Stats();
+
+            var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+            ok.Value.Should().BeSameAs(stats);
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi.Tests/Controllers/RatingControllerTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Controllers/RatingControllerTests.cs
@@ -1,0 +1,78 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SorobanSecurityPortalApi.Controllers;
+using SorobanSecurityPortalApi.Models.DbModels;
+using SorobanSecurityPortalApi.Models.ViewModels;
+using SorobanSecurityPortalApi.Services.ControllersServices;
+using Xunit;
+using FluentAssertions;
+
+namespace SorobanSecurityPortalApi.Tests.Controllers
+{
+    public class RatingControllerTests
+    {
+        private readonly Mock<IRatingService> _ratingServiceMock = new();
+        private readonly RatingController _controller;
+
+        public RatingControllerTests()
+        {
+            _controller = new RatingController(_ratingServiceMock.Object);
+        }
+
+        [Fact]
+        public async Task CreateOrUpdate_Should_ReturnBadRequest_WhenReviewExceeds2000Chars()
+        {
+            var request = new CreateRatingRequest
+            {
+                EntityType = EntityType.Protocol,
+                EntityId = 1,
+                Score = 3,
+                Review = new string('x', 2001)
+            };
+
+            var result = await _controller.CreateOrUpdate(request);
+
+            var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+            badRequest.Value.Should().Be("Review must not exceed 2000 characters.");
+            _ratingServiceMock.Verify(s => s.AddOrUpdateRating(It.IsAny<CreateRatingRequest>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task CreateOrUpdate_Should_Accept_ReviewAtExactly2000Chars()
+        {
+            var request = new CreateRatingRequest
+            {
+                EntityType = EntityType.Protocol,
+                EntityId = 1,
+                Score = 3,
+                Review = new string('x', 2000)
+            };
+
+            _ratingServiceMock
+                .Setup(s => s.AddOrUpdateRating(request))
+                .ReturnsAsync(new RatingViewModel { Id = 1, Score = 3 });
+
+            var result = await _controller.CreateOrUpdate(request);
+
+            result.Should().BeOfType<OkObjectResult>();
+        }
+
+        [Fact]
+        public async Task CreateOrUpdate_Should_ReturnBadRequest_WhenScoreOutOfRange()
+        {
+            var request = new CreateRatingRequest
+            {
+                EntityType = EntityType.Protocol,
+                EntityId = 1,
+                Score = 6,
+                Review = "ok"
+            };
+
+            var result = await _controller.CreateOrUpdate(request);
+
+            result.Should().BeOfType<BadRequestObjectResult>();
+            _ratingServiceMock.Verify(s => s.AddOrUpdateRating(It.IsAny<CreateRatingRequest>()), Times.Never);
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi.Tests/Controllers/RatingControllerTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Controllers/RatingControllerTests.cs
@@ -74,5 +74,27 @@ namespace SorobanSecurityPortalApi.Tests.Controllers
             result.Should().BeOfType<BadRequestObjectResult>();
             _ratingServiceMock.Verify(s => s.AddOrUpdateRating(It.IsAny<CreateRatingRequest>()), Times.Never);
         }
+
+        [Fact]
+        public async Task CreateOrUpdate_Should_NormalizeNullReviewToEmpty_AndNotFail()
+        {
+            var request = new CreateRatingRequest
+            {
+                EntityType = EntityType.Protocol,
+                EntityId = 1,
+                Score = 4,
+                Review = null!
+            };
+
+            _ratingServiceMock
+                .Setup(s => s.AddOrUpdateRating(It.IsAny<CreateRatingRequest>()))
+                .ReturnsAsync(new RatingViewModel { Id = 1, Score = 4 });
+
+            var result = await _controller.CreateOrUpdate(request);
+
+            result.Should().BeOfType<OkObjectResult>();
+            // A null review must be coerced to empty string before reaching the NOT NULL column.
+            _ratingServiceMock.Verify(s => s.AddOrUpdateRating(It.Is<CreateRatingRequest>(r => r.Review == string.Empty)), Times.Once);
+        }
     }
 }

--- a/Backend/SorobanSecurityPortalApi.Tests/Services/ContentFilterServiceTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Services/ContentFilterServiceTests.cs
@@ -396,7 +396,7 @@ public class ContentFilterServiceTests
 
         // Assert
         result.Should().BeTrue();
-        _cacheAccessorMock.Verify(x => x.SetCacheValue(It.IsAny<string>(), "1", 60), Times.Once);
+        _cacheAccessorMock.Verify(x => x.SetCacheValue(It.IsAny<string>(), "1", 120), Times.Once);
     }
 
     [Fact]
@@ -411,7 +411,7 @@ public class ContentFilterServiceTests
 
         // Assert
         result.Should().BeTrue();
-        _cacheAccessorMock.Verify(x => x.SetCacheValue(It.IsAny<string>(), "6", 60), Times.Once);
+        _cacheAccessorMock.Verify(x => x.SetCacheValue(It.IsAny<string>(), "6", 120), Times.Once);
     }
 
     [Fact]
@@ -440,7 +440,7 @@ public class ContentFilterServiceTests
 
         // Assert
         result.Should().BeTrue();
-        _cacheAccessorMock.Verify(x => x.SetCacheValue(It.IsAny<string>(), "1", 60), Times.Once);
+        _cacheAccessorMock.Verify(x => x.SetCacheValue(It.IsAny<string>(), "1", 120), Times.Once);
     }
 
     #endregion

--- a/Backend/SorobanSecurityPortalApi.Tests/Services/ContentFlagServiceTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Services/ContentFlagServiceTests.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Data.Processors;
+using SorobanSecurityPortalApi.Models.DbModels;
+using SorobanSecurityPortalApi.Models.ViewModels;
+using SorobanSecurityPortalApi.Services.ControllersServices;
+using SorobanSecurityPortalApi.Services.Moderation;
+using Xunit;
+
+namespace SorobanSecurityPortalApi.Tests.Services
+{
+    public class ContentFlagServiceTests
+    {
+        private readonly Mock<IContentFlagProcessor> _flagsMock;
+        private readonly Mock<IModerationTargetRegistry> _registryMock;
+        private readonly Mock<IUserContextAccessor> _userContextMock;
+        private readonly Mock<IModerationTarget> _targetMock;
+
+        public ContentFlagServiceTests()
+        {
+            _flagsMock = new Mock<IContentFlagProcessor>();
+            _registryMock = new Mock<IModerationTargetRegistry>();
+            _userContextMock = new Mock<IUserContextAccessor>();
+            _targetMock = new Mock<IModerationTarget>();
+        }
+
+        private ContentFlagService CreateService()
+            => new ContentFlagService(_flagsMock.Object, _registryMock.Object, _userContextMock.Object);
+
+        private void SetupValidTarget(int contentId, ModerationTargetInfo? info)
+        {
+            IModerationTarget outTarget = _targetMock.Object;
+            _registryMock
+                .Setup(r => r.TryGet(ModeratedContentType.Vulnerability, out outTarget))
+                .Returns(true);
+            _targetMock
+                .Setup(t => t.Get(contentId))
+                .ReturnsAsync(info);
+        }
+
+        private void SetupUser(int userId)
+        {
+            _userContextMock
+                .Setup(u => u.GetLoginIdAsync())
+                .ReturnsAsync(userId);
+        }
+
+        // --- Success case ---
+
+        [Fact]
+        public async Task Flag_Success_AddCalledOnce()
+        {
+            // Arrange
+            var contentId = 42;
+            SetupValidTarget(contentId, new ModerationTargetInfo { Preview = "Preview", FullContent = "Full", AuthorUserId = 5 });
+            SetupUser(10);
+            _flagsMock
+                .Setup(f => f.Exists(ModeratedContentType.Vulnerability, contentId, 10))
+                .ReturnsAsync(false);
+            _flagsMock
+                .Setup(f => f.Add(It.IsAny<ContentFlagModel>()))
+                .Returns(Task.CompletedTask);
+
+            var service = CreateService();
+            var request = new FlagContentRequest
+            {
+                ContentType = "vulnerability",
+                ContentId = contentId,
+                Reason = "Spam",
+                Comment = "test"
+            };
+
+            // Act
+            var result = await service.Flag(request);
+
+            // Assert
+            result.Should().BeOfType<Result<bool, string>.Ok>();
+            _flagsMock.Verify(f => f.Add(It.Is<ContentFlagModel>(m =>
+                m.ContentType == ModeratedContentType.Vulnerability &&
+                m.ContentId == contentId &&
+                m.FlaggedByUserId == 10 &&
+                m.Reason == FlagReason.Spam &&
+                m.Comment == "test"
+            )), Times.Once);
+        }
+
+        // --- Duplicate flag ---
+
+        [Fact]
+        public async Task Flag_AlreadyFlagged_ReturnsErr_AndAddNotCalled()
+        {
+            // Arrange
+            var contentId = 1;
+            SetupValidTarget(contentId, new ModerationTargetInfo { Preview = "P", FullContent = "F", AuthorUserId = 1 });
+            SetupUser(7);
+            _flagsMock
+                .Setup(f => f.Exists(ModeratedContentType.Vulnerability, contentId, 7))
+                .ReturnsAsync(true);
+
+            var service = CreateService();
+            var request = new FlagContentRequest
+            {
+                ContentType = "vulnerability",
+                ContentId = contentId,
+                Reason = "Spam"
+            };
+
+            // Act
+            var result = await service.Flag(request);
+
+            // Assert
+            result.Should().BeOfType<Result<bool, string>.Err>();
+            var err = (Result<bool, string>.Err)result;
+            err.Error.Should().Be("Already flagged");
+            _flagsMock.Verify(f => f.Add(It.IsAny<ContentFlagModel>()), Times.Never);
+        }
+
+        // --- Content not found ---
+
+        [Fact]
+        public async Task Flag_ContentNotFound_ReturnsErr_ContentNotFound()
+        {
+            // Arrange
+            var contentId = 999;
+            SetupValidTarget(contentId, null);
+
+            var service = CreateService();
+            var request = new FlagContentRequest
+            {
+                ContentType = "vulnerability",
+                ContentId = contentId,
+                Reason = "Spam"
+            };
+
+            // Act
+            var result = await service.Flag(request);
+
+            // Assert
+            result.Should().BeOfType<Result<bool, string>.Err>();
+            var err = (Result<bool, string>.Err)result;
+            err.Error.Should().Be("Content not found");
+            _flagsMock.Verify(f => f.Add(It.IsAny<ContentFlagModel>()), Times.Never);
+        }
+
+        // --- Invalid content type ---
+
+        [Fact]
+        public async Task Flag_InvalidContentType_ReturnsErr()
+        {
+            // Arrange
+            var service = CreateService();
+            var request = new FlagContentRequest
+            {
+                ContentType = "bogus",
+                ContentId = 1,
+                Reason = "Spam"
+            };
+
+            // Act
+            var result = await service.Flag(request);
+
+            // Assert
+            result.Should().BeOfType<Result<bool, string>.Err>();
+            var err = (Result<bool, string>.Err)result;
+            err.Error.Should().Be("Invalid content type");
+            _flagsMock.Verify(f => f.Add(It.IsAny<ContentFlagModel>()), Times.Never);
+        }
+
+        // --- Invalid reason ---
+
+        [Fact]
+        public async Task Flag_InvalidReason_ReturnsErr()
+        {
+            // Arrange
+            var service = CreateService();
+            var request = new FlagContentRequest
+            {
+                ContentType = "vulnerability",
+                ContentId = 1,
+                Reason = "NotARealReason"
+            };
+
+            // Act
+            var result = await service.Flag(request);
+
+            // Assert
+            result.Should().BeOfType<Result<bool, string>.Err>();
+            var err = (Result<bool, string>.Err)result;
+            err.Error.Should().Be("Invalid reason");
+        }
+
+        // --- Registry returns false (no target) ---
+
+        [Fact]
+        public async Task Flag_RegistryReturnsNoTarget_ReturnsErr_InvalidContentType()
+        {
+            // Arrange
+            IModerationTarget outTarget = null!;
+            _registryMock
+                .Setup(r => r.TryGet(ModeratedContentType.Report, out outTarget))
+                .Returns(false);
+
+            var service = CreateService();
+            var request = new FlagContentRequest
+            {
+                ContentType = "report",
+                ContentId = 1,
+                Reason = "Spam"
+            };
+
+            // Act
+            var result = await service.Flag(request);
+
+            // Assert
+            result.Should().BeOfType<Result<bool, string>.Err>();
+            var err = (Result<bool, string>.Err)result;
+            err.Error.Should().Be("Invalid content type");
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi.Tests/Services/ModerationServiceTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Services/ModerationServiceTests.cs
@@ -1,0 +1,511 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Data.Processors;
+using SorobanSecurityPortalApi.Models.DbModels;
+using SorobanSecurityPortalApi.Models.ViewModels;
+using SorobanSecurityPortalApi.Services.ControllersServices;
+using SorobanSecurityPortalApi.Services.Moderation;
+using Xunit;
+
+namespace SorobanSecurityPortalApi.Tests.Services
+{
+    public class ModerationServiceTests
+    {
+        private readonly Mock<IContentFlagProcessor> _flagsMock = new();
+        private readonly Mock<IModerationActionProcessor> _actionsMock = new();
+        private readonly Mock<IModerationTargetRegistry> _registryMock = new();
+        private readonly Mock<IUserContextAccessor> _userContextMock = new();
+        private readonly Mock<ILoginProcessor> _loginProcessorMock = new();
+        private readonly Mock<IUserProfileProcessor> _profileProcessorMock = new();
+        private readonly Mock<IModerationTarget> _vulnTargetMock = new();
+
+        public ModerationServiceTests()
+        {
+            // Default: CountSince returns 0
+            _actionsMock
+                .Setup(a => a.CountSince(It.IsAny<DateTime>()))
+                .ReturnsAsync(0);
+
+            // Default: login and profile return empty/null
+            _loginProcessorMock
+                .Setup(l => l.GetById(It.IsAny<int>()))
+                .ReturnsAsync((LoginModel?)null);
+            _profileProcessorMock
+                .Setup(p => p.GetByLoginIdAsync(It.IsAny<int>()))
+                .ReturnsAsync((UserProfileModel?)null);
+        }
+
+        private ModerationService CreateService()
+            => new ModerationService(
+                _flagsMock.Object,
+                _actionsMock.Object,
+                _registryMock.Object,
+                _userContextMock.Object,
+                _loginProcessorMock.Object,
+                _profileProcessorMock.Object);
+
+        private void SetupVulnTarget(int contentId, ModerationTargetInfo? info)
+        {
+            IModerationTarget outTarget = _vulnTargetMock.Object;
+            _registryMock
+                .Setup(r => r.TryGet(ModeratedContentType.Vulnerability, out outTarget))
+                .Returns(true);
+            _vulnTargetMock
+                .Setup(t => t.Get(contentId))
+                .ReturnsAsync(info);
+        }
+
+        // --- Queue aggregation: two flags on same (vuln, 1) → FlagCount=2, reason map ---
+
+        [Fact]
+        public async Task GetQueue_TwoFlagsOnSameItem_AggregatesToFlagCount2_WithReasonMap()
+        {
+            // Arrange
+            var baseTime = new DateTime(2026, 1, 10, 12, 0, 0, DateTimeKind.Utc);
+            var flags = new List<ContentFlagModel>
+            {
+                new() { Id = 1, ContentType = ModeratedContentType.Vulnerability, ContentId = 1, FlaggedByUserId = 10, Reason = FlagReason.Spam, CreatedAt = baseTime },
+                new() { Id = 2, ContentType = ModeratedContentType.Vulnerability, ContentId = 1, FlaggedByUserId = 11, Reason = FlagReason.Inappropriate, CreatedAt = baseTime.AddHours(1) }
+            };
+            _flagsMock.Setup(f => f.GetAll()).ReturnsAsync(flags);
+            _actionsMock.Setup(a => a.GetAll()).ReturnsAsync(new List<ModerationActionModel>());
+
+            SetupVulnTarget(1, new ModerationTargetInfo { Preview = "Re-entry bug", FullContent = "Full text", AuthorUserId = 5 });
+
+            var service = CreateService();
+
+            // Act
+            var queue = await service.GetQueue(null, null, 1);
+
+            // Assert
+            queue.Should().HaveCount(1);
+            var item = queue[0];
+            item.FlagCount.Should().Be(2);
+            item.Reasons.Should().ContainKey("spam").WhoseValue.Should().Be(1);
+            item.Reasons.Should().ContainKey("inappropriate").WhoseValue.Should().Be(1);
+            item.Id.Should().Be("vulnerability:1");
+        }
+
+        // --- Status = pending when no action ---
+
+        [Fact]
+        public async Task GetQueue_NoAction_StatusIsPending()
+        {
+            // Arrange
+            var flags = new List<ContentFlagModel>
+            {
+                new() { Id = 1, ContentType = ModeratedContentType.Vulnerability, ContentId = 1, FlaggedByUserId = 10, Reason = FlagReason.Spam, CreatedAt = DateTime.UtcNow }
+            };
+            _flagsMock.Setup(f => f.GetAll()).ReturnsAsync(flags);
+            _actionsMock.Setup(a => a.GetAll()).ReturnsAsync(new List<ModerationActionModel>());
+            SetupVulnTarget(1, new ModerationTargetInfo { Preview = "P", FullContent = "F", AuthorUserId = 1 });
+
+            var service = CreateService();
+
+            // Act
+            var queue = await service.GetQueue(null, null, 1);
+
+            // Assert
+            queue.Should().HaveCount(1);
+            queue[0].Status.Should().Be("pending");
+        }
+
+        // --- Status = hidden after a Hide action ---
+
+        [Fact]
+        public async Task GetQueue_AfterHideAction_StatusIsHidden()
+        {
+            // Arrange
+            var flagTime = new DateTime(2026, 1, 5, 0, 0, 0, DateTimeKind.Utc);
+            var actionTime = flagTime.AddHours(1);
+
+            var flags = new List<ContentFlagModel>
+            {
+                new() { Id = 1, ContentType = ModeratedContentType.Vulnerability, ContentId = 1, FlaggedByUserId = 10, Reason = FlagReason.Spam, CreatedAt = flagTime }
+            };
+            var actions = new List<ModerationActionModel>
+            {
+                new() { Id = 1, ContentType = ModeratedContentType.Vulnerability, ContentId = 1, ModeratorId = 99, Action = ModerationActionType.Hide, CreatedAt = actionTime }
+            };
+            _flagsMock.Setup(f => f.GetAll()).ReturnsAsync(flags);
+            _actionsMock.Setup(a => a.GetAll()).ReturnsAsync(actions);
+            SetupVulnTarget(1, new ModerationTargetInfo { Preview = "P", FullContent = "F", AuthorUserId = 1 });
+
+            var service = CreateService();
+
+            // Act
+            var queue = await service.GetQueue(null, null, 1);
+
+            // Assert
+            queue.Should().HaveCount(1);
+            queue[0].Status.Should().Be("hidden");
+        }
+
+        // --- Re-queue: flag newer than last action → status pending ---
+
+        [Fact]
+        public async Task GetQueue_FlagNewerThanLastAction_ReturnsStatusPending()
+        {
+            // Arrange
+            var actionTime = new DateTime(2026, 1, 5, 0, 0, 0, DateTimeKind.Utc);
+            var newFlagTime = actionTime.AddDays(1); // newer than the action
+
+            var flags = new List<ContentFlagModel>
+            {
+                new() { Id = 1, ContentType = ModeratedContentType.Vulnerability, ContentId = 1, FlaggedByUserId = 10, Reason = FlagReason.Spam, CreatedAt = actionTime.AddHours(-1) },
+                new() { Id = 2, ContentType = ModeratedContentType.Vulnerability, ContentId = 1, FlaggedByUserId = 12, Reason = FlagReason.Other, CreatedAt = newFlagTime }
+            };
+            var actions = new List<ModerationActionModel>
+            {
+                new() { Id = 1, ContentType = ModeratedContentType.Vulnerability, ContentId = 1, ModeratorId = 99, Action = ModerationActionType.Hide, CreatedAt = actionTime }
+            };
+            _flagsMock.Setup(f => f.GetAll()).ReturnsAsync(flags);
+            _actionsMock.Setup(a => a.GetAll()).ReturnsAsync(actions);
+            SetupVulnTarget(1, new ModerationTargetInfo { Preview = "P", FullContent = "F", AuthorUserId = 1 });
+
+            var service = CreateService();
+
+            // Act
+            var queue = await service.GetQueue(null, null, 1);
+
+            // Assert
+            queue.Should().HaveCount(1);
+            queue[0].Status.Should().Be("pending");
+        }
+
+        // --- TakeAction Hide: calls target.Hide and records action ---
+
+        [Fact]
+        public async Task TakeAction_Hide_CallsTargetHide_AndRecordsAction()
+        {
+            // Arrange
+            _userContextMock.Setup(u => u.GetLoginIdAsync()).ReturnsAsync(99);
+            _actionsMock.Setup(a => a.Add(It.IsAny<ModerationActionModel>())).Returns(Task.CompletedTask);
+            _vulnTargetMock.Setup(t => t.Hide(1)).Returns(Task.CompletedTask);
+
+            IModerationTarget outTarget = _vulnTargetMock.Object;
+            _registryMock.Setup(r => r.TryGet(ModeratedContentType.Vulnerability, out outTarget)).Returns(true);
+
+            var service = CreateService();
+            var request = new ModerationActionRequest
+            {
+                ContentType = "vulnerability",
+                ContentId = 1,
+                Action = "Hide",
+                Reason = "Violates policy"
+            };
+
+            // Act
+            var result = await service.TakeAction(request);
+
+            // Assert
+            result.Should().BeOfType<Result<bool, string>.Ok>();
+            _vulnTargetMock.Verify(t => t.Hide(1), Times.Once);
+            _actionsMock.Verify(a => a.Add(It.Is<ModerationActionModel>(m =>
+                m.ContentType == ModeratedContentType.Vulnerability &&
+                m.ContentId == 1 &&
+                m.ModeratorId == 99 &&
+                m.Action == ModerationActionType.Hide &&
+                m.Reason == "Violates policy"
+            )), Times.Once);
+        }
+
+        // --- TakeAction Hide with empty reason → Err ---
+
+        [Fact]
+        public async Task TakeAction_Hide_EmptyReason_ReturnsErr()
+        {
+            // Arrange
+            IModerationTarget outTarget = _vulnTargetMock.Object;
+            _registryMock.Setup(r => r.TryGet(It.IsAny<ModeratedContentType>(), out outTarget)).Returns(true);
+
+            var service = CreateService();
+            var request = new ModerationActionRequest
+            {
+                ContentType = "vulnerability",
+                ContentId = 1,
+                Action = "Hide",
+                Reason = "   " // whitespace only
+            };
+
+            // Act
+            var result = await service.TakeAction(request);
+
+            // Assert
+            result.Should().BeOfType<Result<bool, string>.Err>();
+            var err = (Result<bool, string>.Err)result;
+            err.Error.Should().Be("Reason is required for hide/delete");
+            _actionsMock.Verify(a => a.Add(It.IsAny<ModerationActionModel>()), Times.Never);
+        }
+
+        // --- TakeAction Delete with empty reason → Err ---
+
+        [Fact]
+        public async Task TakeAction_Delete_EmptyReason_ReturnsErr()
+        {
+            // Arrange
+            var service = CreateService();
+            var request = new ModerationActionRequest
+            {
+                ContentType = "vulnerability",
+                ContentId = 1,
+                Action = "Delete",
+                Reason = null
+            };
+
+            // Act
+            var result = await service.TakeAction(request);
+
+            // Assert
+            result.Should().BeOfType<Result<bool, string>.Err>();
+            var err = (Result<bool, string>.Err)result;
+            err.Error.Should().Be("Reason is required for hide/delete");
+        }
+
+        // --- TakeAction Approve: calls target.Restore ---
+
+        [Fact]
+        public async Task TakeAction_Approve_CallsTargetRestore()
+        {
+            // Arrange
+            _userContextMock.Setup(u => u.GetLoginIdAsync()).ReturnsAsync(99);
+            _actionsMock.Setup(a => a.Add(It.IsAny<ModerationActionModel>())).Returns(Task.CompletedTask);
+            _vulnTargetMock.Setup(t => t.Restore(1)).Returns(Task.CompletedTask);
+
+            IModerationTarget outTarget = _vulnTargetMock.Object;
+            _registryMock.Setup(r => r.TryGet(ModeratedContentType.Vulnerability, out outTarget)).Returns(true);
+
+            var service = CreateService();
+            var request = new ModerationActionRequest
+            {
+                ContentType = "vulnerability",
+                ContentId = 1,
+                Action = "Approve",
+                Reason = null
+            };
+
+            // Act
+            var result = await service.TakeAction(request);
+
+            // Assert
+            result.Should().BeOfType<Result<bool, string>.Ok>();
+            _vulnTargetMock.Verify(t => t.Restore(1), Times.Once);
+        }
+
+        // --- TakeAction invalid action ---
+
+        [Fact]
+        public async Task TakeAction_InvalidAction_ReturnsErr()
+        {
+            // Arrange
+            var service = CreateService();
+            var request = new ModerationActionRequest
+            {
+                ContentType = "vulnerability",
+                ContentId = 1,
+                Action = "Teleport"
+            };
+
+            // Act
+            var result = await service.TakeAction(request);
+
+            // Assert
+            result.Should().BeOfType<Result<bool, string>.Err>();
+            var err = (Result<bool, string>.Err)result;
+            err.Error.Should().Be("Invalid action");
+        }
+
+        // --- TakeAction invalid content type ---
+
+        [Fact]
+        public async Task TakeAction_InvalidContentType_ReturnsErr()
+        {
+            // Arrange
+            var service = CreateService();
+            var request = new ModerationActionRequest
+            {
+                ContentType = "forum_post",
+                ContentId = 1,
+                Action = "Hide",
+                Reason = "Some reason"
+            };
+
+            // Act
+            var result = await service.TakeAction(request);
+
+            // Assert
+            result.Should().BeOfType<Result<bool, string>.Err>();
+            var err = (Result<bool, string>.Err)result;
+            err.Error.Should().Be("Invalid content type");
+        }
+
+        // --- GetStats: QueueSize from pending queue + CountSince values ---
+
+        [Fact]
+        public async Task GetStats_ReturnsCorrectQueueSizeAndActionCounts()
+        {
+            // Arrange: one pending flag item
+            var flagTime = new DateTime(2026, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+            var flags = new List<ContentFlagModel>
+            {
+                new() { Id = 1, ContentType = ModeratedContentType.Vulnerability, ContentId = 1, FlaggedByUserId = 10, Reason = FlagReason.Spam, CreatedAt = flagTime }
+            };
+            _flagsMock.Setup(f => f.GetAll()).ReturnsAsync(flags);
+            _actionsMock.Setup(a => a.GetAll()).ReturnsAsync(new List<ModerationActionModel>());
+            SetupVulnTarget(1, new ModerationTargetInfo { Preview = "P", FullContent = "F", AuthorUserId = 1 });
+
+            _actionsMock.Setup(a => a.CountSince(It.IsAny<DateTime>())).ReturnsAsync(5);
+
+            var service = CreateService();
+
+            // Act
+            var stats = await service.GetStats();
+
+            // Assert
+            stats.QueueSize.Should().Be(1);
+            stats.ActionsToday.Should().Be(5);
+            stats.ActionsThisWeek.Should().Be(5);
+            stats.ActionsThisMonth.Should().Be(5);
+        }
+
+        // --- GetStats: QueueSize is NOT capped at the GetQueue pageSize limit (100) ---
+
+        [Fact]
+        public async Task GetStats_QueueSize_IsNotCappedAt100()
+        {
+            // Arrange: 101 distinct pending content items, one flag each
+            var baseTime = new DateTime(2026, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+            var flags = new List<ContentFlagModel>();
+            for (int id = 1; id <= 101; id++)
+            {
+                flags.Add(new ContentFlagModel
+                {
+                    Id = id,
+                    ContentType = ModeratedContentType.Vulnerability,
+                    ContentId = id,
+                    FlaggedByUserId = 10,
+                    Reason = FlagReason.Spam,
+                    CreatedAt = baseTime.AddMinutes(id)
+                });
+            }
+            _flagsMock.Setup(f => f.GetAll()).ReturnsAsync(flags);
+            _actionsMock.Setup(a => a.GetAll()).ReturnsAsync(new List<ModerationActionModel>());
+
+            // Target returns a non-null info for ANY content id
+            _vulnTargetMock
+                .Setup(t => t.Get(It.IsAny<int>()))
+                .ReturnsAsync(new ModerationTargetInfo { Preview = "P", FullContent = "F", AuthorUserId = 1 });
+            IModerationTarget outTarget = _vulnTargetMock.Object;
+            _registryMock
+                .Setup(r => r.TryGet(ModeratedContentType.Vulnerability, out outTarget))
+                .Returns(true);
+
+            // Author lookups return something for any id
+            _loginProcessorMock
+                .Setup(l => l.GetById(It.IsAny<int>()))
+                .ReturnsAsync(new LoginModel { LoginId = 1, FullName = "Author", Email = "a@b.com" });
+            _profileProcessorMock
+                .Setup(p => p.GetByLoginIdAsync(It.IsAny<int>()))
+                .ReturnsAsync(new UserProfileModel { LoginId = 1, ReputationScore = 50 });
+
+            var service = CreateService();
+
+            // Act
+            var stats = await service.GetStats();
+
+            // Assert: must NOT be capped at 100
+            stats.QueueSize.Should().Be(101);
+        }
+
+        // --- GetQueue ModerationHistory is populated correctly ---
+
+        [Fact]
+        public async Task GetQueue_ModerationHistory_PopulatedFromActions()
+        {
+            // Arrange
+            var flagTime = new DateTime(2026, 1, 5, 0, 0, 0, DateTimeKind.Utc);
+            var action1Time = flagTime.AddHours(1);
+            var action2Time = flagTime.AddHours(2);
+
+            var flags = new List<ContentFlagModel>
+            {
+                new() { Id = 1, ContentType = ModeratedContentType.Vulnerability, ContentId = 1, FlaggedByUserId = 10, Reason = FlagReason.Spam, CreatedAt = flagTime }
+            };
+            var actions = new List<ModerationActionModel>
+            {
+                new() { Id = 10, ContentType = ModeratedContentType.Vulnerability, ContentId = 1, ModeratorId = 99, Action = ModerationActionType.Hide, Reason = "Policy", CreatedAt = action1Time },
+                new() { Id = 11, ContentType = ModeratedContentType.Vulnerability, ContentId = 1, ModeratorId = 98, Action = ModerationActionType.Approve, CreatedAt = action2Time }
+            };
+            _flagsMock.Setup(f => f.GetAll()).ReturnsAsync(flags);
+            _actionsMock.Setup(a => a.GetAll()).ReturnsAsync(actions);
+            SetupVulnTarget(1, new ModerationTargetInfo { Preview = "P", FullContent = "F", AuthorUserId = 1 });
+
+            // Moderators referenced by the actions resolve to names via the login lookup.
+            _loginProcessorMock.Setup(l => l.GetById(99)).ReturnsAsync(new LoginModel { LoginId = 99, FullName = "Mod Ninetynine" });
+            _loginProcessorMock.Setup(l => l.GetById(98)).ReturnsAsync(new LoginModel { LoginId = 98, FullName = "Mod Ninetyeight" });
+
+            var service = CreateService();
+
+            // Act
+            var queue = await service.GetQueue(null, null, 1);
+
+            // Assert
+            queue.Should().HaveCount(1);
+            var item = queue[0];
+            item.ModerationHistory.Should().HaveCount(2);
+            item.ModerationHistory[0].Id.Should().Be("10");
+            item.ModerationHistory[0].Action.Should().Be("hidden");
+            item.ModerationHistory[0].ModeratorName.Should().Be("Mod Ninetynine");
+            item.ModerationHistory[1].Id.Should().Be("11");
+            item.ModerationHistory[1].Action.Should().Be("approved");
+            item.ModerationHistory[1].ModeratorName.Should().Be("Mod Ninetyeight");
+            // Last action is Approve (newer than flag), status should be "approved"
+            item.Status.Should().Be("approved");
+        }
+
+        // --- GetQueue: status filter works ---
+
+        [Fact]
+        public async Task GetQueue_StatusFilter_OnlyReturnsPendingItems()
+        {
+            // Arrange: two items, one pending, one hidden
+            var baseTime = new DateTime(2026, 1, 10, 0, 0, 0, DateTimeKind.Utc);
+            var flags = new List<ContentFlagModel>
+            {
+                // ContentId=1: pending (no action)
+                new() { Id = 1, ContentType = ModeratedContentType.Vulnerability, ContentId = 1, FlaggedByUserId = 10, Reason = FlagReason.Spam, CreatedAt = baseTime },
+                // ContentId=2: hidden (action before flag)
+                new() { Id = 2, ContentType = ModeratedContentType.Vulnerability, ContentId = 2, FlaggedByUserId = 11, Reason = FlagReason.Spam, CreatedAt = baseTime }
+            };
+            var actions = new List<ModerationActionModel>
+            {
+                new() { Id = 5, ContentType = ModeratedContentType.Vulnerability, ContentId = 2, ModeratorId = 99, Action = ModerationActionType.Hide, CreatedAt = baseTime.AddHours(1) }
+            };
+            _flagsMock.Setup(f => f.GetAll()).ReturnsAsync(flags);
+            _actionsMock.Setup(a => a.GetAll()).ReturnsAsync(actions);
+
+            // Setup both targets
+            _vulnTargetMock.Setup(t => t.Get(1)).ReturnsAsync(new ModerationTargetInfo { Preview = "P1", FullContent = "F1", AuthorUserId = 1 });
+            _vulnTargetMock.Setup(t => t.Get(2)).ReturnsAsync(new ModerationTargetInfo { Preview = "P2", FullContent = "F2", AuthorUserId = 2 });
+            IModerationTarget outTarget = _vulnTargetMock.Object;
+            _registryMock.Setup(r => r.TryGet(ModeratedContentType.Vulnerability, out outTarget)).Returns(true);
+
+            var service = CreateService();
+
+            // Act
+            var pendingQueue = await service.GetQueue("pending", null, 1);
+            var hiddenQueue = await service.GetQueue("hidden", null, 1);
+
+            // Assert
+            pendingQueue.Should().HaveCount(1);
+            pendingQueue[0].ContentId.Should().Be("1");
+
+            hiddenQueue.Should().HaveCount(1);
+            hiddenQueue[0].ContentId.Should().Be("2");
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi.Tests/Services/ModerationTargetTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Services/ModerationTargetTests.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using SorobanSecurityPortalApi.Common.Data;
+using SorobanSecurityPortalApi.Models.DbModels;
+using SorobanSecurityPortalApi.Services.Moderation;
+using Xunit;
+
+namespace SorobanSecurityPortalApi.Tests.Services
+{
+    public class ModerationTargetTests
+    {
+        // --- Helpers ---
+
+        private static Mock<DbSet<T>> CreateDbSetMock<T>(List<T> sourceList) where T : class
+        {
+            var queryable = sourceList.AsQueryable();
+            var dbSetMock = new Mock<DbSet<T>>();
+
+            dbSetMock.As<IQueryable<T>>().Setup(m => m.Provider).Returns(new TestAsyncQueryProvider<T>(queryable.Provider));
+            dbSetMock.As<IQueryable<T>>().Setup(m => m.Expression).Returns(queryable.Expression);
+            dbSetMock.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(queryable.ElementType);
+            dbSetMock.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(queryable.GetEnumerator());
+            dbSetMock.As<IAsyncEnumerable<T>>().Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+                .Returns(new TestAsyncEnumerator<T>(queryable.GetEnumerator()));
+
+            dbSetMock.Setup(d => d.Add(It.IsAny<T>())).Callback<T>(sourceList.Add);
+            dbSetMock.Setup(d => d.AddRange(It.IsAny<IEnumerable<T>>())).Callback<IEnumerable<T>>(sourceList.AddRange);
+
+            return dbSetMock;
+        }
+
+        private static (Mock<IDbContextFactory<Db>> factory, Mock<Db> db) BuildVulnerabilityFactory(List<VulnerabilityModel> list)
+        {
+            var dbQueryMock = new Mock<IDbQuery>();
+            var loggerMock = new Mock<Microsoft.Extensions.Logging.ILogger<Db>>();
+            var dataSourceProviderMock = new Mock<IDataSourceProvider>();
+
+            var dbMock = new Mock<Db>(
+                dbQueryMock.Object,
+                loggerMock.Object,
+                dataSourceProviderMock.Object
+            ) { CallBase = true };
+
+            dbMock.Setup(d => d.Vulnerability).Returns(CreateDbSetMock(list).Object);
+            dbMock.Setup(d => d.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            var factoryMock = new Mock<IDbContextFactory<Db>>();
+            factoryMock
+                .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dbMock.Object);
+
+            return (factoryMock, dbMock);
+        }
+
+        private static (Mock<IDbContextFactory<Db>> factory, Mock<Db> db) BuildReportFactory(List<ReportModel> list)
+        {
+            var dbQueryMock = new Mock<IDbQuery>();
+            var loggerMock = new Mock<Microsoft.Extensions.Logging.ILogger<Db>>();
+            var dataSourceProviderMock = new Mock<IDataSourceProvider>();
+
+            var dbMock = new Mock<Db>(
+                dbQueryMock.Object,
+                loggerMock.Object,
+                dataSourceProviderMock.Object
+            ) { CallBase = true };
+
+            dbMock.Setup(d => d.Report).Returns(CreateDbSetMock(list).Object);
+            dbMock.Setup(d => d.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            var factoryMock = new Mock<IDbContextFactory<Db>>();
+            factoryMock
+                .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dbMock.Object);
+
+            return (factoryMock, dbMock);
+        }
+
+        // --- VulnerabilityModerationTarget tests ---
+
+        [Fact]
+        public async Task Vulnerability_Get_Returns_MappedInfo_ForExistingId()
+        {
+            var vuln = new VulnerabilityModel
+            {
+                Id = 1,
+                Title = "Reentrancy Bug",
+                Description = "Detailed description here",
+                CreatedBy = 42,
+                IsHidden = false,
+                IsDeleted = false
+            };
+            var (factory, _) = BuildVulnerabilityFactory(new List<VulnerabilityModel> { vuln });
+            var target = new VulnerabilityModerationTarget(factory.Object);
+
+            var info = await target.Get(1);
+
+            info.Should().NotBeNull();
+            info!.Preview.Should().Be("Reentrancy Bug");
+            info.FullContent.Should().Be("Reentrancy Bug\n\nDetailed description here");
+            info.AuthorUserId.Should().Be(42);
+            info.IsHidden.Should().BeFalse();
+            info.IsDeleted.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task Vulnerability_Get_Returns_Null_ForMissingId()
+        {
+            var (factory, _) = BuildVulnerabilityFactory(new List<VulnerabilityModel>());
+            var target = new VulnerabilityModerationTarget(factory.Object);
+
+            var info = await target.Get(999);
+
+            info.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Vulnerability_Get_FullContent_UsesTitle_WhenDescriptionEmpty()
+        {
+            var vuln = new VulnerabilityModel { Id = 2, Title = "Title Only", Description = "", CreatedBy = 1 };
+            var (factory, _) = BuildVulnerabilityFactory(new List<VulnerabilityModel> { vuln });
+            var target = new VulnerabilityModerationTarget(factory.Object);
+
+            var info = await target.Get(2);
+
+            info!.FullContent.Should().Be("Title Only");
+        }
+
+        [Fact]
+        public async Task Vulnerability_Hide_Sets_IsHidden_True_And_SaveChanges()
+        {
+            var vuln = new VulnerabilityModel { Id = 1, Title = "T", CreatedBy = 1, IsHidden = false };
+            var list = new List<VulnerabilityModel> { vuln };
+            var (factory, dbMock) = BuildVulnerabilityFactory(list);
+            var target = new VulnerabilityModerationTarget(factory.Object);
+
+            await target.Hide(1);
+
+            vuln.IsHidden.Should().BeTrue();
+            dbMock.Verify(d => d.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Vulnerability_SoftDelete_Sets_IsDeleted_True_And_SaveChanges()
+        {
+            var vuln = new VulnerabilityModel { Id = 1, Title = "T", CreatedBy = 1, IsDeleted = false };
+            var list = new List<VulnerabilityModel> { vuln };
+            var (factory, dbMock) = BuildVulnerabilityFactory(list);
+            var target = new VulnerabilityModerationTarget(factory.Object);
+
+            await target.SoftDelete(1);
+
+            vuln.IsDeleted.Should().BeTrue();
+            dbMock.Verify(d => d.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Vulnerability_Restore_Clears_BothHiddenAndDeleted()
+        {
+            // An item that is both hidden AND soft-deleted: Restore (the "approve" action)
+            // must fully un-suppress it — both flags become false.
+            var vuln = new VulnerabilityModel { Id = 1, Title = "T", CreatedBy = 1, IsHidden = true, IsDeleted = true };
+            var list = new List<VulnerabilityModel> { vuln };
+            var (factory, _) = BuildVulnerabilityFactory(list);
+            var target = new VulnerabilityModerationTarget(factory.Object);
+
+            await target.Restore(1);
+
+            vuln.IsHidden.Should().BeFalse();
+            vuln.IsDeleted.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task Vulnerability_ContentType_Is_Vulnerability()
+        {
+            var (factory, _) = BuildVulnerabilityFactory(new List<VulnerabilityModel>());
+            var target = new VulnerabilityModerationTarget(factory.Object);
+
+            target.ContentType.Should().Be(ModeratedContentType.Vulnerability);
+        }
+
+        // --- ReportModerationTarget tests ---
+
+        [Fact]
+        public async Task Report_Get_Returns_MappedInfo_ForExistingId()
+        {
+            var report = new ReportModel
+            {
+                Id = 10,
+                Name = "Audit Report 2025",
+                CreatedBy = 7,
+                IsHidden = false,
+                IsDeleted = false
+            };
+            var (factory, _) = BuildReportFactory(new List<ReportModel> { report });
+            var target = new ReportModerationTarget(factory.Object);
+
+            var info = await target.Get(10);
+
+            info.Should().NotBeNull();
+            info!.Preview.Should().Be("Audit Report 2025");
+            info.FullContent.Should().Be("Audit Report 2025");
+            info.AuthorUserId.Should().Be(7);
+        }
+
+        [Fact]
+        public async Task Report_Get_Returns_Null_ForMissingId()
+        {
+            var (factory, _) = BuildReportFactory(new List<ReportModel>());
+            var target = new ReportModerationTarget(factory.Object);
+
+            var info = await target.Get(999);
+
+            info.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task Report_ContentType_Is_Report()
+        {
+            var (factory, _) = BuildReportFactory(new List<ReportModel>());
+            var target = new ReportModerationTarget(factory.Object);
+
+            target.ContentType.Should().Be(ModeratedContentType.Report);
+        }
+
+        // --- ModerationTargetRegistry tests ---
+
+        [Fact]
+        public void Registry_Resolves_TargetsByContentType()
+        {
+            // No DB call happens during construction or lookup, so a bare factory mock is fine.
+            var factory = new Mock<IDbContextFactory<Db>>().Object;
+            var registry = new ModerationTargetRegistry(new IModerationTarget[]
+            {
+                new VulnerabilityModerationTarget(factory),
+                new ReportModerationTarget(factory)
+            });
+
+            registry.Get(ModeratedContentType.Vulnerability).ContentType.Should().Be(ModeratedContentType.Vulnerability);
+            registry.Get(ModeratedContentType.Report).ContentType.Should().Be(ModeratedContentType.Report);
+
+            registry.TryGet(ModeratedContentType.Report, out var t).Should().BeTrue();
+            t.ContentType.Should().Be(ModeratedContentType.Report);
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi.Tests/Services/PublicVisibilityTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Services/PublicVisibilityTests.cs
@@ -1,0 +1,334 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Common.Data;
+using SorobanSecurityPortalApi.Data.Processors;
+using SorobanSecurityPortalApi.Models.DbModels;
+using Xunit;
+
+namespace SorobanSecurityPortalApi.Tests.Services
+{
+    /// <summary>
+    /// Phase 5: Verifies that hidden and soft-deleted content is excluded from public processor queries.
+    /// Tests call VulnerabilityProcessor.Search(null) and ReportProcessor.GetList(false) which
+    /// are the entry points for public listing and both use the updated Approved+!IsHidden+!IsDeleted filter.
+    /// </summary>
+    public class PublicVisibilityTests
+    {
+        // ---- Helpers ----
+
+        private static Mock<DbSet<T>> CreateDbSetMock<T>(List<T> sourceList) where T : class
+        {
+            var queryable = sourceList.AsQueryable();
+            var dbSetMock = new Mock<DbSet<T>>();
+
+            dbSetMock.As<IQueryable<T>>().Setup(m => m.Provider)
+                .Returns(new TestAsyncQueryProvider<T>(queryable.Provider));
+            dbSetMock.As<IQueryable<T>>().Setup(m => m.Expression).Returns(queryable.Expression);
+            dbSetMock.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(queryable.ElementType);
+            dbSetMock.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(queryable.GetEnumerator());
+            dbSetMock.As<IAsyncEnumerable<T>>()
+                .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+                .Returns(new TestAsyncEnumerator<T>(queryable.GetEnumerator()));
+
+            dbSetMock.Setup(d => d.Add(It.IsAny<T>())).Callback<T>(sourceList.Add);
+            dbSetMock.Setup(d => d.AddRange(It.IsAny<IEnumerable<T>>()))
+                .Callback<IEnumerable<T>>(sourceList.AddRange);
+
+            return dbSetMock;
+        }
+
+        private static (VulnerabilityProcessor processor, Mock<IDbContextFactory<Db>> factory)
+            BuildVulnerabilityProcessor(List<VulnerabilityModel> list)
+        {
+            var dbQueryMock = new Mock<IDbQuery>();
+            var loggerMock = new Mock<ILogger<Db>>();
+            var dataSourceProviderMock = new Mock<IDataSourceProvider>();
+
+            var dbMock = new Mock<Db>(
+                dbQueryMock.Object,
+                loggerMock.Object,
+                dataSourceProviderMock.Object
+            ) { CallBase = true };
+
+            dbMock.Setup(d => d.Vulnerability).Returns(CreateDbSetMock(list).Object);
+            dbMock.Setup(d => d.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            var factoryMock = new Mock<IDbContextFactory<Db>>();
+            factoryMock
+                .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dbMock.Object);
+
+            // ExtendedConfig is never accessed by Search(null) — the search-text / embedding
+            // branch is skipped when s == null, so passing null! is safe here.
+            var processor = new VulnerabilityProcessor(factoryMock.Object, null!);
+            return (processor, factoryMock);
+        }
+
+        private static (ReportProcessor processor, Mock<IDbContextFactory<Db>> factory)
+            BuildReportProcessor(List<ReportModel> list)
+        {
+            var dbQueryMock = new Mock<IDbQuery>();
+            var loggerMock = new Mock<ILogger<Db>>();
+            var dataSourceProviderMock = new Mock<IDataSourceProvider>();
+
+            var dbMock = new Mock<Db>(
+                dbQueryMock.Object,
+                loggerMock.Object,
+                dataSourceProviderMock.Object
+            ) { CallBase = true };
+
+            dbMock.Setup(d => d.Report).Returns(CreateDbSetMock(list).Object);
+            dbMock.Setup(d => d.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            var factoryMock = new Mock<IDbContextFactory<Db>>();
+            factoryMock
+                .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dbMock.Object);
+
+            // ExtendedConfig is never accessed by GetList — no search-text path; null! is safe.
+            var processor = new ReportProcessor(factoryMock.Object, null!);
+            return (processor, factoryMock);
+        }
+
+        // ---- Vulnerability tests ----
+
+        [Fact]
+        public async Task VulnerabilitySearch_ExcludesHiddenContent()
+        {
+            var visible = new VulnerabilityModel
+            {
+                Id = 1,
+                Status = VulnerabilityModelStatus.Approved,
+                Category = VulnerabilityCategory.Valid,
+                IsHidden = false,
+                IsDeleted = false,
+                Title = "Visible"
+            };
+            var hidden = new VulnerabilityModel
+            {
+                Id = 2,
+                Status = VulnerabilityModelStatus.Approved,
+                Category = VulnerabilityCategory.Valid,
+                IsHidden = true,
+                IsDeleted = false,
+                Title = "Hidden"
+            };
+
+            var (processor, _) = BuildVulnerabilityProcessor(new List<VulnerabilityModel> { visible, hidden });
+
+            var result = await processor.Search(null);
+
+            result.Should().HaveCount(1);
+            result[0].Id.Should().Be(1);
+            result[0].Title.Should().Be("Visible");
+        }
+
+        [Fact]
+        public async Task VulnerabilitySearch_ExcludesDeletedContent()
+        {
+            var visible = new VulnerabilityModel
+            {
+                Id = 1,
+                Status = VulnerabilityModelStatus.Approved,
+                Category = VulnerabilityCategory.Valid,
+                IsHidden = false,
+                IsDeleted = false,
+                Title = "Visible"
+            };
+            var deleted = new VulnerabilityModel
+            {
+                Id = 3,
+                Status = VulnerabilityModelStatus.Approved,
+                Category = VulnerabilityCategory.Valid,
+                IsHidden = false,
+                IsDeleted = true,
+                Title = "Deleted"
+            };
+
+            var (processor, _) = BuildVulnerabilityProcessor(new List<VulnerabilityModel> { visible, deleted });
+
+            var result = await processor.Search(null);
+
+            result.Should().HaveCount(1);
+            result[0].Id.Should().Be(1);
+            result[0].Title.Should().Be("Visible");
+        }
+
+        [Fact]
+        public async Task VulnerabilitySearch_ReturnsOnlyApprovedVisibleContent()
+        {
+            // Hidden+Deleted both excluded; unapproved excluded; only the clean visible one comes through.
+            var list = new List<VulnerabilityModel>
+            {
+                new() { Id = 1, Status = VulnerabilityModelStatus.Approved, Category = VulnerabilityCategory.Valid, IsHidden = false, IsDeleted = false, Title = "OK" },
+                new() { Id = 2, Status = VulnerabilityModelStatus.Approved, Category = VulnerabilityCategory.Valid, IsHidden = true,  IsDeleted = false, Title = "Hidden" },
+                new() { Id = 3, Status = VulnerabilityModelStatus.Approved, Category = VulnerabilityCategory.Valid, IsHidden = false, IsDeleted = true,  Title = "Deleted" },
+                new() { Id = 4, Status = VulnerabilityModelStatus.New,      Category = VulnerabilityCategory.Valid, IsHidden = false, IsDeleted = false, Title = "Unapproved" },
+            };
+
+            var (processor, _) = BuildVulnerabilityProcessor(list);
+
+            var result = await processor.Search(null);
+
+            result.Should().HaveCount(1);
+            result[0].Id.Should().Be(1);
+        }
+
+        // ---- Report tests ----
+
+        [Fact]
+        public async Task ReportGetList_ExcludesHiddenContent()
+        {
+            var visible = new ReportModel
+            {
+                Id = 10,
+                Status = ReportModelStatus.Approved,
+                IsHidden = false,
+                IsDeleted = false,
+                Name = "Visible Report"
+            };
+            var hidden = new ReportModel
+            {
+                Id = 20,
+                Status = ReportModelStatus.Approved,
+                IsHidden = true,
+                IsDeleted = false,
+                Name = "Hidden Report"
+            };
+
+            var (processor, _) = BuildReportProcessor(new List<ReportModel> { visible, hidden });
+
+            var result = await processor.GetList(includeNotApproved: false);
+
+            result.Should().HaveCount(1);
+            result[0].Id.Should().Be(10);
+            result[0].Name.Should().Be("Visible Report");
+        }
+
+        [Fact]
+        public async Task ReportGetList_ExcludesDeletedContent()
+        {
+            var visible = new ReportModel
+            {
+                Id = 10,
+                Status = ReportModelStatus.Approved,
+                IsHidden = false,
+                IsDeleted = false,
+                Name = "Visible Report"
+            };
+            var deleted = new ReportModel
+            {
+                Id = 30,
+                Status = ReportModelStatus.Approved,
+                IsHidden = false,
+                IsDeleted = true,
+                Name = "Deleted Report"
+            };
+
+            var (processor, _) = BuildReportProcessor(new List<ReportModel> { visible, deleted });
+
+            var result = await processor.GetList(includeNotApproved: false);
+
+            result.Should().HaveCount(1);
+            result[0].Id.Should().Be(10);
+        }
+
+        [Fact]
+        public async Task ReportGetList_IncludeNotApproved_ReturnsAllIncludingHidden()
+        {
+            // Admin path: includeNotApproved: true must NOT apply the visibility filter —
+            // this verifies we only touched the public branch.
+            var list = new List<ReportModel>
+            {
+                new() { Id = 10, Status = ReportModelStatus.Approved,  IsHidden = false, IsDeleted = false, Name = "Approved" },
+                new() { Id = 20, Status = ReportModelStatus.Approved,  IsHidden = true,  IsDeleted = false, Name = "Hidden Approved" },
+                new() { Id = 30, Status = ReportModelStatus.New,       IsHidden = false, IsDeleted = false, Name = "New" },
+            };
+
+            var (processor, _) = BuildReportProcessor(list);
+
+            var result = await processor.GetList(includeNotApproved: true);
+
+            result.Should().HaveCount(3, "admin path returns all records regardless of hidden/deleted/status");
+        }
+
+        // ---- GetPublic (direct-URL detail path) tests ----
+
+        [Fact]
+        public async Task VulnerabilityGetPublic_ReturnsEntity_WhenVisible()
+        {
+            var vuln = new VulnerabilityModel { Id = 1, IsHidden = false, IsDeleted = false, Title = "Visible" };
+            var (processor, _) = BuildVulnerabilityProcessor(new List<VulnerabilityModel> { vuln });
+
+            var result = await processor.GetPublic(1);
+
+            result.Should().NotBeNull();
+            result!.Id.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task VulnerabilityGetPublic_ReturnsNull_WhenHidden()
+        {
+            var vuln = new VulnerabilityModel { Id = 1, IsHidden = true, IsDeleted = false, Title = "Hidden" };
+            var (processor, _) = BuildVulnerabilityProcessor(new List<VulnerabilityModel> { vuln });
+
+            var result = await processor.GetPublic(1);
+
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task VulnerabilityGetPublic_ReturnsNull_WhenDeleted()
+        {
+            var vuln = new VulnerabilityModel { Id = 1, IsHidden = false, IsDeleted = true, Title = "Deleted" };
+            var (processor, _) = BuildVulnerabilityProcessor(new List<VulnerabilityModel> { vuln });
+
+            var result = await processor.GetPublic(1);
+
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ReportGetPublic_ReturnsEntity_WhenVisible()
+        {
+            var report = new ReportModel { Id = 10, IsHidden = false, IsDeleted = false, Name = "Visible" };
+            var (processor, _) = BuildReportProcessor(new List<ReportModel> { report });
+
+            var result = await processor.GetPublic(10);
+
+            result.Should().NotBeNull();
+            result!.Id.Should().Be(10);
+        }
+
+        [Fact]
+        public async Task ReportGetPublic_ReturnsNull_WhenHidden()
+        {
+            var report = new ReportModel { Id = 10, IsHidden = true, IsDeleted = false, Name = "Hidden" };
+            var (processor, _) = BuildReportProcessor(new List<ReportModel> { report });
+
+            var result = await processor.GetPublic(10);
+
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task ReportGetPublic_ReturnsNull_WhenDeleted()
+        {
+            var report = new ReportModel { Id = 10, IsHidden = false, IsDeleted = true, Name = "Deleted" };
+            var (processor, _) = BuildReportProcessor(new List<ReportModel> { report });
+
+            var result = await processor.GetPublic(10);
+
+            result.Should().BeNull();
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi.Tests/Services/RatingServiceTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Services/RatingServiceTests.cs
@@ -178,16 +178,77 @@ namespace SorobanSecurityPortalApi.Tests.Services
         {
             for (int i = 1; i <= 15; i++)
             {
-                _dataStore.Add(new RatingModel 
-                { 
+                _dataStore.Add(new RatingModel
+                {
                     Id = i, UserId = i, EntityId = 50, EntityType = EntityType.Protocol, Score = 5,
                     CreatedAt = DateTime.UtcNow.AddMinutes(i)
                 });
             }
 
             var result = await _service.GetRatings(EntityType.Protocol, 50, page: 2, pageSize: 10);
-            result.Should().HaveCount(5); 
+            result.Should().HaveCount(5);
             result.First().Id.Should().Be(5);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        [InlineData(-100)]
+        public async Task GetRatings_Should_ClampPageToOne_WhenPageIsZeroOrNegative(int badPage)
+        {
+            for (int i = 1; i <= 5; i++)
+            {
+                _dataStore.Add(new RatingModel
+                {
+                    Id = i, UserId = i, EntityId = 77, EntityType = EntityType.Protocol, Score = 3,
+                    CreatedAt = DateTime.UtcNow.AddMinutes(i)
+                });
+            }
+
+            // Should not throw and should return the same result as page=1
+            var result = await _service.GetRatings(EntityType.Protocol, 77, page: badPage, pageSize: 10);
+            var resultPage1 = await _service.GetRatings(EntityType.Protocol, 77, page: 1, pageSize: 10);
+
+            result.Should().HaveCount(5);
+            result.Should().BeEquivalentTo(resultPage1);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-5)]
+        public async Task GetRatings_Should_ClampPageSize_WhenZeroOrNegative(int badPageSize)
+        {
+            for (int i = 1; i <= 5; i++)
+            {
+                _dataStore.Add(new RatingModel
+                {
+                    Id = i, UserId = i, EntityId = 88, EntityType = EntityType.Protocol, Score = 3,
+                    CreatedAt = DateTime.UtcNow.AddMinutes(i)
+                });
+            }
+
+            // Should not throw; clamped pageSize (>=1) returns at least one item
+            var result = await _service.GetRatings(EntityType.Protocol, 88, page: 1, pageSize: badPageSize);
+
+            result.Should().NotBeEmpty();
+            result.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public async Task GetRatings_Should_NotIncludeUserId_InPublicList()
+        {
+            _dataStore.Add(new RatingModel
+            {
+                Id = 1, UserId = 42, EntityId = 10, EntityType = EntityType.Protocol, Score = 4,
+                Review = "Great", CreatedAt = DateTime.UtcNow
+            });
+
+            var result = await _service.GetRatings(EntityType.Protocol, 10, page: 1, pageSize: 10);
+
+            result.Should().HaveCount(1);
+            // PublicRatingViewModel has no UserId property — verified by type
+            result[0].Should().BeOfType<PublicRatingViewModel>();
+            result[0].Score.Should().Be(4);
         }
 
         // --- HELPERS ---

--- a/Backend/SorobanSecurityPortalApi.Tests/Services/UserProfileServiceTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Services/UserProfileServiceTests.cs
@@ -1,0 +1,177 @@
+using AutoMapper;
+using Microsoft.Extensions.Logging.Abstractions;
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Models.DbModels;
+using SorobanSecurityPortalApi.Models.Mapping;
+using SorobanSecurityPortalApi.Models.ViewModels;
+
+namespace SorobanSecurityPortalApi.Tests.Services;
+
+/// <summary>
+/// Regression tests locking in the fix for #125: public profile endpoint must not leak PII.
+/// </summary>
+public class UserProfileServiceTests
+{
+    private readonly IMapper _mapper;
+
+    public UserProfileServiceTests()
+    {
+        var config = new MapperConfiguration(
+            mc => mc.AddProfile(new UserProfileModelProfile()),
+            NullLoggerFactory.Instance);
+        _mapper = config.CreateMapper();
+    }
+
+    // --- DTO shape: no PII fields allowed on the public view model ---
+
+    [Fact]
+    public void PublicUserProfileViewModel_DoesNotExposeEmail()
+    {
+        typeof(PublicUserProfileViewModel)
+            .GetProperty("Email")
+            .Should().BeNull("PublicUserProfileViewModel must not expose Email");
+    }
+
+    [Fact]
+    public void PublicUserProfileViewModel_DoesNotExposeFullName()
+    {
+        typeof(PublicUserProfileViewModel)
+            .GetProperty("FullName")
+            .Should().BeNull("PublicUserProfileViewModel must not expose FullName");
+    }
+
+    [Fact]
+    public void PublicUserProfileViewModel_DoesNotExposeConnectedAccounts()
+    {
+        typeof(PublicUserProfileViewModel)
+            .GetProperty("ConnectedAccounts")
+            .Should().BeNull("PublicUserProfileViewModel must not expose ConnectedAccounts");
+    }
+
+    // --- Mapping: LoginId round-trips; safe fields map correctly; PII is absent ---
+
+    [Fact]
+    public void Mapping_UserProfileModel_To_PublicViewModel_MapsLoginId()
+    {
+        var model = BuildUserProfileModel(loginId: 42);
+
+        var vm = _mapper.Map<PublicUserProfileViewModel>(model);
+
+        vm.LoginId.Should().Be(42);
+    }
+
+    [Fact]
+    public void Mapping_UserProfileModel_To_PublicViewModel_MapsSafeFields()
+    {
+        var model = BuildUserProfileModel(loginId: 7,
+            bio: "security researcher",
+            location: "Berlin",
+            website: "https://example.com",
+            expertiseTags: new List<string> { "DeFi", "Soroban" },
+            reputationScore: 100);
+
+        var vm = _mapper.Map<PublicUserProfileViewModel>(model);
+
+        vm.Bio.Should().Be("security researcher");
+        vm.Location.Should().Be("Berlin");
+        vm.Website.Should().Be("https://example.com");
+        vm.ExpertiseTags.Should().BeEquivalentTo(new[] { "DeFi", "Soroban" });
+        vm.ReputationScore.Should().Be(100);
+    }
+
+    [Fact]
+    public void Mapping_UserProfileModel_WithPIIOnLogin_DoesNotLeakPIIIntoPublicViewModel()
+    {
+        // The Login navigation holds Email/FullName/ConnectedAccounts — none should
+        // appear on the mapped PublicUserProfileViewModel, even when populated.
+        var model = BuildUserProfileModel(loginId: 5);
+        model.Login = new LoginModel
+        {
+            LoginId = 5,
+            Email = "secret@example.com",
+            FullName = "Alice Smith",
+            ConnectedAccounts = new List<ConnectedAccountModel>
+            {
+                new() { ServiceName = "Google", AccountId = "g-12345" }
+            }
+        };
+
+        var vm = _mapper.Map<PublicUserProfileViewModel>(model);
+
+        // Verify via reflection: there is genuinely no pathway to the PII.
+        var vmType = vm.GetType();
+        vmType.GetProperty("Email").Should().BeNull();
+        vmType.GetProperty("FullName").Should().BeNull();
+        vmType.GetProperty("ConnectedAccounts").Should().BeNull();
+
+        // And LoginId still round-trips correctly.
+        vm.LoginId.Should().Be(5);
+    }
+
+    // --- Validation ordering: length error reported before scheme error for an oversized website ---
+
+    [Fact]
+    public async Task ValidateProfileDto_ReportsLengthError_BeforeSchemeError_ForOversizedWebsite()
+    {
+        // A value > 200 chars that is also not a valid http/https URL (e.g. just "x" * 201).
+        // After the fix the length check fires first, so we get the length error.
+        var oversized = new string('x', 201);
+        var dto = new UpdateUserProfileViewModel { Website = oversized };
+
+        var service = BuildService();
+        // Invoke via the public surface: use CreateProfileAsync which calls ValidateProfileDto.
+        // Since processor.ExistsAsync would be called only after validation, we only need the
+        // validation result, which is surfaced as an Err result before any DB access.
+        var result = await service.CreateProfileAsync(99, dto);
+
+        result.Should().BeOfType<Result<UserProfileViewModel, string>.Err>();
+        var err = (Result<UserProfileViewModel, string>.Err)result;
+        err.Error.Should().Contain("200", because: "length error is reported before scheme error");
+    }
+
+    [Fact]
+    public async Task ValidateProfileDto_ReportsSchemeError_WhenLengthIsAcceptableButSchemeIsWrong()
+    {
+        var dto = new UpdateUserProfileViewModel { Website = "ftp://example.com" };
+
+        var service = BuildService();
+        var result = await service.CreateProfileAsync(99, dto);
+
+        result.Should().BeOfType<Result<UserProfileViewModel, string>.Err>();
+        var err = (Result<UserProfileViewModel, string>.Err)result;
+        err.Error.Should().Contain("http", because: "scheme error is reported for a short but invalid URL");
+    }
+
+    // --- Helpers ---
+
+    private static UserProfileModel BuildUserProfileModel(
+        int loginId = 1,
+        string? bio = null,
+        string? location = null,
+        string? website = null,
+        List<string>? expertiseTags = null,
+        int reputationScore = 0)
+    {
+        return new UserProfileModel
+        {
+            Id = 100,
+            LoginId = loginId,
+            Login = new LoginModel { LoginId = loginId },
+            Bio = bio,
+            Location = location,
+            Website = website,
+            ExpertiseTags = expertiseTags ?? new List<string>(),
+            ReputationScore = reputationScore,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+
+    private SorobanSecurityPortalApi.Services.ControllersServices.UserProfileService BuildService()
+    {
+        var processorMock = new Moq.Mock<SorobanSecurityPortalApi.Data.Processors.IUserProfileProcessor>();
+        // ExistsAsync is never reached when validation fails — no setup needed.
+        return new SorobanSecurityPortalApi.Services.ControllersServices.UserProfileService(
+            processorMock.Object, _mapper);
+    }
+}

--- a/Backend/SorobanSecurityPortalApi.Tests/Services/VulnerabilityServiceAddTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Services/VulnerabilityServiceAddTests.cs
@@ -1,0 +1,194 @@
+using System.Security.Claims;
+using AutoMapper;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Data.Processors;
+using SorobanSecurityPortalApi.Models.DbModels;
+using SorobanSecurityPortalApi.Models.Mapping;
+using SorobanSecurityPortalApi.Models.ViewModels;
+using SorobanSecurityPortalApi.Services.ControllersServices;
+
+namespace SorobanSecurityPortalApi.Tests.Services;
+
+/// <summary>
+/// Wiring tests for #115 C-1: ContentFilterService is invoked from the vulnerability submission path.
+/// Locks in: blocked content -> Err; clean non-empty -> Ok with ORIGINAL markdown persisted (I-2);
+/// empty Description -> still succeeds (I-3).
+/// </summary>
+public class VulnerabilityServiceAddTests
+{
+    private const int TestLoginId = 7;
+
+    private readonly IMapper _mapper;
+    private readonly Mock<IVulnerabilityProcessor> _vulnerabilityProcessorMock = new();
+    private readonly Mock<IReportProcessor> _reportProcessorMock = new();
+    private readonly Mock<IFileProcessor> _fileProcessorMock = new();
+    private readonly Mock<IGeminiEmbeddingService> _embeddingServiceMock = new();
+    private readonly Mock<ILoginProcessor> _loginProcessorMock = new();
+    private readonly Mock<IContentFilterService> _contentFilterMock = new();
+
+    public VulnerabilityServiceAddTests()
+    {
+        var config = new MapperConfiguration(
+            mc => mc.AddProfile(new VulnerabilityModelProfile()),
+            NullLoggerFactory.Instance);
+        _mapper = config.CreateMapper();
+
+        // Login resolution: claims principal -> ILoginProcessor returns our test login id.
+        _loginProcessorMock
+            .Setup(x => x.GetByLogin(It.IsAny<string>(), It.IsAny<LoginTypeEnum>()))
+            .ReturnsAsync(new LoginModel { LoginId = TestLoginId, Login = "tester" });
+
+        // Embedding generation is irrelevant to Add (Add does not call it), but stub defensively.
+        _embeddingServiceMock
+            .Setup(x => x.GenerateEmbeddingForDocumentAsync(It.IsAny<string>()))
+            .ReturnsAsync(new float[] { 0f });
+    }
+
+    [Fact]
+    public async Task Add_BlockedContent_ReturnsErr_AndDoesNotPersist()
+    {
+        _contentFilterMock.Setup(x => x.CheckRateLimitAsync(TestLoginId)).ReturnsAsync(true);
+        _contentFilterMock
+            .Setup(x => x.FilterContentAsync(It.IsAny<string>(), TestLoginId))
+            .ReturnsAsync(new ContentFilterResult
+            {
+                IsBlocked = true,
+                Warnings = { "Too many links detected" },
+                SanitizedContent = "<p>ignored html</p>"
+            });
+
+        var service = CreateService();
+        var vm = new VulnerabilityViewModel { Title = "t", Description = "spammy content with links" };
+
+        var result = await service.Add(vm, new List<FileViewModel>());
+
+        result.Should().BeOfType<Result<VulnerabilityViewModel, string>.Err>();
+        ((Result<VulnerabilityViewModel, string>.Err)result).Error.Should().Contain("Too many links");
+        _vulnerabilityProcessorMock.Verify(x => x.Add(It.IsAny<VulnerabilityModel>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Add_RateLimited_ReturnsErr_AndDoesNotPersist()
+    {
+        _contentFilterMock.Setup(x => x.CheckRateLimitAsync(TestLoginId)).ReturnsAsync(false);
+
+        var service = CreateService();
+        var vm = new VulnerabilityViewModel { Title = "t", Description = "anything" };
+
+        var result = await service.Add(vm, new List<FileViewModel>());
+
+        result.Should().BeOfType<Result<VulnerabilityViewModel, string>.Err>();
+        ((Result<VulnerabilityViewModel, string>.Err)result).Error.Should().Contain("Rate limit");
+        _vulnerabilityProcessorMock.Verify(x => x.Add(It.IsAny<VulnerabilityModel>()), Times.Never);
+        // Filter must not run when rate-limited.
+        _contentFilterMock.Verify(x => x.FilterContentAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Add_CleanContent_ReturnsOk_AndPersistsOriginalMarkdown()
+    {
+        const string originalMarkdown = "Found a bug in **transfer**. See `auth.rs` line 10.";
+
+        _contentFilterMock.Setup(x => x.CheckRateLimitAsync(TestLoginId)).ReturnsAsync(true);
+        _contentFilterMock
+            .Setup(x => x.FilterContentAsync(originalMarkdown, TestLoginId))
+            .ReturnsAsync(new ContentFilterResult
+            {
+                IsBlocked = false,
+                RequiresModeration = false,
+                // Filter returns HTML, which MUST NOT end up persisted (I-2).
+                SanitizedContent = "<p>Found a bug in <strong>transfer</strong>. See <code>auth.rs</code> line 10.</p>"
+            });
+
+        VulnerabilityModel? persisted = null;
+        _vulnerabilityProcessorMock
+            .Setup(x => x.Add(It.IsAny<VulnerabilityModel>()))
+            .Callback<VulnerabilityModel>(m => persisted = m)
+            .ReturnsAsync(BuildPersistedModel());
+
+        var service = CreateService();
+        var vm = new VulnerabilityViewModel { Title = "t", Description = originalMarkdown };
+
+        var result = await service.Add(vm, new List<FileViewModel>());
+
+        result.Should().BeOfType<Result<VulnerabilityViewModel, string>.Ok>();
+        persisted.Should().NotBeNull();
+        persisted!.Description.Should().Be(originalMarkdown, "Description is markdown and must round-trip unchanged");
+        persisted.Description.Should().NotContain("<p>", "sanitized HTML must not overwrite the markdown");
+        persisted.CreatedBy.Should().Be(TestLoginId);
+    }
+
+    [Fact]
+    public async Task Add_EmptyDescription_StillSucceeds_AndSkipsFilter()
+    {
+        _contentFilterMock.Setup(x => x.CheckRateLimitAsync(TestLoginId)).ReturnsAsync(true);
+
+        VulnerabilityModel? persisted = null;
+        _vulnerabilityProcessorMock
+            .Setup(x => x.Add(It.IsAny<VulnerabilityModel>()))
+            .Callback<VulnerabilityModel>(m => persisted = m)
+            .ReturnsAsync(BuildPersistedModel());
+
+        var service = CreateService();
+        var vm = new VulnerabilityViewModel { Title = "t", Description = "" };
+
+        var result = await service.Add(vm, new List<FileViewModel>());
+
+        result.Should().BeOfType<Result<VulnerabilityViewModel, string>.Ok>();
+        persisted.Should().NotBeNull();
+        persisted!.Description.Should().Be("");
+        // Empty content must never reach the filter (which would block it).
+        _contentFilterMock.Verify(x => x.FilterContentAsync(It.IsAny<string>(), It.IsAny<int>()), Times.Never);
+        // Rate-limit still runs for empty submissions.
+        _contentFilterMock.Verify(x => x.CheckRateLimitAsync(TestLoginId), Times.Once);
+    }
+
+    private VulnerabilityService CreateService()
+    {
+        return new VulnerabilityService(
+            _mapper,
+            _vulnerabilityProcessorMock.Object,
+            _reportProcessorMock.Object,
+            _fileProcessorMock.Object,
+            _embeddingServiceMock.Object,
+            BuildUserContextAccessor(),
+            _contentFilterMock.Object);
+    }
+
+    private UserContextAccessor BuildUserContextAccessor()
+    {
+        var identity = new ClaimsIdentity(new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, "tester")
+        }, authenticationType: "Test");
+        var httpContext = new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+        var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+        httpContextAccessorMock.Setup(x => x.HttpContext).Returns(httpContext);
+        return new UserContextAccessor(httpContextAccessorMock.Object, _loginProcessorMock.Object);
+    }
+
+    // Reverse mapping (VulnerabilityModel -> VulnerabilityViewModel) dereferences the Report graph,
+    // so the persisted model returned by the processor must carry a populated graph.
+    private static VulnerabilityModel BuildPersistedModel()
+    {
+        return new VulnerabilityModel
+        {
+            Id = 99,
+            Description = "persisted",
+            Report = new ReportModel
+            {
+                Id = 1,
+                Name = "Report 1",
+                Auditor = new AuditorModel { Id = 1, Name = "Auditor 1" },
+                Protocol = new ProtocolModel
+                {
+                    Id = 1,
+                    Name = "Protocol 1",
+                    Company = new CompanyModel { Id = 1, Name = "Company 1" }
+                }
+            }
+        };
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Common/Data/Db.cs
+++ b/Backend/SorobanSecurityPortalApi/Common/Data/Db.cs
@@ -98,6 +98,21 @@ namespace SorobanSecurityPortalApi.Common.Data
 
             builder.Entity<ForumPostModel>()
                 .HasIndex(p => new { p.ThreadId, p.CreatedAt });
+
+            // #134-L3: deleting a user (login) must NOT cascade-delete their forum
+            // threads/posts (would wipe whole discussions). Use Restrict for author FKs.
+            builder.Entity<ForumThreadModel>()
+                .HasOne(t => t.Author)
+                .WithMany()
+                .HasForeignKey(t => t.AuthorId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder.Entity<ForumPostModel>()
+                .HasOne(p => p.Author)
+                .WithMany()
+                .HasForeignKey(p => p.AuthorId)
+                .OnDelete(DeleteBehavior.Restrict);
+
             var seedDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
             builder.Entity<ForumCategoryModel>().HasData(
@@ -135,7 +150,7 @@ namespace SorobanSecurityPortalApi.Common.Data
                     Slug = "vulnerability-discussions", 
                     Description = "Deep dives into specific vulnerabilities.", 
                     SortOrder = 4, 
-                    CreatedAt = seedDate 
+                    CreatedAt = seedDate
                 }
             );
 

--- a/Backend/SorobanSecurityPortalApi/Common/Data/Db.cs
+++ b/Backend/SorobanSecurityPortalApi/Common/Data/Db.cs
@@ -28,6 +28,8 @@ namespace SorobanSecurityPortalApi.Common.Data
 
 
         public virtual DbSet<RatingModel> Rating { get; set; }
+        public DbSet<ContentFlagModel> ContentFlag { get; set; }
+        public DbSet<ModerationActionModel> ModerationAction { get; set; }
         private readonly IDbQuery _dbQuery;
         private readonly ILogger<Db> _logger;
         private readonly IDataSourceProvider _dataSourceProvider;
@@ -160,6 +162,16 @@ namespace SorobanSecurityPortalApi.Common.Data
 
             builder.Entity<RatingModel>()
                 .HasIndex(r => new { r.EntityType, r.EntityId });
+
+            builder.Entity<ContentFlagModel>()
+                .HasIndex(f => new { f.ContentType, f.ContentId, f.FlaggedByUserId })
+                .IsUnique();
+            builder.Entity<ContentFlagModel>()
+                .HasIndex(f => new { f.ContentType, f.ContentId });
+            builder.Entity<ModerationActionModel>()
+                .HasIndex(a => new { a.ContentType, a.ContentId, a.CreatedAt });
+            builder.Entity<ModerationActionModel>()
+                .HasIndex(a => a.CreatedAt);
 
             builder.HasDbFunction(typeof(TrigramExtensions).GetMethod(nameof(TrigramExtensions.TrigramSimilarity))!)
                 .HasName("similarity"); // PostgreSQL built-in function

--- a/Backend/SorobanSecurityPortalApi/Common/Data/Db.cs
+++ b/Backend/SorobanSecurityPortalApi/Common/Data/Db.cs
@@ -11,8 +11,8 @@ namespace SorobanSecurityPortalApi.Common.Data
         public DbSet<LoginModel> Login { get; set; }
         public DbSet<LoginHistoryModel> LoginHistory { get; set; }
         public DbSet<ClientSsoModel> ClientSso { get; set; }
-        public DbSet<VulnerabilityModel> Vulnerability { get; set; }
-        public DbSet<ReportModel> Report { get; set; }
+        public virtual DbSet<VulnerabilityModel> Vulnerability { get; set; }
+        public virtual DbSet<ReportModel> Report { get; set; }
         public DbSet<SubscriptionModel> Subscription { get; set; }
         public DbSet<ProtocolModel> Protocol { get; set; }
         public DbSet<AuditorModel> Auditor { get; set; }

--- a/Backend/SorobanSecurityPortalApi/Common/ExtendedConfig.cs
+++ b/Backend/SorobanSecurityPortalApi/Common/ExtendedConfig.cs
@@ -191,43 +191,41 @@ public class ExtendedConfig : IExtendedConfig
     [Tooltip("Enables the profanity filter for user-generated content. When enabled, content containing profane words will be flagged for moderation.")]
     public bool ProfanityFilterEnabled => GetValue<bool>("ProfanityFilterEnabled", false);
 
+    // H-3: stored/displayed as a raw string so the settings UI never serialises a List<T>.
+    // The persisted setting key MUST remain "ProfanityWords" (the key PR #115 introduced and the
+    // settings screen reads/writes); the property is named accordingly so reflection keys it the same.
     [Category(CategoryAttribute.ConfigCategoryEnum.ContentFilter)]
     [DataType(DataTypeAttribute.ConfigDataTypeEnum.Multiline)]
     [Description("Custom Profanity Words (one per line)")]
     [Tooltip("Additional words to filter beyond the default dictionary. Enter one word per line. Words are matched case-insensitively. The system will notify you if a word already exists in the default dictionary.")]
-    public List<string> ProfanityWords
-    {
-        get
-        {
-            var words = GetValue<string>("ProfanityWords", "");
-            return string.IsNullOrWhiteSpace(words)
-                ? new List<string>()
-                : words.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                       .Select(w => w.Trim())
-                       .Where(w => !string.IsNullOrWhiteSpace(w))
-                       .ToList();
-        }
-    }
+    public string ProfanityWords => GetValue<string>("ProfanityWords", "");
+
+    // Parsed list for ContentFilterService — exposed only via IExtendedConfig (explicit impl is
+    // invisible to the settings reflection), so the UI shows/saves the raw string above.
+    List<string> IExtendedConfig.ProfanityWords =>
+        ProfanityWords.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                      .Select(w => w.Trim())
+                      .Where(w => !string.IsNullOrWhiteSpace(w))
+                      .ToList();
 
     [Category(CategoryAttribute.ConfigCategoryEnum.ContentFilter)]
     [DataType(DataTypeAttribute.ConfigDataTypeEnum.Link)]
     [Description("View Default Profanity Dictionary")]
     [Tooltip("Click to view the built-in profanity words that are always active. These words cannot be modified, but you can add custom words above.")]
-    public string DefaultProfanityWordsLink => "/api/settings/default-profanity-words";
+    public string DefaultProfanityWordsLink => "/api/v1/settings/default-profanity-words";
 
+    // H-3: stored/displayed as a raw string; persisted key stays "TrustedDomains".
     [Category(CategoryAttribute.ConfigCategoryEnum.ContentFilter)]
     [Description("Trusted Domains")]
     [Tooltip("Comma-separated list of trusted domains for URLs in content (e.g., github.com,stellar.org). If empty, all HTTPS URLs are allowed but flagged for moderation.")]
-    public List<string> TrustedDomains
-    {
-        get
-        {
-            var domains = GetValue<string>("TrustedDomains", "");
-            return string.IsNullOrWhiteSpace(domains)
-                ? new List<string>()
-                : domains.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(d => d.Trim()).ToList();
-        }
-    }
+    public string TrustedDomains => GetValue<string>("TrustedDomains", "");
+
+    // Parsed list for ContentFilterService — exposed only via IExtendedConfig.
+    List<string> IExtendedConfig.TrustedDomains =>
+        TrustedDomains.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                      .Select(d => d.Trim())
+                      .Where(d => !string.IsNullOrWhiteSpace(d))
+                      .ToList();
 
 }
 

--- a/Backend/SorobanSecurityPortalApi/Controllers/ContentFlagController.cs
+++ b/Backend/SorobanSecurityPortalApi/Controllers/ContentFlagController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Models.ViewModels;
+using SorobanSecurityPortalApi.Services.ControllersServices;
+
+namespace SorobanSecurityPortalApi.Controllers
+{
+    [ApiController]
+    [Route("api/v1/content-flags")]
+    [Authorize]
+    public class ContentFlagController : ControllerBase
+    {
+        private readonly IContentFlagService _service;
+        public ContentFlagController(IContentFlagService service) => _service = service;
+
+        [HttpPost]
+        public async Task<IActionResult> Flag([FromBody] FlagContentRequest request)
+        {
+            var result = await _service.Flag(request);
+            return result switch
+            {
+                Result<bool, string>.Ok => Ok(true),
+                Result<bool, string>.Err e when e.Error == ContentFlagService.ErrContentNotFound => NotFound(e.Error),
+                Result<bool, string>.Err e when e.Error == ContentFlagService.ErrAlreadyFlagged => Conflict(e.Error),
+                Result<bool, string>.Err e => BadRequest(e.Error),
+                _ => throw new InvalidOperationException("Unexpected result")
+            };
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Controllers/ModerationController.cs
+++ b/Backend/SorobanSecurityPortalApi/Controllers/ModerationController.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Mvc;
+using SorobanSecurityPortalApi.Authorization.Attributes;
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Models.ViewModels;
+using SorobanSecurityPortalApi.Services.ControllersServices;
+
+namespace SorobanSecurityPortalApi.Controllers
+{
+    [ApiController]
+    [Route("api/v1/moderation")]
+    public class ModerationController : ControllerBase
+    {
+        private readonly IModerationService _service;
+        public ModerationController(IModerationService service) => _service = service;
+
+        [HttpGet("queue")]
+        [RoleAuthorize(Role.Admin, Role.Moderator)]
+        public async Task<IActionResult> Queue([FromQuery] string? status, [FromQuery] string? contentType, [FromQuery] int page = 1)
+            => Ok(await _service.GetQueue(status, contentType, page));
+
+        [HttpPost("action")]
+        [RoleAuthorize(Role.Admin, Role.Moderator)]
+        public async Task<IActionResult> Action([FromBody] ModerationActionRequest request)
+        {
+            var result = await _service.TakeAction(request);
+            return result switch
+            {
+                Result<bool, string>.Ok => Ok(true),
+                Result<bool, string>.Err e => BadRequest(e.Error),
+                _ => throw new InvalidOperationException("Unexpected result")
+            };
+        }
+
+        [HttpGet("stats")]
+        [RoleAuthorize(Role.Admin, Role.Moderator)]
+        public async Task<IActionResult> Stats() => Ok(await _service.GetStats());
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Controllers/RatingController.cs
+++ b/Backend/SorobanSecurityPortalApi/Controllers/RatingController.cs
@@ -49,7 +49,6 @@ namespace SorobanSecurityPortalApi.Controllers
         [Authorize]
         public async Task<IActionResult> CreateOrUpdate([FromBody] CreateRatingRequest request)
         {
-            
             if (request == null)
             {
                 return BadRequest("Request body cannot be null.");
@@ -59,7 +58,12 @@ namespace SorobanSecurityPortalApi.Controllers
             {
                 return BadRequest("Score must be between 1 and 5.");
             }
-            
+
+            if (request.Review?.Length > 2000)
+            {
+                return BadRequest("Review must not exceed 2000 characters.");
+            }
+
             var result = await _ratingService.AddOrUpdateRating(request);
             return Ok(result);
         }

--- a/Backend/SorobanSecurityPortalApi/Controllers/RatingController.cs
+++ b/Backend/SorobanSecurityPortalApi/Controllers/RatingController.cs
@@ -64,6 +64,9 @@ namespace SorobanSecurityPortalApi.Controllers
                 return BadRequest("Review must not exceed 2000 characters.");
             }
 
+            // Review is stored in a NOT NULL column; treat an omitted/null review as empty.
+            request.Review ??= string.Empty;
+
             var result = await _ratingService.AddOrUpdateRating(request);
             return Ok(result);
         }

--- a/Backend/SorobanSecurityPortalApi/Controllers/ReportsController.cs
+++ b/Backend/SorobanSecurityPortalApi/Controllers/ReportsController.cs
@@ -76,7 +76,11 @@ namespace SorobanSecurityPortalApi.Controllers
         [HttpGet("{reportId}/image.png")]
         public async Task<IActionResult> GetImage(int reportId)
         {
-            var result = await _reportService.Get(reportId);
+            var result = await _reportService.GetPublic(reportId);
+            if (result == null)
+            {
+                return NotFound();
+            }
             if (result.Image == null || result.Image.Length == 0)
             {
                 return BadRequest("Report is not found.");
@@ -242,7 +246,9 @@ namespace SorobanSecurityPortalApi.Controllers
         [HttpGet("{reportId}")]
         public async Task<IActionResult> Get(int reportId)
         {
-            var result = await _reportService.Get(reportId);
+            var result = await _reportService.GetPublic(reportId);
+            if (result == null)
+                return NotFound();
             result.Image = null;
             result.BinFile = null;
             return Ok(result);
@@ -263,6 +269,9 @@ namespace SorobanSecurityPortalApi.Controllers
             return Ok(result);
         }
 
+        // Returns ALL reports including hidden/deleted/unapproved — admin/moderator dashboard only.
+        // The public site browses via the Search endpoint and the filtered GetList, never this one.
+        [RoleAuthorize(Role.Admin, Role.Moderator)]
         [HttpGet("all")]
         public async Task<IActionResult> GetListAll()
         {

--- a/Backend/SorobanSecurityPortalApi/Controllers/UserProfileController.cs
+++ b/Backend/SorobanSecurityPortalApi/Controllers/UserProfileController.cs
@@ -25,15 +25,15 @@ namespace SorobanSecurityPortalApi.Controllers
         }
 
         /// <summary>
-        /// Get user profile by user ID (public endpoint)
+        /// Get public user profile by login ID (public endpoint — no PII)
         /// </summary>
-        [HttpGet("{userId}")]
+        [HttpGet("{loginId}")]
         [AllowAnonymous]
-        public async Task<ActionResult<UserProfileViewModel>> GetProfile(int userId)
+        public async Task<ActionResult<PublicUserProfileViewModel>> GetProfile(int loginId)
         {
             try
             {
-                var profile = await _profileService.GetProfileByUserIdAsync(userId);
+                var profile = await _profileService.GetPublicProfileByLoginIdAsync(loginId);
                 if (profile == null)
                 {
                     return NotFound(new { message = "Profile not found" });
@@ -43,7 +43,7 @@ namespace SorobanSecurityPortalApi.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error retrieving profile for userId: {UserId}", userId);
+                _logger.LogError(ex, "Error retrieving profile for loginId: {LoginId}", loginId);
                 return StatusCode(500, new { message = "An error occurred while retrieving the profile" });
             }
         }
@@ -87,18 +87,23 @@ namespace SorobanSecurityPortalApi.Controllers
                 var loginId = await _userContext.GetLoginIdAsync();
 
                 var existingProfile = await _profileService.GetProfileByLoginIdAsync(loginId);
-                UserProfileViewModel updatedProfile;
+                Result<UserProfileViewModel, string> result;
 
                 if (existingProfile == null)
                 {
-                    updatedProfile = await _profileService.CreateProfileAsync(loginId, profileDto);
+                    result = await _profileService.CreateProfileAsync(loginId, profileDto);
                 }
                 else
                 {
-                    updatedProfile = await _profileService.UpdateProfileAsync(loginId, profileDto);
+                    result = await _profileService.UpdateProfileAsync(loginId, profileDto);
                 }
 
-                return Ok(updatedProfile);
+                if (result is Result<UserProfileViewModel, string>.Ok ok)
+                    return Ok(ok.Value);
+                else if (result is Result<UserProfileViewModel, string>.Err err)
+                    return BadRequest(new { message = err.Error });
+
+                return StatusCode(500, new { message = "An error occurred while updating your profile" });
             }
             catch (Exception ex)
             {

--- a/Backend/SorobanSecurityPortalApi/Controllers/VulnerabilitiesController.cs
+++ b/Backend/SorobanSecurityPortalApi/Controllers/VulnerabilitiesController.cs
@@ -135,6 +135,8 @@ namespace SorobanSecurityPortalApi.Controllers
         public async Task<IActionResult> Get(int vulnerabilityId)
         {
             var result = await _vulnerabilityService.Get(vulnerabilityId);
+            if (result == null)
+                return NotFound();
             return Ok(result);
         }
 
@@ -183,6 +185,9 @@ namespace SorobanSecurityPortalApi.Controllers
             return Ok(result);
         }
 
+        // Returns ALL vulnerabilities including hidden/deleted/unapproved — admin/moderator dashboard only.
+        // The public site browses via the Search endpoint, never this one.
+        [RoleAuthorize(Role.Admin, Role.Moderator)]
         [HttpGet]
         public async Task<IActionResult> GetList()
         {

--- a/Backend/SorobanSecurityPortalApi/Controllers/VulnerabilitiesController.cs
+++ b/Backend/SorobanSecurityPortalApi/Controllers/VulnerabilitiesController.cs
@@ -89,7 +89,12 @@ namespace SorobanSecurityPortalApi.Controllers
                 }
             }
             var result = await _vulnerabilityService.Add(vulnerabilityModel, files);
-            return Ok(result);
+            return result switch
+            {
+                Result<VulnerabilityViewModel, string>.Ok ok => Ok(ok.Value),
+                Result<VulnerabilityViewModel, string>.Err err => BadRequest(err.Error),
+                _ => throw new InvalidOperationException("Unexpected result type")
+            };
         }
 
         [RoleAuthorize(Role.Admin, Role.Moderator)]

--- a/Backend/SorobanSecurityPortalApi/Data/Processors/ContentFlagProcessor.cs
+++ b/Backend/SorobanSecurityPortalApi/Data/Processors/ContentFlagProcessor.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using SorobanSecurityPortalApi.Common.Data;
+using SorobanSecurityPortalApi.Models.DbModels;
+
+namespace SorobanSecurityPortalApi.Data.Processors
+{
+    public interface IContentFlagProcessor
+    {
+        Task<bool> Exists(ModeratedContentType type, int contentId, int userId);
+        Task Add(ContentFlagModel flag);
+        Task<List<ContentFlagModel>> GetAll();
+    }
+
+    public class ContentFlagProcessor : IContentFlagProcessor
+    {
+        private readonly IDbContextFactory<Db> _dbFactory;
+
+        public ContentFlagProcessor(IDbContextFactory<Db> dbFactory) => _dbFactory = dbFactory;
+
+        public async Task<bool> Exists(ModeratedContentType type, int contentId, int userId)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ContentFlag.AsNoTracking().AnyAsync(f => f.ContentType == type && f.ContentId == contentId && f.FlaggedByUserId == userId);
+        }
+
+        public async Task Add(ContentFlagModel flag)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            db.ContentFlag.Add(flag);
+            await db.SaveChangesAsync();
+        }
+
+        public async Task<List<ContentFlagModel>> GetAll()
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ContentFlag.AsNoTracking().ToListAsync();
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Data/Processors/ModerationActionProcessor.cs
+++ b/Backend/SorobanSecurityPortalApi/Data/Processors/ModerationActionProcessor.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore;
+using SorobanSecurityPortalApi.Common.Data;
+using SorobanSecurityPortalApi.Models.DbModels;
+
+namespace SorobanSecurityPortalApi.Data.Processors
+{
+    public interface IModerationActionProcessor
+    {
+        Task Add(ModerationActionModel action);
+        Task<List<ModerationActionModel>> GetAll();
+        Task<int> CountSince(DateTime sinceUtc);
+    }
+
+    public class ModerationActionProcessor : IModerationActionProcessor
+    {
+        private readonly IDbContextFactory<Db> _dbFactory;
+
+        public ModerationActionProcessor(IDbContextFactory<Db> dbFactory) => _dbFactory = dbFactory;
+
+        public async Task Add(ModerationActionModel action)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            db.ModerationAction.Add(action);
+            await db.SaveChangesAsync();
+        }
+
+        public async Task<List<ModerationActionModel>> GetAll()
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ModerationAction.AsNoTracking().ToListAsync();
+        }
+
+        public async Task<int> CountSince(DateTime sinceUtc)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ModerationAction.AsNoTracking().CountAsync(a => a.CreatedAt >= sinceUtc);
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Data/Processors/ReportProcessor.cs
+++ b/Backend/SorobanSecurityPortalApi/Data/Processors/ReportProcessor.cs
@@ -28,7 +28,7 @@ namespace SorobanSecurityPortalApi.Data.Processors
                 .Include(v => v.Auditor)
                 .Include(v => v.Protocol)
                 .ThenInclude(p => p!.Company)
-                .AsNoTracking().Where(v => v.Status == ReportModelStatus.Approved);
+                .AsNoTracking().Where(v => v.Status == ReportModelStatus.Approved && !v.IsHidden && !v.IsDeleted);
 
             if (reportSearch != null)
             {
@@ -161,6 +161,24 @@ namespace SorobanSecurityPortalApi.Data.Processors
             return report;
         }
 
+        // Public detail/image path: hidden/soft-deleted reports must never be served by direct URL.
+        // Returns null (not throw) when missing/hidden/deleted so callers can map it to NotFound.
+        // Approval-status is intentionally NOT filtered here; only the moderation flags are applied.
+        public async Task<ReportModel?> GetPublic(int reportId)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var report = await db.Report
+                .Include(r => r.Auditor)
+                .Include(r => r.Protocol)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(item => item.Id == reportId && !item.IsHidden && !item.IsDeleted);
+            if (report == null)
+                return null;
+            if (report.BinFile == null)
+                report.BinFile = Array.Empty<byte>();
+            return report;
+        }
+
         public async Task Approve(ReportModel reportModel, int userId)
         {
             await using var db = await _dbFactory.CreateDbContextAsync();
@@ -201,7 +219,7 @@ namespace SorobanSecurityPortalApi.Data.Processors
                 .AsNoTracking();
             if (!includeNotApproved)
             {
-                query = query.Where(r => r.Status == ReportModelStatus.Approved);
+                query = query.Where(r => r.Status == ReportModelStatus.Approved && !r.IsHidden && !r.IsDeleted);
             }
             query = query.Select(v => new ReportModel
             {
@@ -267,13 +285,13 @@ namespace SorobanSecurityPortalApi.Data.Processors
             var ago = DateTime.UtcNow.AddMonths(-1);
             var newReports = await db.Report
                 .AsNoTracking()
-                .Where(v => v.Status == ReportModelStatus.Approved && v.Date >= ago)
+                .Where(v => v.Status == ReportModelStatus.Approved && !v.IsHidden && !v.IsDeleted && v.Date >= ago)
                 .CountAsync();
             return new ReportStatisticsChangesViewModel
             {
                 Total = await db.Report
                     .AsNoTracking()
-                    .CountAsync(v => v.Status == ReportModelStatus.Approved),
+                    .CountAsync(v => v.Status == ReportModelStatus.Approved && !v.IsHidden && !v.IsDeleted),
                 New = newReports
             };
         }
@@ -285,6 +303,7 @@ namespace SorobanSecurityPortalApi.Data.Processors
         Task<ReportModel> Add(ReportModel reportModel);
         Task<ReportModel> Edit(ReportModel reportModel, int userId);
         Task<ReportModel> Get(int reportId);
+        Task<ReportModel?> GetPublic(int reportId);
         Task Approve(ReportModel reportModel, int userId);
         Task Reject(ReportModel reportModel, int userId);
         Task Remove(int reportId);

--- a/Backend/SorobanSecurityPortalApi/Data/Processors/VulnerabilityProcessor.cs
+++ b/Backend/SorobanSecurityPortalApi/Data/Processors/VulnerabilityProcessor.cs
@@ -57,7 +57,7 @@ namespace SorobanSecurityPortalApi.Data.Processors
                     .ThenInclude(p => p!.Company)
                 .Include(v => v.Report)
                     .ThenInclude(r => r!.Auditor)
-                .Where(v => v.Status == VulnerabilityModelStatus.Approved && v.Category != VulnerabilityCategory.Invalid);
+                .Where(v => v.Status == VulnerabilityModelStatus.Approved && v.Category != VulnerabilityCategory.Invalid && !v.IsHidden && !v.IsDeleted);
 
             if (s == null) return query;
 
@@ -231,6 +231,22 @@ namespace SorobanSecurityPortalApi.Data.Processors
                 .FirstOrDefaultAsync(v => v.Id == vulnerabilityId);
         }
 
+        // Public detail path: hidden/soft-deleted content must never be served by direct URL.
+        // Approval-status is intentionally NOT filtered here (matches the unfiltered Get behavior);
+        // only the moderation flags are applied.
+        public async Task<VulnerabilityModel?> GetPublic(int vulnerabilityId)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.Vulnerability
+                .Include(v => v.Report)
+                    .ThenInclude(r => r!.Protocol)
+                    .ThenInclude(p => p!.Company)
+                .Include(v => v.Report)
+                    .ThenInclude(r => r!.Auditor)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(v => v.Id == vulnerabilityId && !v.IsHidden && !v.IsDeleted);
+        }
+
         public async Task<VulnerabilityModel> Update(int userId, VulnerabilityModel vulnerabilityModel)
         {
             await using var db = await _dbFactory.CreateDbContextAsync();
@@ -285,7 +301,7 @@ namespace SorobanSecurityPortalApi.Data.Processors
             await using var db = await _dbFactory.CreateDbContextAsync();
             var bySeverity = await db.Vulnerability
                     .AsNoTracking()
-                    .Where(v => v.Status == VulnerabilityModelStatus.Approved && v.Category != VulnerabilityCategory.Invalid)
+                    .Where(v => v.Status == VulnerabilityModelStatus.Approved && v.Category != VulnerabilityCategory.Invalid && !v.IsHidden && !v.IsDeleted)
                     .GroupBy(v => v.Severity)
                     .Select(g => new
                     {
@@ -296,7 +312,7 @@ namespace SorobanSecurityPortalApi.Data.Processors
 
             var vulnerabilitiesWithTags = await db.Vulnerability
                 .AsNoTracking()
-                .Where(v => v.Status == VulnerabilityModelStatus.Approved && v.Category != VulnerabilityCategory.Invalid && v.Tags != null)
+                .Where(v => v.Status == VulnerabilityModelStatus.Approved && v.Category != VulnerabilityCategory.Invalid && !v.IsHidden && !v.IsDeleted && v.Tags != null)
                 .Select(v => new { v.Id, v.Tags })
                 .ToListAsync();
 
@@ -312,7 +328,7 @@ namespace SorobanSecurityPortalApi.Data.Processors
 
             var byCategory = await db.Vulnerability
                     .AsNoTracking()
-                    .Where(v => v.Status == VulnerabilityModelStatus.Approved && v.Category != VulnerabilityCategory.Invalid)
+                    .Where(v => v.Status == VulnerabilityModelStatus.Approved && v.Category != VulnerabilityCategory.Invalid && !v.IsHidden && !v.IsDeleted)
                     .GroupBy(v => v.Category)
                     .Select(g => new
                     {
@@ -324,7 +340,7 @@ namespace SorobanSecurityPortalApi.Data.Processors
             {
                 Total = await db.Vulnerability
                     .AsNoTracking()
-                    .CountAsync(v => v.Status == VulnerabilityModelStatus.Approved && v.Category != VulnerabilityCategory.Invalid),
+                    .CountAsync(v => v.Status == VulnerabilityModelStatus.Approved && v.Category != VulnerabilityCategory.Invalid && !v.IsHidden && !v.IsDeleted),
                 BySeverity = bySeverity.ToDictionary(x => x.Severity, x => x.Count),
                 ByTag = byTag.ToDictionary(x => x.Tag, x => x.Count),
                 ByCategory = byCategory.ToDictionary(x => x.Category, x => x.Count)
@@ -337,13 +353,13 @@ namespace SorobanSecurityPortalApi.Data.Processors
             var ago = DateTime.UtcNow.AddMonths(-1);
             var newVulnerabilities = await db.Vulnerability
                 .AsNoTracking()
-                .Where(v => v.Status == VulnerabilityModelStatus.Approved && v.Category != VulnerabilityCategory.Invalid && v.Date >= ago)
+                .Where(v => v.Status == VulnerabilityModelStatus.Approved && v.Category != VulnerabilityCategory.Invalid && !v.IsHidden && !v.IsDeleted && v.Date >= ago)
                 .CountAsync();
             return new VulnerabilityStatisticsChangesViewModel
             {
                 Total = db.Vulnerability
                     .AsNoTracking()
-                    .Count(v => v.Status == VulnerabilityModelStatus.Approved && v.Category != VulnerabilityCategory.Invalid),
+                    .Count(v => v.Status == VulnerabilityModelStatus.Approved && v.Category != VulnerabilityCategory.Invalid && !v.IsHidden && !v.IsDeleted),
                 New = newVulnerabilities
             };
         }
@@ -359,6 +375,7 @@ namespace SorobanSecurityPortalApi.Data.Processors
         Task Reject(VulnerabilityModel vulnerabilityModel, int userId);
         Task Remove(int vulnerabilityId);
         Task<VulnerabilityModel?> Get(int vulnerabilityId);
+        Task<VulnerabilityModel?> GetPublic(int vulnerabilityId);
         Task<VulnerabilityModel> Update(int userId, VulnerabilityModel vulnerabilityModel);
         Task<List<VulnerabilityModel>> GetList();
         Task<List<VulnerabilityModel>> GetListForEmbedding();

--- a/Backend/SorobanSecurityPortalApi/Migrations/20260522130556_AddModerationLog.Designer.cs
+++ b/Backend/SorobanSecurityPortalApi/Migrations/20260522130556_AddModerationLog.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -14,9 +15,11 @@ using SorobanSecurityPortalApi.Models.DbModels;
 namespace SorobanSecurityPortalApi.Migrations
 {
     [DbContext(typeof(Db))]
-    partial class DbModelSnapshot : ModelSnapshot
+    [Migration("20260522130556_AddModerationLog")]
+    partial class AddModerationLog
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -263,212 +266,6 @@ namespace SorobanSecurityPortalApi.Migrations
                     b.ToTable("file");
                 });
 
-            modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.ForumCategoryModel", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at");
-
-                    b.Property<string>("Description")
-                        .IsRequired()
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)")
-                        .HasColumnName("description");
-
-                    b.Property<bool>("IsLocked")
-                        .HasColumnType("boolean")
-                        .HasColumnName("is_locked");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)")
-                        .HasColumnName("name");
-
-                    b.Property<string>("Slug")
-                        .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)")
-                        .HasColumnName("slug");
-
-                    b.Property<int>("SortOrder")
-                        .HasColumnType("integer")
-                        .HasColumnName("sort_order");
-
-                    b.HasKey("Id")
-                        .HasName("pk_forum_category");
-
-                    b.HasIndex("Slug")
-                        .IsUnique()
-                        .HasDatabaseName("ix_forum_category_slug");
-
-                    b.ToTable("forum_category");
-
-                    b.HasData(
-                        new
-                        {
-                            Id = 1,
-                            CreatedAt = new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Description = "General discussions about the portal.",
-                            IsLocked = false,
-                            Name = "General",
-                            Slug = "general",
-                            SortOrder = 1
-                        },
-                        new
-                        {
-                            Id = 2,
-                            CreatedAt = new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Description = "Discussions about smart contract development.",
-                            IsLocked = false,
-                            Name = "Soroban Development",
-                            Slug = "soroban-development",
-                            SortOrder = 2
-                        },
-                        new
-                        {
-                            Id = 3,
-                            CreatedAt = new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Description = "Sharing security tips and patterns.",
-                            IsLocked = false,
-                            Name = "Security Best Practices",
-                            Slug = "security-best-practices",
-                            SortOrder = 3
-                        },
-                        new
-                        {
-                            Id = 4,
-                            CreatedAt = new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Description = "Deep dives into specific vulnerabilities.",
-                            IsLocked = false,
-                            Name = "Vulnerability Discussions",
-                            Slug = "vulnerability-discussions",
-                            SortOrder = 4
-                        });
-                });
-
-            modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.ForumPostModel", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("AuthorId")
-                        .HasColumnType("integer")
-                        .HasColumnName("author_id");
-
-                    b.Property<string>("Content")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("content");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at");
-
-                    b.Property<bool>("IsFirstPost")
-                        .HasColumnType("boolean")
-                        .HasColumnName("is_first_post");
-
-                    b.Property<int>("ThreadId")
-                        .HasColumnType("integer")
-                        .HasColumnName("thread_id");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("updated_at");
-
-                    b.Property<int>("Votes")
-                        .HasColumnType("integer")
-                        .HasColumnName("votes");
-
-                    b.HasKey("Id")
-                        .HasName("pk_forum_post");
-
-                    b.HasIndex("AuthorId")
-                        .HasDatabaseName("ix_forum_post_author_id");
-
-                    b.HasIndex("ThreadId", "CreatedAt")
-                        .HasDatabaseName("ix_forum_post_thread_id_created_at");
-
-                    b.ToTable("forum_post");
-                });
-
-            modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.ForumThreadModel", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("AuthorId")
-                        .HasColumnType("integer")
-                        .HasColumnName("author_id");
-
-                    b.Property<int>("CategoryId")
-                        .HasColumnType("integer")
-                        .HasColumnName("category_id");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at");
-
-                    b.Property<bool>("IsLocked")
-                        .HasColumnType("boolean")
-                        .HasColumnName("is_locked");
-
-                    b.Property<bool>("IsPinned")
-                        .HasColumnType("boolean")
-                        .HasColumnName("is_pinned");
-
-                    b.Property<string>("Slug")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)")
-                        .HasColumnName("slug");
-
-                    b.Property<string>("Title")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)")
-                        .HasColumnName("title");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("updated_at");
-
-                    b.Property<int>("ViewCount")
-                        .HasColumnType("integer")
-                        .HasColumnName("view_count");
-
-                    b.HasKey("Id")
-                        .HasName("pk_forum_thread");
-
-                    b.HasIndex("AuthorId")
-                        .HasDatabaseName("ix_forum_thread_author_id");
-
-                    b.HasIndex("Slug")
-                        .IsUnique()
-                        .HasDatabaseName("ix_forum_thread_slug");
-
-                    b.HasIndex("CategoryId", "IsPinned", "CreatedAt")
-                        .HasDatabaseName("ix_forum_thread_category_id_is_pinned_created_at");
-
-                    b.ToTable("forum_thread");
-                });
-
             modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.LoginHistoryModel", b =>
                 {
                     b.Property<int>("LoginHistoryId")
@@ -598,7 +395,7 @@ namespace SorobanSecurityPortalApi.Migrations
                         {
                             LoginId = 1,
                             ConnectedAccounts = new List<ConnectedAccountModel>(),
-                            Created = new DateTime(2026, 5, 22, 13, 7, 23, 580, DateTimeKind.Utc).AddTicks(2865),
+                            Created = new DateTime(2026, 5, 22, 13, 5, 55, 457, DateTimeKind.Utc).AddTicks(1217),
                             CreatedBy = "system",
                             Email = "admin@sorobansecurity.com",
                             FullName = "Admin",
@@ -714,58 +511,6 @@ namespace SorobanSecurityPortalApi.Migrations
                         .HasDatabaseName("ix_protocol_company_id");
 
                     b.ToTable("protocol");
-                });
-
-            modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.RatingModel", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at");
-
-                    b.Property<int>("EntityId")
-                        .HasColumnType("integer")
-                        .HasColumnName("entity_id");
-
-                    b.Property<int>("EntityType")
-                        .HasColumnType("integer")
-                        .HasColumnName("entity_type");
-
-                    b.Property<string>("Review")
-                        .IsRequired()
-                        .HasMaxLength(2000)
-                        .HasColumnType("character varying(2000)")
-                        .HasColumnName("review");
-
-                    b.Property<int>("Score")
-                        .HasColumnType("integer")
-                        .HasColumnName("score");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("updated_at");
-
-                    b.Property<int>("UserId")
-                        .HasColumnType("integer")
-                        .HasColumnName("user_id");
-
-                    b.HasKey("Id")
-                        .HasName("pk_rating");
-
-                    b.HasIndex("EntityType", "EntityId")
-                        .HasDatabaseName("ix_rating_entity_type_entity_id");
-
-                    b.HasIndex("UserId", "EntityType", "EntityId")
-                        .IsUnique()
-                        .HasDatabaseName("ix_rating_user_id_entity_type_entity_id");
-
-                    b.ToTable("rating");
                 });
 
             modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.ReportModel", b =>
@@ -1025,48 +770,6 @@ namespace SorobanSecurityPortalApi.Migrations
                         .HasDatabaseName("ix_vulnerability_report_id");
 
                     b.ToTable("vulnerability");
-                });
-
-            modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.ForumPostModel", b =>
-                {
-                    b.HasOne("SorobanSecurityPortalApi.Models.DbModels.LoginModel", "Author")
-                        .WithMany()
-                        .HasForeignKey("AuthorId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired()
-                        .HasConstraintName("fk_forum_post_login_author_id");
-
-                    b.HasOne("SorobanSecurityPortalApi.Models.DbModels.ForumThreadModel", "Thread")
-                        .WithMany()
-                        .HasForeignKey("ThreadId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_forum_post_forum_thread_thread_id");
-
-                    b.Navigation("Author");
-
-                    b.Navigation("Thread");
-                });
-
-            modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.ForumThreadModel", b =>
-                {
-                    b.HasOne("SorobanSecurityPortalApi.Models.DbModels.LoginModel", "Author")
-                        .WithMany()
-                        .HasForeignKey("AuthorId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired()
-                        .HasConstraintName("fk_forum_thread_login_author_id");
-
-                    b.HasOne("SorobanSecurityPortalApi.Models.DbModels.ForumCategoryModel", "Category")
-                        .WithMany()
-                        .HasForeignKey("CategoryId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_forum_thread_forum_category_category_id");
-
-                    b.Navigation("Author");
-
-                    b.Navigation("Category");
                 });
 
             modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.ProtocolModel", b =>

--- a/Backend/SorobanSecurityPortalApi/Migrations/20260522130556_AddModerationLog.cs
+++ b/Backend/SorobanSecurityPortalApi/Migrations/20260522130556_AddModerationLog.cs
@@ -1,8 +1,6 @@
-using System;
-using System.Collections.Generic;
+﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
-using SorobanSecurityPortalApi.Models.DbModels;
 
 #nullable disable
 
@@ -33,23 +31,6 @@ namespace SorobanSecurityPortalApi.Migrations
                 {
                     table.PrimaryKey("pk_moderation_log", x => x.id);
                 });
-
-            migrationBuilder.CreateIndex(
-                name: "ix_moderation_log_user_id",
-                table: "moderation_log",
-                column: "user_id");
-
-            migrationBuilder.CreateIndex(
-                name: "ix_moderation_log_created_at",
-                table: "moderation_log",
-                column: "created_at");
-
-            migrationBuilder.UpdateData(
-                table: "login",
-                keyColumn: "login_id",
-                keyValue: 1,
-                columns: new[] { "connected_accounts", "created" },
-                values: new object[] { new List<ConnectedAccountModel>(), new DateTime(2026, 1, 22, 0, 0, 0, 0, DateTimeKind.Utc) });
         }
 
         /// <inheritdoc />
@@ -57,13 +38,6 @@ namespace SorobanSecurityPortalApi.Migrations
         {
             migrationBuilder.DropTable(
                 name: "moderation_log");
-
-            migrationBuilder.UpdateData(
-                table: "login",
-                keyColumn: "login_id",
-                keyValue: 1,
-                columns: new[] { "connected_accounts", "created" },
-                values: new object[] { new List<ConnectedAccountModel>(), new DateTime(2025, 11, 30, 2, 29, 25, 139, DateTimeKind.Utc).AddTicks(1314) });
         }
     }
 }

--- a/Backend/SorobanSecurityPortalApi/Migrations/20260522130647_AddRatings.Designer.cs
+++ b/Backend/SorobanSecurityPortalApi/Migrations/20260522130647_AddRatings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -14,9 +15,11 @@ using SorobanSecurityPortalApi.Models.DbModels;
 namespace SorobanSecurityPortalApi.Migrations
 {
     [DbContext(typeof(Db))]
-    partial class DbModelSnapshot : ModelSnapshot
+    [Migration("20260522130647_AddRatings")]
+    partial class AddRatings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -263,212 +266,6 @@ namespace SorobanSecurityPortalApi.Migrations
                     b.ToTable("file");
                 });
 
-            modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.ForumCategoryModel", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at");
-
-                    b.Property<string>("Description")
-                        .IsRequired()
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)")
-                        .HasColumnName("description");
-
-                    b.Property<bool>("IsLocked")
-                        .HasColumnType("boolean")
-                        .HasColumnName("is_locked");
-
-                    b.Property<string>("Name")
-                        .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)")
-                        .HasColumnName("name");
-
-                    b.Property<string>("Slug")
-                        .IsRequired()
-                        .HasMaxLength(100)
-                        .HasColumnType("character varying(100)")
-                        .HasColumnName("slug");
-
-                    b.Property<int>("SortOrder")
-                        .HasColumnType("integer")
-                        .HasColumnName("sort_order");
-
-                    b.HasKey("Id")
-                        .HasName("pk_forum_category");
-
-                    b.HasIndex("Slug")
-                        .IsUnique()
-                        .HasDatabaseName("ix_forum_category_slug");
-
-                    b.ToTable("forum_category");
-
-                    b.HasData(
-                        new
-                        {
-                            Id = 1,
-                            CreatedAt = new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Description = "General discussions about the portal.",
-                            IsLocked = false,
-                            Name = "General",
-                            Slug = "general",
-                            SortOrder = 1
-                        },
-                        new
-                        {
-                            Id = 2,
-                            CreatedAt = new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Description = "Discussions about smart contract development.",
-                            IsLocked = false,
-                            Name = "Soroban Development",
-                            Slug = "soroban-development",
-                            SortOrder = 2
-                        },
-                        new
-                        {
-                            Id = 3,
-                            CreatedAt = new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Description = "Sharing security tips and patterns.",
-                            IsLocked = false,
-                            Name = "Security Best Practices",
-                            Slug = "security-best-practices",
-                            SortOrder = 3
-                        },
-                        new
-                        {
-                            Id = 4,
-                            CreatedAt = new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
-                            Description = "Deep dives into specific vulnerabilities.",
-                            IsLocked = false,
-                            Name = "Vulnerability Discussions",
-                            Slug = "vulnerability-discussions",
-                            SortOrder = 4
-                        });
-                });
-
-            modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.ForumPostModel", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("AuthorId")
-                        .HasColumnType("integer")
-                        .HasColumnName("author_id");
-
-                    b.Property<string>("Content")
-                        .IsRequired()
-                        .HasColumnType("text")
-                        .HasColumnName("content");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at");
-
-                    b.Property<bool>("IsFirstPost")
-                        .HasColumnType("boolean")
-                        .HasColumnName("is_first_post");
-
-                    b.Property<int>("ThreadId")
-                        .HasColumnType("integer")
-                        .HasColumnName("thread_id");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("updated_at");
-
-                    b.Property<int>("Votes")
-                        .HasColumnType("integer")
-                        .HasColumnName("votes");
-
-                    b.HasKey("Id")
-                        .HasName("pk_forum_post");
-
-                    b.HasIndex("AuthorId")
-                        .HasDatabaseName("ix_forum_post_author_id");
-
-                    b.HasIndex("ThreadId", "CreatedAt")
-                        .HasDatabaseName("ix_forum_post_thread_id_created_at");
-
-                    b.ToTable("forum_post");
-                });
-
-            modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.ForumThreadModel", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasColumnName("id");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
-
-                    b.Property<int>("AuthorId")
-                        .HasColumnType("integer")
-                        .HasColumnName("author_id");
-
-                    b.Property<int>("CategoryId")
-                        .HasColumnType("integer")
-                        .HasColumnName("category_id");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at");
-
-                    b.Property<bool>("IsLocked")
-                        .HasColumnType("boolean")
-                        .HasColumnName("is_locked");
-
-                    b.Property<bool>("IsPinned")
-                        .HasColumnType("boolean")
-                        .HasColumnName("is_pinned");
-
-                    b.Property<string>("Slug")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)")
-                        .HasColumnName("slug");
-
-                    b.Property<string>("Title")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)")
-                        .HasColumnName("title");
-
-                    b.Property<DateTime?>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("updated_at");
-
-                    b.Property<int>("ViewCount")
-                        .HasColumnType("integer")
-                        .HasColumnName("view_count");
-
-                    b.HasKey("Id")
-                        .HasName("pk_forum_thread");
-
-                    b.HasIndex("AuthorId")
-                        .HasDatabaseName("ix_forum_thread_author_id");
-
-                    b.HasIndex("Slug")
-                        .IsUnique()
-                        .HasDatabaseName("ix_forum_thread_slug");
-
-                    b.HasIndex("CategoryId", "IsPinned", "CreatedAt")
-                        .HasDatabaseName("ix_forum_thread_category_id_is_pinned_created_at");
-
-                    b.ToTable("forum_thread");
-                });
-
             modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.LoginHistoryModel", b =>
                 {
                     b.Property<int>("LoginHistoryId")
@@ -598,7 +395,7 @@ namespace SorobanSecurityPortalApi.Migrations
                         {
                             LoginId = 1,
                             ConnectedAccounts = new List<ConnectedAccountModel>(),
-                            Created = new DateTime(2026, 5, 22, 13, 7, 23, 580, DateTimeKind.Utc).AddTicks(2865),
+                            Created = new DateTime(2026, 5, 22, 13, 6, 46, 623, DateTimeKind.Utc).AddTicks(4231),
                             CreatedBy = "system",
                             Email = "admin@sorobansecurity.com",
                             FullName = "Admin",
@@ -1025,48 +822,6 @@ namespace SorobanSecurityPortalApi.Migrations
                         .HasDatabaseName("ix_vulnerability_report_id");
 
                     b.ToTable("vulnerability");
-                });
-
-            modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.ForumPostModel", b =>
-                {
-                    b.HasOne("SorobanSecurityPortalApi.Models.DbModels.LoginModel", "Author")
-                        .WithMany()
-                        .HasForeignKey("AuthorId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired()
-                        .HasConstraintName("fk_forum_post_login_author_id");
-
-                    b.HasOne("SorobanSecurityPortalApi.Models.DbModels.ForumThreadModel", "Thread")
-                        .WithMany()
-                        .HasForeignKey("ThreadId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_forum_post_forum_thread_thread_id");
-
-                    b.Navigation("Author");
-
-                    b.Navigation("Thread");
-                });
-
-            modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.ForumThreadModel", b =>
-                {
-                    b.HasOne("SorobanSecurityPortalApi.Models.DbModels.LoginModel", "Author")
-                        .WithMany()
-                        .HasForeignKey("AuthorId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired()
-                        .HasConstraintName("fk_forum_thread_login_author_id");
-
-                    b.HasOne("SorobanSecurityPortalApi.Models.DbModels.ForumCategoryModel", "Category")
-                        .WithMany()
-                        .HasForeignKey("CategoryId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired()
-                        .HasConstraintName("fk_forum_thread_forum_category_category_id");
-
-                    b.Navigation("Author");
-
-                    b.Navigation("Category");
                 });
 
             modelBuilder.Entity("SorobanSecurityPortalApi.Models.DbModels.ProtocolModel", b =>

--- a/Backend/SorobanSecurityPortalApi/Migrations/20260522130647_AddRatings.cs
+++ b/Backend/SorobanSecurityPortalApi/Migrations/20260522130647_AddRatings.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -6,8 +6,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace SorobanSecurityPortalApi.Migrations
 {
+    /// <inheritdoc />
     public partial class AddRatings : Migration
     {
+        /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.CreateTable(
@@ -20,7 +22,7 @@ namespace SorobanSecurityPortalApi.Migrations
                     entity_type = table.Column<int>(type: "integer", nullable: false),
                     entity_id = table.Column<int>(type: "integer", nullable: false),
                     score = table.Column<int>(type: "integer", nullable: false),
-                    review = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    review = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false),
                     created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                     updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
                 },
@@ -39,12 +41,11 @@ namespace SorobanSecurityPortalApi.Migrations
                 table: "rating",
                 columns: new[] { "user_id", "entity_type", "entity_id" },
                 unique: true);
-
         }
 
+        /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            
             migrationBuilder.DropTable(
                 name: "rating");
         }

--- a/Backend/SorobanSecurityPortalApi/Migrations/20260522130724_AddForumTables.Designer.cs
+++ b/Backend/SorobanSecurityPortalApi/Migrations/20260522130724_AddForumTables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -14,9 +15,11 @@ using SorobanSecurityPortalApi.Models.DbModels;
 namespace SorobanSecurityPortalApi.Migrations
 {
     [DbContext(typeof(Db))]
-    partial class DbModelSnapshot : ModelSnapshot
+    [Migration("20260522130724_AddForumTables")]
+    partial class AddForumTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/SorobanSecurityPortalApi/Migrations/20260522130724_AddForumTables.cs
+++ b/Backend/SorobanSecurityPortalApi/Migrations/20260522130724_AddForumTables.cs
@@ -1,16 +1,19 @@
-using System;
+﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
 namespace SorobanSecurityPortalApi.Migrations
 {
+    /// <inheritdoc />
     public partial class AddForumTables : Migration
     {
+        /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            // Create ForumCategory Table
             migrationBuilder.CreateTable(
                 name: "forum_category",
                 columns: table => new
@@ -29,7 +32,6 @@ namespace SorobanSecurityPortalApi.Migrations
                     table.PrimaryKey("pk_forum_category", x => x.id);
                 });
 
-            // Create ForumThread Table
             migrationBuilder.CreateTable(
                 name: "forum_thread",
                 columns: table => new
@@ -60,10 +62,9 @@ namespace SorobanSecurityPortalApi.Migrations
                         column: x => x.author_id,
                         principalTable: "login",
                         principalColumn: "login_id",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
-            // Create ForumPost Table
             migrationBuilder.CreateTable(
                 name: "forum_post",
                 columns: table => new
@@ -92,22 +93,20 @@ namespace SorobanSecurityPortalApi.Migrations
                         column: x => x.author_id,
                         principalTable: "login",
                         principalColumn: "login_id",
-                        onDelete: ReferentialAction.Cascade);
+                        onDelete: ReferentialAction.Restrict);
                 });
 
-            // Seed Data
             migrationBuilder.InsertData(
                 table: "forum_category",
                 columns: new[] { "id", "created_at", "description", "is_locked", "name", "slug", "sort_order" },
                 values: new object[,]
                 {
-                    { 1, new DateTime(2026, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc), "General discussions about the portal.", false, "General", "general", 1 },
-                    { 2, new DateTime(2026, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc), "Discussions about smart contract development.", false, "Soroban Development", "soroban-development", 2 },
-                    { 3, new DateTime(2026, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc), "Sharing security tips and patterns.", false, "Security Best Practices", "security-best-practices", 3 },
-                    { 4, new DateTime(2026, 2, 1, 0, 0, 0, 0, DateTimeKind.Utc), "Deep dives into specific vulnerabilities.", false, "Vulnerability Discussions", "vulnerability-discussions", 4 }
+                    { 1, new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), "General discussions about the portal.", false, "General", "general", 1 },
+                    { 2, new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), "Discussions about smart contract development.", false, "Soroban Development", "soroban-development", 2 },
+                    { 3, new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), "Sharing security tips and patterns.", false, "Security Best Practices", "security-best-practices", 3 },
+                    { 4, new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), "Deep dives into specific vulnerabilities.", false, "Vulnerability Discussions", "vulnerability-discussions", 4 }
                 });
 
-            // Indexes
             migrationBuilder.CreateIndex(
                 name: "ix_forum_category_slug",
                 table: "forum_category",
@@ -115,10 +114,19 @@ namespace SorobanSecurityPortalApi.Migrations
                 unique: true);
 
             migrationBuilder.CreateIndex(
-                name: "ix_forum_thread_slug",
+                name: "ix_forum_post_author_id",
+                table: "forum_post",
+                column: "author_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_forum_post_thread_id_created_at",
+                table: "forum_post",
+                columns: new[] { "thread_id", "created_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_forum_thread_author_id",
                 table: "forum_thread",
-                column: "slug",
-                unique: true);
+                column: "author_id");
 
             migrationBuilder.CreateIndex(
                 name: "ix_forum_thread_category_id_is_pinned_created_at",
@@ -126,27 +134,23 @@ namespace SorobanSecurityPortalApi.Migrations
                 columns: new[] { "category_id", "is_pinned", "created_at" });
 
             migrationBuilder.CreateIndex(
-                name: "ix_forum_post_thread_id_created_at",
-                table: "forum_post",
-                columns: new[] { "thread_id", "created_at" });
-                
-            // FK Indexes
-            migrationBuilder.CreateIndex(
-                name: "ix_forum_thread_author_id",
+                name: "ix_forum_thread_slug",
                 table: "forum_thread",
-                column: "author_id");
-                
-            migrationBuilder.CreateIndex(
-                name: "ix_forum_post_author_id",
-                table: "forum_post",
-                column: "author_id");
+                column: "slug",
+                unique: true);
         }
 
+        /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropTable(name: "forum_post");
-            migrationBuilder.DropTable(name: "forum_thread");
-            migrationBuilder.DropTable(name: "forum_category");
+            migrationBuilder.DropTable(
+                name: "forum_post");
+
+            migrationBuilder.DropTable(
+                name: "forum_thread");
+
+            migrationBuilder.DropTable(
+                name: "forum_category");
         }
     }
 }

--- a/Backend/SorobanSecurityPortalApi/Migrations/20260522214051_AddContentModeration.Designer.cs
+++ b/Backend/SorobanSecurityPortalApi/Migrations/20260522214051_AddContentModeration.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -14,9 +15,11 @@ using SorobanSecurityPortalApi.Models.DbModels;
 namespace SorobanSecurityPortalApi.Migrations
 {
     [DbContext(typeof(Db))]
-    partial class DbModelSnapshot : ModelSnapshot
+    [Migration("20260522214051_AddContentModeration")]
+    partial class AddContentModeration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/SorobanSecurityPortalApi/Migrations/20260522214051_AddContentModeration.cs
+++ b/Backend/SorobanSecurityPortalApi/Migrations/20260522214051_AddContentModeration.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+using SorobanSecurityPortalApi.Models.DbModels;
+
+#nullable disable
+
+namespace SorobanSecurityPortalApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddContentModeration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_deleted",
+                table: "vulnerability",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_hidden",
+                table: "vulnerability",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_deleted",
+                table: "report",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_hidden",
+                table: "report",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateTable(
+                name: "content_flag",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    content_type = table.Column<int>(type: "integer", nullable: false),
+                    content_id = table.Column<int>(type: "integer", nullable: false),
+                    flagged_by_user_id = table.Column<int>(type: "integer", nullable: false),
+                    reason = table.Column<int>(type: "integer", nullable: false),
+                    comment = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_content_flag", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "moderation_action",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    content_type = table.Column<int>(type: "integer", nullable: false),
+                    content_id = table.Column<int>(type: "integer", nullable: false),
+                    moderator_id = table.Column<int>(type: "integer", nullable: false),
+                    action = table.Column<int>(type: "integer", nullable: false),
+                    reason = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_moderation_action", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_content_flag_content_type_content_id",
+                table: "content_flag",
+                columns: new[] { "content_type", "content_id" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_content_flag_content_type_content_id_flagged_by_user_id",
+                table: "content_flag",
+                columns: new[] { "content_type", "content_id", "flagged_by_user_id" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_moderation_action_content_type_content_id_created_at",
+                table: "moderation_action",
+                columns: new[] { "content_type", "content_id", "created_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_moderation_action_created_at",
+                table: "moderation_action",
+                column: "created_at");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "content_flag");
+
+            migrationBuilder.DropTable(
+                name: "moderation_action");
+
+            migrationBuilder.DropColumn(
+                name: "is_deleted",
+                table: "vulnerability");
+
+            migrationBuilder.DropColumn(
+                name: "is_hidden",
+                table: "vulnerability");
+
+            migrationBuilder.DropColumn(
+                name: "is_deleted",
+                table: "report");
+
+            migrationBuilder.DropColumn(
+                name: "is_hidden",
+                table: "report");
+
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Models/DbModels/ContentFlagModel.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/DbModels/ContentFlagModel.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace SorobanSecurityPortalApi.Models.DbModels
+{
+    [Table("content_flag")]
+    public class ContentFlagModel
+    {
+        [Key] public int Id { get; set; }
+        public ModeratedContentType ContentType { get; set; }
+        public int ContentId { get; set; }
+        public int FlaggedByUserId { get; set; }
+        public FlagReason Reason { get; set; }
+        [MaxLength(1000)] public string? Comment { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Models/DbModels/ForumPostModel.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/DbModels/ForumPostModel.cs
@@ -27,9 +27,9 @@ namespace SorobanSecurityPortalApi.Models.DbModels
 
         // Relationships
         [ForeignKey("ThreadId")]
-        public virtual ForumThreadModel Thread { get; set; }
+        public virtual ForumThreadModel Thread { get; set; } = null!;
 
         [ForeignKey("AuthorId")]
-        public virtual LoginModel Author { get; set; }
+        public virtual LoginModel Author { get; set; } = null!;
     }
 }

--- a/Backend/SorobanSecurityPortalApi/Models/DbModels/ForumThreadModel.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/DbModels/ForumThreadModel.cs
@@ -33,9 +33,9 @@ namespace SorobanSecurityPortalApi.Models.DbModels
 
         // Relationships
         [ForeignKey("CategoryId")]
-        public virtual ForumCategoryModel Category { get; set; }
+        public virtual ForumCategoryModel Category { get; set; } = null!;
 
         [ForeignKey("AuthorId")]
-        public virtual LoginModel Author { get; set; }
+        public virtual LoginModel Author { get; set; } = null!;
     }
 }

--- a/Backend/SorobanSecurityPortalApi/Models/DbModels/ModerationActionModel.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/DbModels/ModerationActionModel.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace SorobanSecurityPortalApi.Models.DbModels
+{
+    [Table("moderation_action")]
+    public class ModerationActionModel
+    {
+        [Key] public int Id { get; set; }
+        public ModeratedContentType ContentType { get; set; }
+        public int ContentId { get; set; }
+        public int ModeratorId { get; set; }
+        public ModerationActionType Action { get; set; }
+        [MaxLength(1000)] public string? Reason { get; set; }
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Models/DbModels/ModerationEnums.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/DbModels/ModerationEnums.cs
@@ -1,0 +1,6 @@
+namespace SorobanSecurityPortalApi.Models.DbModels
+{
+    public enum ModeratedContentType { Vulnerability = 1, Report = 2 }
+    public enum FlagReason { Spam = 1, Harassment = 2, Inappropriate = 3, Misinformation = 4, Other = 5 }
+    public enum ModerationActionType { Approve = 1, Hide = 2, Delete = 3 }
+}

--- a/Backend/SorobanSecurityPortalApi/Models/DbModels/ReportModel.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/DbModels/ReportModel.cs
@@ -24,6 +24,8 @@ namespace SorobanSecurityPortalApi.Models.DbModels
         [ForeignKey("Auditor")]
         public int? AuditorId { get; set; }
         public AuditorModel? Auditor { get; set; } = null!;
+        public bool IsHidden { get; set; }
+        public bool IsDeleted { get; set; }
         [Column(TypeName = "vector(3072)")]
         public Vector? Embedding { get; set; }
         public List<VulnerabilityModel> Vulnerabilities { get; set; } = new();

--- a/Backend/SorobanSecurityPortalApi/Models/DbModels/VulnerabilityModel.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/DbModels/VulnerabilityModel.cs
@@ -24,6 +24,8 @@ namespace SorobanSecurityPortalApi.Models.DbModels
         public int LastActionBy { get; set; }
         public DateTime LastActionAt { get; set; }
         public string PicturesContainerGuid { get; set; } = "";
+        public bool IsHidden { get; set; }
+        public bool IsDeleted { get; set; }
         [Column(TypeName = "vector(3072)")]
         public Vector? Embedding { get; set; }
         public VulnerabilityCategory Category { get; set; } = VulnerabilityCategory.NA;

--- a/Backend/SorobanSecurityPortalApi/Models/Mapping/RatingModelProfile.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/Mapping/RatingModelProfile.cs
@@ -9,6 +9,7 @@ namespace SorobanSecurityPortalApi.Models.Mapping
         public RatingModelProfile()
         {
             CreateMap<RatingModel, RatingViewModel>();
+            CreateMap<RatingModel, PublicRatingViewModel>();
 
             CreateMap<CreateRatingRequest, RatingModel>()
                 .ForMember(dest => dest.Id, opt => opt.Ignore())

--- a/Backend/SorobanSecurityPortalApi/Models/Mapping/UserProfileModelProfile.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/Mapping/UserProfileModelProfile.cs
@@ -16,6 +16,10 @@ namespace SorobanSecurityPortalApi.Models.Mapping
                 .ForMember(dest => dest.ConnectedAccounts,
                     opt => opt.MapFrom(src => src.Login.ConnectedAccounts));
 
+            CreateMap<UserProfileModel, PublicUserProfileViewModel>()
+                .ForMember(dest => dest.LoginId, opt => opt.MapFrom(src => src.LoginId))
+                .ForMember(dest => dest.ReputationScore, opt => opt.MapFrom(src => src.ReputationScore));
+
             CreateMap<UpdateUserProfileViewModel, UserProfileModel>()
                 .ForAllMembers(opts => opts.Condition((src, dest, srcMember) => srcMember != null));
         }

--- a/Backend/SorobanSecurityPortalApi/Models/ViewModels/ModerationViewModels.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/ViewModels/ModerationViewModels.cs
@@ -35,6 +35,13 @@ namespace SorobanSecurityPortalApi.Models.ViewModels
         public string Timestamp { get; set; } = string.Empty;
     }
 
+    public class ContentFlagDetailViewModel
+    {
+        public string Reason { get; set; } = string.Empty;
+        public string? Comment { get; set; }
+        public string CreatedAt { get; set; } = string.Empty;
+    }
+
     public class FlaggedContentViewModel
     {
         public string Id { get; set; } = string.Empty;
@@ -45,6 +52,8 @@ namespace SorobanSecurityPortalApi.Models.ViewModels
         public ModerationAuthorViewModel Author { get; set; } = new();
         public int FlagCount { get; set; }
         public Dictionary<string, int> Reasons { get; set; } = new();
+        // The individual reports against this content — each flagger's reason + the note they wrote.
+        public List<ContentFlagDetailViewModel> Flags { get; set; } = new();
         public string FirstFlaggedAt { get; set; } = string.Empty;
         public string LastFlaggedAt { get; set; } = string.Empty;
         public string Status { get; set; } = string.Empty;

--- a/Backend/SorobanSecurityPortalApi/Models/ViewModels/ModerationViewModels.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/ViewModels/ModerationViewModels.cs
@@ -1,0 +1,61 @@
+namespace SorobanSecurityPortalApi.Models.ViewModels
+{
+    public class FlagContentRequest
+    {
+        public string ContentType { get; set; } = string.Empty;
+        public int ContentId { get; set; }
+        public string Reason { get; set; } = string.Empty;
+        public string? Comment { get; set; }
+    }
+
+    public class ModerationActionRequest
+    {
+        public string ContentType { get; set; } = string.Empty;
+        public int ContentId { get; set; }
+        public string Action { get; set; } = string.Empty;
+        public string? Reason { get; set; }
+    }
+
+    public class ModerationAuthorViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+        public int ReputationScore { get; set; }
+        public string? AvatarUrl { get; set; }
+    }
+
+    public class ModerationActionViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string ModeratorId { get; set; } = string.Empty;
+        public string ModeratorName { get; set; } = string.Empty;
+        public string Action { get; set; } = string.Empty;
+        public string? Reason { get; set; }
+        public string Timestamp { get; set; } = string.Empty;
+    }
+
+    public class FlaggedContentViewModel
+    {
+        public string Id { get; set; } = string.Empty;
+        public string ContentType { get; set; } = string.Empty;
+        public string ContentId { get; set; } = string.Empty;
+        public string ContentPreview { get; set; } = string.Empty;
+        public string FullContent { get; set; } = string.Empty;
+        public ModerationAuthorViewModel Author { get; set; } = new();
+        public int FlagCount { get; set; }
+        public Dictionary<string, int> Reasons { get; set; } = new();
+        public string FirstFlaggedAt { get; set; } = string.Empty;
+        public string LastFlaggedAt { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;
+        public List<ModerationActionViewModel> ModerationHistory { get; set; } = new();
+    }
+
+    public class ModerationStatsViewModel
+    {
+        public int QueueSize { get; set; }
+        public int ActionsToday { get; set; }
+        public int ActionsThisWeek { get; set; }
+        public int ActionsThisMonth { get; set; }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Models/ViewModels/PublicUserProfileViewModel.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/ViewModels/PublicUserProfileViewModel.cs
@@ -1,0 +1,12 @@
+namespace SorobanSecurityPortalApi.Models.ViewModels
+{
+    public class PublicUserProfileViewModel
+    {
+        public int LoginId { get; set; }
+        public string? Bio { get; set; }
+        public string? Location { get; set; }
+        public string? Website { get; set; }
+        public List<string> ExpertiseTags { get; set; } = new List<string>();
+        public int ReputationScore { get; set; }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Models/ViewModels/RatingViewModel.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/ViewModels/RatingViewModel.cs
@@ -15,6 +15,17 @@ namespace SorobanSecurityPortalApi.Models.ViewModels
         public DateTime CreatedAt { get; set; }
     }
 
+    // Public list DTO — no UserId to avoid exposing who-rated-what
+    public class PublicRatingViewModel
+    {
+        public int Id { get; set; }
+        public EntityType EntityType { get; set; }
+        public int EntityId { get; set; }
+        public int Score { get; set; }
+        public string Review { get; set; } = string.Empty;
+        public DateTime CreatedAt { get; set; }
+    }
+
     public class CreateRatingRequest
     {
         public EntityType EntityType { get; set; }

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ContentFilterService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ContentFilterService.cs
@@ -10,12 +10,16 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
 {
     public class ContentFilterService : IContentFilterService
     {
-        private readonly IHtmlSanitizer _sanitizer;
         private readonly ICacheAccessor _cacheAccessor;
         private readonly IModerationLogProcessor _moderationLogProcessor;
         private readonly IExtendedConfig _config;
         private readonly ILogger<ContentFilterService> _logger;
-        private readonly HashSet<string> _defaultProfanityWords;
+
+        // Profanity words are read from disk once and cached process-wide (the file never changes at runtime).
+        private static readonly Lazy<HashSet<string>> _sharedDefaultProfanityWords = new(LoadDefaultProfanityWordsStatic, LazyThreadSafetyMode.ExecutionAndPublication);
+
+        // Markdig pipeline is immutable and thread-safe once built, so it is shared.
+        private static readonly MarkdownPipeline MarkdownPipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().Build();
 
         private static readonly string[] AllowedTags = { "p", "br", "strong", "em", "code", "pre", "a", "ul", "ol", "li", "blockquote" };
         private static readonly Regex AnchorHrefRegex = new(@"<a\s+[^>]*href\s*=\s*[""']([^""']*)[""'][^>]*>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
@@ -35,76 +39,58 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             _moderationLogProcessor = moderationLogProcessor;
             _config = config;
             _logger = logger;
-
-            _sanitizer = new HtmlSanitizer();
-            ConfigureSanitizer();
-
-            _defaultProfanityWords = LoadDefaultProfanityWords();
         }
 
-        private HashSet<string> LoadDefaultProfanityWords()
+        private static HashSet<string> LoadDefaultProfanityWordsStatic()
         {
             try
             {
-                if (File.Exists(DefaultProfanityWordsFile))
+                // Resolve relative to the deployed assembly, not the (possibly different) process CWD.
+                var path = Path.Combine(AppContext.BaseDirectory, DefaultProfanityWordsFile);
+                if (File.Exists(path))
                 {
-                    var words = File.ReadAllLines(DefaultProfanityWordsFile)
+                    return File.ReadAllLines(path)
                         .Select(w => w.Trim().ToLowerInvariant())
                         .Where(w => !string.IsNullOrWhiteSpace(w))
                         .ToHashSet();
-
-                    _logger.LogInformation("Loaded {Count} default profanity words", words.Count);
-                    return words;
                 }
-                else
-                {
-                    _logger.LogWarning("Default profanity words file not found at {Path}", DefaultProfanityWordsFile);
-                    return new HashSet<string>();
-                }
+                return new HashSet<string>();
             }
-            catch (Exception ex)
+            catch
             {
-                _logger.LogError(ex, "Failed to load default profanity words");
                 return new HashSet<string>();
             }
         }
 
-        public HashSet<string> GetDefaultProfanityWords() => _defaultProfanityWords;
+        // Ganss HtmlSanitizer is not safe for concurrent Sanitize() calls on a single instance, so a
+        // fresh (cheap) instance is built per call. Configuration is centralised here.
+        private static IHtmlSanitizer CreateSanitizerInstance()
+        {
+            var sanitizer = new HtmlSanitizer();
+            sanitizer.AllowedTags.Clear();
+            foreach (var tag in AllowedTags)
+            {
+                sanitizer.AllowedTags.Add(tag);
+            }
+            sanitizer.AllowedAttributes.Clear();
+            sanitizer.AllowedAttributes.Add("href");
+            sanitizer.AllowedAttributes.Add("class");
+            sanitizer.AllowedSchemes.Clear();
+            sanitizer.AllowedSchemes.Add("http");
+            sanitizer.AllowedSchemes.Add("https");
+            return sanitizer;
+        }
+
+        public HashSet<string> GetDefaultProfanityWords() => _sharedDefaultProfanityWords.Value;
 
         public HashSet<string> GetAllProfanityWords()
         {
-            var allWords = new HashSet<string>(_defaultProfanityWords, StringComparer.OrdinalIgnoreCase);
+            var allWords = new HashSet<string>(_sharedDefaultProfanityWords.Value, StringComparer.OrdinalIgnoreCase);
             foreach (var word in _config.ProfanityWords)
             {
                 allWords.Add(word.ToLowerInvariant());
             }
             return allWords;
-        }
-
-        private void ConfigureSanitizer()
-        {
-            _sanitizer.AllowedTags.Clear();
-            foreach (var tag in AllowedTags)
-            {
-                _sanitizer.AllowedTags.Add(tag);
-            }
-
-            _sanitizer.AllowedAttributes.Clear();
-            _sanitizer.AllowedAttributes.Add("href");
-            _sanitizer.AllowedAttributes.Add("class");
-
-            _sanitizer.AllowedSchemes.Clear();
-            _sanitizer.AllowedSchemes.Add("http");
-            _sanitizer.AllowedSchemes.Add("https");
-
-            _sanitizer.RemovingAttribute += (sender, args) =>
-            {
-                if (args.Attribute.Name.StartsWith("on", StringComparison.OrdinalIgnoreCase))
-                {
-                    args.Cancel = false;
-                    _logger.LogWarning("Removed dangerous attribute: {AttributeName}", args.Attribute.Name);
-                }
-            };
         }
 
         public async Task<ContentFilterResult> FilterContentAsync(string content, int userId)
@@ -120,9 +106,10 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
                 return result;
             }
 
-            var markdownHtml = Markdown.ToHtml(content, new MarkdownPipelineBuilder().UseAdvancedExtensions().Build());
+            var markdownHtml = Markdown.ToHtml(content, MarkdownPipeline);
 
-            var sanitizedHtml = _sanitizer.Sanitize(markdownHtml);
+            // Per-call sanitizer instance — HtmlSanitizer is not concurrency-safe (see CreateSanitizerInstance).
+            var sanitizedHtml = CreateSanitizerInstance().Sanitize(markdownHtml);
 
             result.SanitizedContent = sanitizedHtml;
 
@@ -162,13 +149,13 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
                 {
                     var lowerContent = content.ToLowerInvariant();
                     var foundProfanity = allWords
-                        .Where(word => lowerContent.Contains(word))
+                        .Where(word => Regex.IsMatch(lowerContent, $@"\b{Regex.Escape(word)}\b", RegexOptions.IgnoreCase))
                         .ToList();
 
                     if (foundProfanity.Any())
                     {
                         result.RequiresModeration = true;
-                        result.Warnings.Add($"Profanity detected: {string.Join(", ", foundProfanity)}");
+                        result.Warnings.Add($"Profanity detected: {foundProfanity.Count} word(s) matched");
                         _logger.LogWarning("Profanity detected in content from user");
                     }
                 }
@@ -282,32 +269,35 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             }
         }
 
-        public async Task<bool> CheckRateLimitAsync(int userId)
+        // Fixed-window rate limiter keyed by the current calendar minute (UTC). The bucket key name
+        // itself rolls over at each minute boundary, so the count resets every minute regardless of
+        // how many times the TTL is re-written, and a stale bucket key self-expires after its TTL.
+        // NOTE: ICacheAccessor wraps IDistributedCache, which exposes neither an atomic INCR nor the
+        // remaining TTL, so the read-then-write within a single minute is not atomic — concurrent
+        // requests in the same minute can over-count slightly. That residual race is acceptable here.
+        public Task<bool> CheckRateLimitAsync(int userId)
         {
-            var cacheKey = $"{RateLimitKeyPrefix}{userId}";
-            var currentCount = _cacheAccessor.GetCacheValue(cacheKey);
+            var bucket = DateTime.UtcNow.ToString("yyyyMMddHHmm");
+            var cacheKey = $"{RateLimitKeyPrefix}{userId}_{bucket}";
 
-            if (string.IsNullOrEmpty(currentCount))
+            var currentValue = _cacheAccessor.GetCacheValue(cacheKey);
+            var count = int.TryParse(currentValue, out var parsed) ? parsed : 0;
+
+            var newCount = count + 1;
+            // TTL of 120s comfortably outlives the 1-minute window so the bucket survives until it is
+            // no longer relevant, then self-expires.
+            _cacheAccessor.SetCacheValue(cacheKey, newCount.ToString(), 120);
+
+            if (newCount > RateLimitPerMinute)
             {
-                _cacheAccessor.SetCacheValue(cacheKey, "1", 60);
-                return true;
+                _logger.LogWarning("Rate limit exceeded for user {UserId}: {Count} attempts", userId, newCount);
+                return Task.FromResult(false);
             }
 
-            if (int.TryParse(currentCount, out var count))
-            {
-                if (count >= RateLimitPerMinute)
-                {
-                    _logger.LogWarning("Rate limit exceeded for user {UserId}: {Count} attempts", userId, count);
-                    return false;
-                }
-
-                _cacheAccessor.SetCacheValue(cacheKey, (count + 1).ToString(), 60);
-                return true;
-            }
-
-            _cacheAccessor.SetCacheValue(cacheKey, "1", 60);
-            return true;
+            return Task.FromResult(true);
         }
+
+        private const int MaxStoredContentLength = 2000;
 
         private async Task LogModerationAsync(int userId, string originalContent, string sanitizedContent, string reason, ContentFilterResult result)
         {
@@ -316,7 +306,9 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
                 var log = new ModerationLogModel
                 {
                     UserId = userId,
-                    OriginalContent = originalContent,
+                    OriginalContent = originalContent.Length > MaxStoredContentLength
+                        ? originalContent[..MaxStoredContentLength]
+                        : originalContent,
                     SanitizedContent = sanitizedContent,
                     FilterReason = reason,
                     IsBlocked = result.IsBlocked,

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ContentFlagService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ContentFlagService.cs
@@ -13,6 +13,9 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
 
     public class ContentFlagService : IContentFlagService
     {
+        public const string ErrContentNotFound = "Content not found";
+        public const string ErrAlreadyFlagged = "Already flagged";
+
         private readonly IContentFlagProcessor _flags;
         private readonly IModerationTargetRegistry _registry;
         private readonly IUserContextAccessor _userContext;
@@ -40,12 +43,12 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
 
             var info = await target.Get(request.ContentId);
             if (info == null)
-                return new Result<bool, string>.Err("Content not found");
+                return new Result<bool, string>.Err(ErrContentNotFound);
 
             var userId = await _userContext.GetLoginIdAsync();
 
             if (await _flags.Exists(type, request.ContentId, userId))
-                return new Result<bool, string>.Err("Already flagged");
+                return new Result<bool, string>.Err(ErrAlreadyFlagged);
 
             await _flags.Add(new ContentFlagModel
             {

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ContentFlagService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ContentFlagService.cs
@@ -1,0 +1,63 @@
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Data.Processors;
+using SorobanSecurityPortalApi.Models.DbModels;
+using SorobanSecurityPortalApi.Models.ViewModels;
+using SorobanSecurityPortalApi.Services.Moderation;
+
+namespace SorobanSecurityPortalApi.Services.ControllersServices
+{
+    public interface IContentFlagService
+    {
+        Task<Result<bool, string>> Flag(FlagContentRequest request);
+    }
+
+    public class ContentFlagService : IContentFlagService
+    {
+        private readonly IContentFlagProcessor _flags;
+        private readonly IModerationTargetRegistry _registry;
+        private readonly IUserContextAccessor _userContext;
+
+        public ContentFlagService(
+            IContentFlagProcessor flags,
+            IModerationTargetRegistry registry,
+            IUserContextAccessor userContext)
+        {
+            _flags = flags;
+            _registry = registry;
+            _userContext = userContext;
+        }
+
+        public async Task<Result<bool, string>> Flag(FlagContentRequest request)
+        {
+            if (!ModerationParsing.TryContentType(request.ContentType, out var type))
+                return new Result<bool, string>.Err("Invalid content type");
+
+            if (!ModerationParsing.TryReason(request.Reason, out var reason))
+                return new Result<bool, string>.Err("Invalid reason");
+
+            if (!_registry.TryGet(type, out var target))
+                return new Result<bool, string>.Err("Invalid content type");
+
+            var info = await target.Get(request.ContentId);
+            if (info == null)
+                return new Result<bool, string>.Err("Content not found");
+
+            var userId = await _userContext.GetLoginIdAsync();
+
+            if (await _flags.Exists(type, request.ContentId, userId))
+                return new Result<bool, string>.Err("Already flagged");
+
+            await _flags.Add(new ContentFlagModel
+            {
+                ContentType = type,
+                ContentId = request.ContentId,
+                FlaggedByUserId = userId,
+                Reason = reason,
+                Comment = request.Comment,
+                CreatedAt = DateTime.UtcNow
+            });
+
+            return new Result<bool, string>.Ok(true);
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ModerationService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ModerationService.cs
@@ -160,6 +160,15 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
                         .ToDictionary(
                             g => ModerationParsing.ReasonString(g.Key),
                             g => g.Count()),
+                    Flags = group
+                        .OrderByDescending(f => f.CreatedAt)
+                        .Select(f => new ContentFlagDetailViewModel
+                        {
+                            Reason = ModerationParsing.ReasonString(f.Reason),
+                            Comment = f.Comment,
+                            CreatedAt = f.CreatedAt.ToString("o")
+                        })
+                        .ToList(),
                     FirstFlaggedAt = group.Min(f => f.CreatedAt).ToString("o"),
                     LastFlaggedAt = item.MaxFlagDate.ToString("o"),
                     Status = item.Status,

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ModerationService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ModerationService.cs
@@ -1,0 +1,259 @@
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Data.Processors;
+using SorobanSecurityPortalApi.Models.DbModels;
+using SorobanSecurityPortalApi.Models.ViewModels;
+using SorobanSecurityPortalApi.Services.Moderation;
+
+namespace SorobanSecurityPortalApi.Services.ControllersServices
+{
+    public interface IModerationService
+    {
+        Task<List<FlaggedContentViewModel>> GetQueue(string? status, string? contentType, int page, int pageSize = 20);
+        Task<Result<bool, string>> TakeAction(ModerationActionRequest request);
+        Task<ModerationStatsViewModel> GetStats();
+    }
+
+    public class ModerationService : IModerationService
+    {
+        private readonly IContentFlagProcessor _flagProcessor;
+        private readonly IModerationActionProcessor _actionProcessor;
+        private readonly IModerationTargetRegistry _registry;
+        private readonly IUserContextAccessor _userContext;
+        private readonly ILoginProcessor _loginProcessor;
+        private readonly IUserProfileProcessor _userProfileProcessor;
+
+        public ModerationService(
+            IContentFlagProcessor flagProcessor,
+            IModerationActionProcessor actionProcessor,
+            IModerationTargetRegistry registry,
+            IUserContextAccessor userContext,
+            ILoginProcessor loginProcessor,
+            IUserProfileProcessor userProfileProcessor)
+        {
+            _flagProcessor = flagProcessor;
+            _actionProcessor = actionProcessor;
+            _registry = registry;
+            _userContext = userContext;
+            _loginProcessor = loginProcessor;
+            _userProfileProcessor = userProfileProcessor;
+        }
+
+        public async Task<List<FlaggedContentViewModel>> GetQueue(string? status, string? contentType, int page, int pageSize = 20)
+        {
+            page = Math.Max(1, page);
+            pageSize = Math.Max(1, Math.Min(100, pageSize));
+
+            var queue = await BuildQueue(status, contentType);
+
+            return queue
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToList();
+        }
+
+        // Builds the full aggregated + filtered + ordered queue WITHOUT pagination.
+        // Pagination is applied by GetQueue; GetStats uses this directly so QueueSize is never capped.
+        private async Task<List<FlaggedContentViewModel>> BuildQueue(string? status, string? contentType)
+        {
+            var allFlags = await _flagProcessor.GetAll();
+            var allActions = await _actionProcessor.GetAll();
+
+            // Group flags by (ContentType, ContentId)
+            var flagGroups = allFlags
+                .GroupBy(f => (f.ContentType, f.ContentId))
+                .ToList();
+
+            // Pass 1: resolve each group's content info and the actions that apply to it,
+            // skipping groups whose content is missing/unresolvable. Defer author/moderator
+            // lookups so we can batch them (no per-item DB calls).
+            var items = new List<(
+                (ModeratedContentType ContentType, int ContentId) Key,
+                ModerationTargetInfo Info,
+                IGrouping<(ModeratedContentType, int), ContentFlagModel> Group,
+                List<ModerationActionModel> Actions,
+                DateTime MaxFlagDate,
+                string Status)>();
+
+            foreach (var group in flagGroups)
+            {
+                var key = group.Key;
+
+                if (!_registry.TryGet(key.ContentType, out var target))
+                    continue;
+
+                var info = await target.Get(key.ContentId);
+                if (info == null)
+                    continue;
+
+                // Last action for this content item
+                var actionsForKey = allActions
+                    .Where(a => a.ContentType == key.ContentType && a.ContentId == key.ContentId)
+                    .OrderBy(a => a.CreatedAt)
+                    .ToList();
+
+                var lastAction = actionsForKey.Count > 0 ? actionsForKey[actionsForKey.Count - 1] : null;
+                var maxFlagDate = group.Max(f => f.CreatedAt);
+
+                // Re-queue: if a flag is newer than the last action, treat as pending again
+                string itemStatus;
+                if (lastAction == null || maxFlagDate > lastAction.CreatedAt)
+                    itemStatus = "pending";
+                else
+                    itemStatus = ModerationParsing.ActionToStatus(lastAction.Action);
+
+                items.Add((key, info, group, actionsForKey, maxFlagDate, itemStatus));
+            }
+
+            // Collect every login id we need: content authors PLUS every moderator referenced
+            // in the actions. Look each distinct id up exactly once.
+            var authorIds = items.Select(i => i.Info.AuthorUserId).ToHashSet();
+            var moderatorIds = items.SelectMany(i => i.Actions.Select(a => a.ModeratorId)).ToHashSet();
+            var allLoginIds = new HashSet<int>(authorIds);
+            allLoginIds.UnionWith(moderatorIds);
+
+            var loginDict = new Dictionary<int, LoginModel?>();
+            foreach (var id in allLoginIds)
+                loginDict[id] = await _loginProcessor.GetById(id);
+
+            var reputationDict = new Dictionary<int, int>();
+            foreach (var id in authorIds)
+            {
+                var profile = await _userProfileProcessor.GetByLoginIdAsync(id);
+                reputationDict[id] = profile?.ReputationScore ?? 0;
+            }
+
+            // Pass 2: build the view models from the in-memory dictionaries.
+            var result = new List<(FlaggedContentViewModel Vm, DateTime MaxFlagDate)>();
+
+            foreach (var item in items)
+            {
+                var key = item.Key;
+                var info = item.Info;
+                var group = item.Group;
+
+                var authorLogin = loginDict.TryGetValue(info.AuthorUserId, out var al) ? al : null;
+                var authorName = authorLogin?.FullName ?? string.Empty;
+                var authorEmail = authorLogin?.Email ?? string.Empty;
+                var authorReputation = reputationDict.TryGetValue(info.AuthorUserId, out var rep) ? rep : 0;
+
+                var typeStr = ModerationParsing.ContentTypeString(key.ContentType);
+                var contentIdStr = key.ContentId.ToString();
+
+                var vm = new FlaggedContentViewModel
+                {
+                    Id = $"{typeStr}:{contentIdStr}",
+                    ContentType = typeStr,
+                    ContentId = contentIdStr,
+                    ContentPreview = info.Preview,
+                    FullContent = info.FullContent,
+                    Author = new ModerationAuthorViewModel
+                    {
+                        Id = info.AuthorUserId.ToString(),
+                        Name = authorName,
+                        Email = authorEmail,
+                        ReputationScore = authorReputation,
+                        AvatarUrl = null
+                    },
+                    FlagCount = group.Count(),
+                    Reasons = group
+                        .GroupBy(f => f.Reason)
+                        .ToDictionary(
+                            g => ModerationParsing.ReasonString(g.Key),
+                            g => g.Count()),
+                    FirstFlaggedAt = group.Min(f => f.CreatedAt).ToString("o"),
+                    LastFlaggedAt = item.MaxFlagDate.ToString("o"),
+                    Status = item.Status,
+                    ModerationHistory = item.Actions
+                        .Select(a => new ModerationActionViewModel
+                        {
+                            Id = a.Id.ToString(),
+                            ModeratorId = a.ModeratorId.ToString(),
+                            ModeratorName = loginDict.TryGetValue(a.ModeratorId, out var l) && l != null ? l.FullName : string.Empty,
+                            Action = ModerationParsing.ActionToStatus(a.Action),
+                            Reason = a.Reason,
+                            Timestamp = a.CreatedAt.ToString("o")
+                        })
+                        .ToList()
+                };
+
+                result.Add((vm, item.MaxFlagDate));
+            }
+
+            var filtered = result.AsEnumerable();
+
+            // Apply status filter
+            if (!string.IsNullOrEmpty(status))
+                filtered = filtered.Where(r => r.Vm.Status == status);
+
+            // Apply content type filter
+            if (!string.IsNullOrEmpty(contentType))
+                filtered = filtered.Where(r => r.Vm.ContentType == contentType);
+
+            // Order by last flagged descending using the raw DateTime (not the ISO string,
+            // which avoids lexicographic-sort fragility). Pagination is applied by the caller.
+            return filtered
+                .OrderByDescending(r => r.MaxFlagDate)
+                .Select(r => r.Vm)
+                .ToList();
+        }
+
+        public async Task<Result<bool, string>> TakeAction(ModerationActionRequest request)
+        {
+            if (!ModerationParsing.TryContentType(request.ContentType, out var type))
+                return new Result<bool, string>.Err("Invalid content type");
+
+            if (!ModerationParsing.TryAction(request.Action, out var action))
+                return new Result<bool, string>.Err("Invalid action");
+
+            if ((action == ModerationActionType.Hide || action == ModerationActionType.Delete)
+                && string.IsNullOrWhiteSpace(request.Reason))
+                return new Result<bool, string>.Err("Reason is required for hide/delete");
+
+            if (!_registry.TryGet(type, out var target))
+                return new Result<bool, string>.Err("Invalid content type");
+
+            var moderatorId = await _userContext.GetLoginIdAsync();
+
+            // Not transactional, but ordered: apply the content side-effect FIRST, then record
+            // the action. If the side-effect throws, no phantom moderation_action is persisted.
+            switch (action)
+            {
+                case ModerationActionType.Approve:
+                    await target.Restore(request.ContentId);
+                    break;
+                case ModerationActionType.Hide:
+                    await target.Hide(request.ContentId);
+                    break;
+                case ModerationActionType.Delete:
+                    await target.SoftDelete(request.ContentId);
+                    break;
+            }
+
+            await _actionProcessor.Add(new ModerationActionModel
+            {
+                ContentType = type,
+                ContentId = request.ContentId,
+                ModeratorId = moderatorId,
+                Action = action,
+                Reason = request.Reason,
+                CreatedAt = DateTime.UtcNow
+            });
+
+            return new Result<bool, string>.Ok(true);
+        }
+
+        public async Task<ModerationStatsViewModel> GetStats()
+        {
+            var pending = await BuildQueue("pending", null);
+            var now = DateTime.UtcNow;
+
+            return new ModerationStatsViewModel
+            {
+                QueueSize = pending.Count,
+                ActionsToday = await _actionProcessor.CountSince(now.Date),
+                ActionsThisWeek = await _actionProcessor.CountSince(now.Date.AddDays(-7)),
+                ActionsThisMonth = await _actionProcessor.CountSince(now.Date.AddMonths(-1))
+            };
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/RatingService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/RatingService.cs
@@ -16,7 +16,7 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
     public interface IRatingService
     {
         Task<RatingSummaryViewModel> GetSummary(EntityType entityType, int entityId);
-        Task<List<RatingViewModel>> GetRatings(EntityType entityType, int entityId, int page, int pageSize = 10);
+        Task<List<PublicRatingViewModel>> GetRatings(EntityType entityType, int entityId, int page, int pageSize = 10);
         Task<RatingViewModel> AddOrUpdateRating(CreateRatingRequest request);
         Task DeleteRating(int id);
     }
@@ -81,8 +81,11 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             return summary;
         }
 
-        public async Task<List<RatingViewModel>> GetRatings(EntityType entityType, int entityId, int page, int pageSize = 10)
+        public async Task<List<PublicRatingViewModel>> GetRatings(EntityType entityType, int entityId, int page, int pageSize = 10)
         {
+            page = Math.Max(1, page);
+            pageSize = Math.Max(1, Math.Min(100, pageSize));
+
             var query = _db.Rating
                 .AsNoTracking()
                 .Where(r => r.EntityType == entityType && r.EntityId == entityId)
@@ -93,7 +96,7 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
                 .Take(pageSize)
                 .ToListAsync();
 
-            return _mapper.Map<List<RatingViewModel>>(ratings);
+            return _mapper.Map<List<PublicRatingViewModel>>(ratings);
         }
 
         public async Task<RatingViewModel> AddOrUpdateRating(CreateRatingRequest request)

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ReportService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ReportService.cs
@@ -49,6 +49,17 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             return reportViewModel;
         }
 
+        // Public detail/image path: excludes hidden/soft-deleted reports. Returns null when the
+        // report is missing/hidden/deleted so the controller can return NotFound. The unfiltered
+        // Get above is kept for the /download path (which has its own Approved check) and moderator flows.
+        public async Task<ReportViewModel?> GetPublic(int reportId)
+        {
+            var reportModel = await _reportProcessor.GetPublic(reportId);
+            if (reportModel == null)
+                return null;
+            return _mapper.Map<ReportViewModel>(reportModel);
+        }
+
         //TODO UI should send Protocol and Auditor as Ids, not names. Then need to update the mapping used at the line 55
         public async Task<ReportViewModel> Add(ReportViewModel reportViewModel)
         {
@@ -147,6 +158,7 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
     {
         Task<List<ReportViewModel>> Search(ReportSearchViewModel? reportSearch);
         Task<ReportViewModel> Get(int reportId);
+        Task<ReportViewModel?> GetPublic(int reportId);
         Task<ReportViewModel> Add(ReportViewModel report);
         Task<ReportViewModel> Update(ReportViewModel report);
         Task<Result<bool, string>> Approve(int reportId);

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/UserProfileService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/UserProfileService.cs
@@ -1,4 +1,5 @@
 using AutoMapper;
+using SorobanSecurityPortalApi.Common;
 using SorobanSecurityPortalApi.Data.Processors;
 using SorobanSecurityPortalApi.Models.DbModels;
 using SorobanSecurityPortalApi.Models.ViewModels;
@@ -16,10 +17,10 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             _mapper = mapper;
         }
 
-        public async Task<UserProfileViewModel?> GetProfileByUserIdAsync(int userId)
+        public async Task<PublicUserProfileViewModel?> GetPublicProfileByLoginIdAsync(int loginId)
         {
-            var profile = await _processor.GetByIdAsync(userId);
-            return profile != null ? _mapper.Map<UserProfileViewModel>(profile) : null;
+            var profile = await _processor.GetByLoginIdAsync(loginId);
+            return profile != null ? _mapper.Map<PublicUserProfileViewModel>(profile) : null;
         }
 
         public async Task<UserProfileViewModel?> GetProfileByLoginIdAsync(int loginId)
@@ -28,8 +29,12 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             return profile != null ? _mapper.Map<UserProfileViewModel>(profile) : null;
         }
 
-        public async Task<UserProfileViewModel> CreateProfileAsync(int loginId, UpdateUserProfileViewModel profileDto)
+        public async Task<Result<UserProfileViewModel, string>> CreateProfileAsync(int loginId, UpdateUserProfileViewModel profileDto)
         {
+            var validationError = ValidateProfileDto(profileDto);
+            if (validationError != null)
+                return new Result<UserProfileViewModel, string>.Err(validationError);
+
             if (await _processor.ExistsAsync(loginId))
             {
                 throw new InvalidOperationException("Profile already exists for this user");
@@ -45,25 +50,33 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
                 ReputationScore = 0
             };
 
-            var createdProfile = await _processor.CreateAsync(profile);
-            return _mapper.Map<UserProfileViewModel>(createdProfile);
+            await _processor.CreateAsync(profile);
+
+            // Re-fetch with Login navigation so Email/FullName are populated in the response
+            var createdProfile = await _processor.GetByLoginIdAsync(loginId);
+            return new Result<UserProfileViewModel, string>.Ok(_mapper.Map<UserProfileViewModel>(createdProfile));
         }
 
-        public async Task<UserProfileViewModel> UpdateProfileAsync(int loginId, UpdateUserProfileViewModel profileDto)
+        public async Task<Result<UserProfileViewModel, string>> UpdateProfileAsync(int loginId, UpdateUserProfileViewModel profileDto)
         {
+            var validationError = ValidateProfileDto(profileDto);
+            if (validationError != null)
+                return new Result<UserProfileViewModel, string>.Err(validationError);
+
             var existingProfile = await _processor.GetByLoginIdAsync(loginId);
             if (existingProfile == null)
             {
                 throw new InvalidOperationException("Profile not found");
             }
 
-            if (profileDto.Bio != null) existingProfile.Bio = profileDto.Bio;
-            if (profileDto.Location != null) existingProfile.Location = profileDto.Location;
-            if (profileDto.Website != null) existingProfile.Website = profileDto.Website;
-            if (profileDto.ExpertiseTags != null) existingProfile.ExpertiseTags = profileDto.ExpertiseTags;
+            // PUT semantics: assign every field unconditionally so callers can clear fields
+            existingProfile.Bio = profileDto.Bio;
+            existingProfile.Location = profileDto.Location;
+            existingProfile.Website = profileDto.Website;
+            existingProfile.ExpertiseTags = profileDto.ExpertiseTags ?? new List<string>();
 
             var updatedProfile = await _processor.UpdateAsync(existingProfile);
-            return _mapper.Map<UserProfileViewModel>(updatedProfile);
+            return new Result<UserProfileViewModel, string>.Ok(_mapper.Map<UserProfileViewModel>(updatedProfile));
         }
 
         public async Task DeleteProfileAsync(int loginId)
@@ -74,14 +87,35 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
                 await _processor.DeleteAsync(profile.Id);
             }
         }
+
+        private static string? ValidateProfileDto(UpdateUserProfileViewModel dto)
+        {
+            if (dto.Bio != null && dto.Bio.Length > 500)
+                return "Bio must not exceed 500 characters.";
+
+            if (dto.Location != null && dto.Location.Length > 100)
+                return "Location must not exceed 100 characters.";
+
+            if (dto.Website != null && dto.Website.Length > 200)
+                return "Website must not exceed 200 characters.";
+
+            if (!string.IsNullOrEmpty(dto.Website) &&
+                (!Uri.TryCreate(dto.Website, UriKind.Absolute, out var uri)
+                 || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)))
+            {
+                return "Website must be an absolute http or https URL.";
+            }
+
+            return null;
+        }
     }
 
     public interface IUserProfileService
     {
-        Task<UserProfileViewModel?> GetProfileByUserIdAsync(int userId);
+        Task<PublicUserProfileViewModel?> GetPublicProfileByLoginIdAsync(int loginId);
         Task<UserProfileViewModel?> GetProfileByLoginIdAsync(int loginId);
-        Task<UserProfileViewModel> CreateProfileAsync(int loginId, UpdateUserProfileViewModel profileDto);
-        Task<UserProfileViewModel> UpdateProfileAsync(int loginId, UpdateUserProfileViewModel profileDto);
+        Task<Result<UserProfileViewModel, string>> CreateProfileAsync(int loginId, UpdateUserProfileViewModel profileDto);
+        Task<Result<UserProfileViewModel, string>> UpdateProfileAsync(int loginId, UpdateUserProfileViewModel profileDto);
         Task DeleteProfileAsync(int loginId);
     }
 }

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/VulnerabilitiesService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/VulnerabilitiesService.cs
@@ -15,6 +15,7 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
         private readonly IFileProcessor _fileProcessor;
         private readonly IGeminiEmbeddingService _embeddingService;
         private readonly UserContextAccessor _userContextAccessor;
+        private readonly IContentFilterService _contentFilter;
 
         public VulnerabilityService(
             IMapper mapper,
@@ -22,7 +23,8 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             IReportProcessor reportProcessor,
             IFileProcessor fileProcessor,
             IGeminiEmbeddingService embeddingService,
-            UserContextAccessor userContextAccessor)
+            UserContextAccessor userContextAccessor,
+            IContentFilterService contentFilter)
         {
             _mapper = mapper;
             _vulnerabilityProcessor = vulnerabilityProcessor;
@@ -30,6 +32,7 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             _fileProcessor = fileProcessor;
             _embeddingService = embeddingService;
             _userContextAccessor = userContextAccessor;
+            _contentFilter = contentFilter;
         }
 
         public async Task<List<IdValue>> ListSeverities()
@@ -92,9 +95,32 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             return await _vulnerabilityProcessor.SearchTotal(_mapper.Map<Models.DbModels.VulnerabilitySearchModel>(vulnerabilitySearchModel));
         }
 
-        public async Task<VulnerabilityViewModel> Add(VulnerabilityViewModel vulnerabilityViewModel, List<FileViewModel> files)
+        public async Task<Result<VulnerabilityViewModel, string>> Add(VulnerabilityViewModel vulnerabilityViewModel, List<FileViewModel> files)
         {
             var loginId = await _userContextAccessor.GetLoginIdAsync();
+
+            // Rate-limit check always runs (independent of whether there is text to filter).
+            if (!await _contentFilter.CheckRateLimitAsync(loginId))
+                return new Result<VulnerabilityViewModel, string>.Err("Rate limit exceeded. Please wait before submitting again.");
+
+            // I-3: an empty Description was valid before this PR (no [Required]), and the filter blocks
+            // empty content. Only run the content filter when there is actual text to inspect.
+            if (!string.IsNullOrWhiteSpace(vulnerabilityViewModel.Description))
+            {
+                var filterResult = await _contentFilter.FilterContentAsync(vulnerabilityViewModel.Description, loginId);
+
+                // Only IsBlocked rejects the submission. I-1: RequiresModeration results are recorded in the
+                // moderation log inside FilterContentAsync but are intentionally NOT hard-blocked here.
+                if (filterResult.IsBlocked)
+                    return new Result<VulnerabilityViewModel, string>.Err(
+                        $"Submission blocked: {string.Join("; ", filterResult.Warnings)}");
+
+                // I-2: Description is stored and rendered as MARKDOWN (UI uses ReactMarkdown via MarkdownView).
+                // FilterContentAsync.SanitizedContent is HTML (Markdown.ToHtml -> sanitized), so overwriting
+                // would corrupt the markdown round-trip (double render / raw HTML in the editor). We therefore
+                // run the filter for its protective effects only and persist the ORIGINAL markdown unchanged.
+            }
+
             foreach (var file in files)
             {
                 if (file.BinFile != null && file.BinFile.Length > 0)
@@ -109,7 +135,7 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             var vulnerabilityModel = _mapper.Map<Models.DbModels.VulnerabilityModel>(vulnerabilityViewModel);
             vulnerabilityModel.CreatedBy = loginId;
             var addedVulnerability = await _vulnerabilityProcessor.Add(vulnerabilityModel);
-            return _mapper.Map<VulnerabilityViewModel>(addedVulnerability);
+            return new Result<VulnerabilityViewModel, string>.Ok(_mapper.Map<VulnerabilityViewModel>(addedVulnerability));
         }
 
         public async Task<Result<bool, string>> Approve(int vulnerabilityId)
@@ -215,7 +241,7 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
         Task<List<IdValueUrl>> ListSources();
         Task<List<VulnerabilityViewModel>> Search(VulnerabilitySearchViewModel? vulnerabilitySearch);
         Task<int> SearchTotal(VulnerabilitySearchViewModel? vulnerabilitySearch);
-        Task<VulnerabilityViewModel> Add(VulnerabilityViewModel vulnerability, List<FileViewModel> files);
+        Task<Result<VulnerabilityViewModel, string>> Add(VulnerabilityViewModel vulnerability, List<FileViewModel> files);
         Task<Result<bool, string>> Approve(int vulnerabilityId);
         Task<Result<bool, string>> Reject(int vulnerabilityId);
         Task Remove(int vulnerabilityId);

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/VulnerabilitiesService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/VulnerabilitiesService.cs
@@ -167,9 +167,11 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             await _vulnerabilityProcessor.Remove(vulnerabilityId);
         }
 
+        // Public detail endpoint (anonymous GET /{vulnerabilityId}). Must not serve hidden/soft-deleted
+        // content, so it goes through GetPublic. Approve/Reject use the unfiltered processor.Get directly.
         public async Task<VulnerabilityViewModel> Get(int vulnerabilityId)
         {
-            var vulnerability = await _vulnerabilityProcessor.Get(vulnerabilityId);
+            var vulnerability = await _vulnerabilityProcessor.GetPublic(vulnerabilityId);
             return _mapper.Map<VulnerabilityViewModel>(vulnerability);
         }
 

--- a/Backend/SorobanSecurityPortalApi/Services/Moderation/IModerationTarget.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/Moderation/IModerationTarget.cs
@@ -1,0 +1,16 @@
+using SorobanSecurityPortalApi.Models.DbModels;
+
+namespace SorobanSecurityPortalApi.Services.Moderation
+{
+    public interface IModerationTarget
+    {
+        ModeratedContentType ContentType { get; }
+        Task<ModerationTargetInfo?> Get(int contentId);
+        Task Hide(int contentId);
+        /// <summary>
+        /// Clears all moderation suppression (hidden + soft-deleted) so the content is publicly visible again. Used by the "approve" action.
+        /// </summary>
+        Task Restore(int contentId);
+        Task SoftDelete(int contentId);
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Services/Moderation/IModerationTargetRegistry.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/Moderation/IModerationTargetRegistry.cs
@@ -1,0 +1,10 @@
+using SorobanSecurityPortalApi.Models.DbModels;
+
+namespace SorobanSecurityPortalApi.Services.Moderation
+{
+    public interface IModerationTargetRegistry
+    {
+        IModerationTarget Get(ModeratedContentType type);
+        bool TryGet(ModeratedContentType type, out IModerationTarget target);
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Services/Moderation/ModerationParsing.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/Moderation/ModerationParsing.cs
@@ -1,0 +1,36 @@
+using SorobanSecurityPortalApi.Models.DbModels;
+
+namespace SorobanSecurityPortalApi.Services.Moderation
+{
+    public static class ModerationParsing
+    {
+        public static bool TryContentType(string s, out ModeratedContentType t)
+        {
+            switch ((s ?? "").ToLowerInvariant())
+            {
+                case "vulnerability": t = ModeratedContentType.Vulnerability; return true;
+                case "report": t = ModeratedContentType.Report; return true;
+                default: t = default; return false;
+            }
+        }
+
+        public static string ContentTypeString(ModeratedContentType t)
+            => t == ModeratedContentType.Vulnerability ? "vulnerability" : "report";
+
+        public static bool TryReason(string s, out FlagReason r)
+            => Enum.TryParse(s, true, out r) && Enum.IsDefined(typeof(FlagReason), r);
+
+        public static string ReasonString(FlagReason r) => r.ToString().ToLowerInvariant();
+
+        public static bool TryAction(string s, out ModerationActionType a)
+            => Enum.TryParse(s, true, out a) && Enum.IsDefined(typeof(ModerationActionType), a);
+
+        public static string ActionToStatus(ModerationActionType a) => a switch
+        {
+            ModerationActionType.Approve => "approved",
+            ModerationActionType.Hide => "hidden",
+            ModerationActionType.Delete => "deleted",
+            _ => "pending"
+        };
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Services/Moderation/ModerationTargetInfo.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/Moderation/ModerationTargetInfo.cs
@@ -1,0 +1,11 @@
+namespace SorobanSecurityPortalApi.Services.Moderation
+{
+    public class ModerationTargetInfo
+    {
+        public string Preview { get; set; } = string.Empty;
+        public string FullContent { get; set; } = string.Empty;
+        public int AuthorUserId { get; set; }
+        public bool IsHidden { get; set; }
+        public bool IsDeleted { get; set; }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Services/Moderation/ModerationTargetRegistry.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/Moderation/ModerationTargetRegistry.cs
@@ -1,0 +1,17 @@
+using SorobanSecurityPortalApi.Models.DbModels;
+
+namespace SorobanSecurityPortalApi.Services.Moderation
+{
+    public class ModerationTargetRegistry : IModerationTargetRegistry
+    {
+        private readonly Dictionary<ModeratedContentType, IModerationTarget> _targets;
+
+        public ModerationTargetRegistry(IEnumerable<IModerationTarget> targets)
+            => _targets = targets.ToDictionary(t => t.ContentType);
+
+        public IModerationTarget Get(ModeratedContentType type) => _targets[type];
+
+        public bool TryGet(ModeratedContentType type, out IModerationTarget target)
+            => _targets.TryGetValue(type, out target!);
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Services/Moderation/ReportModerationTarget.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/Moderation/ReportModerationTarget.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using SorobanSecurityPortalApi.Common.Data;
+using SorobanSecurityPortalApi.Models.DbModels;
+
+namespace SorobanSecurityPortalApi.Services.Moderation
+{
+    public class ReportModerationTarget : IModerationTarget
+    {
+        private readonly IDbContextFactory<Db> _dbFactory;
+
+        public ReportModerationTarget(IDbContextFactory<Db> dbFactory) => _dbFactory = dbFactory;
+
+        public ModeratedContentType ContentType => ModeratedContentType.Report;
+
+        public async Task<ModerationTargetInfo?> Get(int contentId)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var r = await db.Report.AsNoTracking().FirstOrDefaultAsync(x => x.Id == contentId);
+            if (r == null) return null;
+            return new ModerationTargetInfo
+            {
+                Preview = r.Name,
+                FullContent = r.Name,
+                AuthorUserId = r.CreatedBy,
+                IsHidden = r.IsHidden,
+                IsDeleted = r.IsDeleted
+            };
+        }
+
+        public Task Hide(int contentId) => SetFlags(contentId, true, null);
+        public Task Restore(int contentId) => SetFlags(contentId, false, false);
+        public Task SoftDelete(int contentId) => SetFlags(contentId, null, true);
+
+        private async Task SetFlags(int contentId, bool? isHidden, bool? isDeleted)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var r = await db.Report.FirstOrDefaultAsync(x => x.Id == contentId);
+            if (r == null) return;
+            if (isHidden.HasValue) r.IsHidden = isHidden.Value;
+            if (isDeleted.HasValue) r.IsDeleted = isDeleted.Value;
+            await db.SaveChangesAsync();
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Services/Moderation/VulnerabilityModerationTarget.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/Moderation/VulnerabilityModerationTarget.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using SorobanSecurityPortalApi.Common.Data;
+using SorobanSecurityPortalApi.Models.DbModels;
+
+namespace SorobanSecurityPortalApi.Services.Moderation
+{
+    public class VulnerabilityModerationTarget : IModerationTarget
+    {
+        private readonly IDbContextFactory<Db> _dbFactory;
+
+        public VulnerabilityModerationTarget(IDbContextFactory<Db> dbFactory) => _dbFactory = dbFactory;
+
+        public ModeratedContentType ContentType => ModeratedContentType.Vulnerability;
+
+        public async Task<ModerationTargetInfo?> Get(int contentId)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var v = await db.Vulnerability.AsNoTracking().FirstOrDefaultAsync(x => x.Id == contentId);
+            if (v == null) return null;
+            return new ModerationTargetInfo
+            {
+                Preview = v.Title,
+                FullContent = string.IsNullOrEmpty(v.Description) ? v.Title : $"{v.Title}\n\n{v.Description}",
+                AuthorUserId = v.CreatedBy,
+                IsHidden = v.IsHidden,
+                IsDeleted = v.IsDeleted
+            };
+        }
+
+        public Task Hide(int contentId) => SetFlags(contentId, true, null);
+        public Task Restore(int contentId) => SetFlags(contentId, false, false);
+        public Task SoftDelete(int contentId) => SetFlags(contentId, null, true);
+
+        private async Task SetFlags(int contentId, bool? isHidden, bool? isDeleted)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var v = await db.Vulnerability.FirstOrDefaultAsync(x => x.Id == contentId);
+            if (v == null) return;
+            if (isHidden.HasValue) v.IsHidden = isHidden.Value;
+            if (isDeleted.HasValue) v.IsDeleted = isDeleted.Value;
+            await db.SaveChangesAsync();
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/SorobanSecurityPortalApi.csproj
+++ b/Backend/SorobanSecurityPortalApi/SorobanSecurityPortalApi.csproj
@@ -38,6 +38,16 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <!--
+      Microsoft.EntityFrameworkCore.Tools 10.0.7 has a broken transitive dependency that
+      pins Microsoft.EntityFrameworkCore.Design to 8.0.0, which is binary-incompatible with
+      the 10.0.4 EF Core runtime and makes `dotnet ef` throw MissingMethodException.
+      Reference Design explicitly at the runtime version to override the bad resolution.
+    -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.7" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />

--- a/Backend/SorobanSecurityPortalApi/Startup.cs
+++ b/Backend/SorobanSecurityPortalApi/Startup.cs
@@ -10,6 +10,7 @@ using SorobanSecurityPortalApi.Common.Data;
 using AspNetCore.Authentication.Basic;
 using Microsoft.OpenApi;
 using SorobanSecurityPortalApi.Services.ControllersServices;
+using SorobanSecurityPortalApi.Services.Moderation;
 
 namespace SorobanSecurityPortalApi;
 
@@ -53,6 +54,12 @@ public class Startup
         // Explicit Scoped registration before the convention scan so the scan skips IRatingService.
         // Scoped is correct: RatingService depends on Db (DbContext) which is Scoped.
         services.AddScoped<IRatingService, RatingService>();
+
+        // Moderation target resolvers registered before the convention scan so the scan skips them.
+        // Multiple IModerationTarget registrations are intentional: ModerationTargetRegistry collects all via IEnumerable<IModerationTarget>.
+        services.AddScoped<IModerationTarget, VulnerabilityModerationTarget>();
+        services.AddScoped<IModerationTarget, ReportModerationTarget>();
+        services.AddScoped<IModerationTargetRegistry, ModerationTargetRegistry>();
 
         services.ForInterfacesMatching("^I(?!.*Processor$).*")
             .OfAssemblies(Assembly.GetExecutingAssembly())

--- a/Backend/SorobanSecurityPortalApi/Startup.cs
+++ b/Backend/SorobanSecurityPortalApi/Startup.cs
@@ -50,11 +50,13 @@ public class Startup
         // construction are handled by static Lazy fields inside the service.
         services.AddSingleton<IContentFilterService, ContentFilterService>();
 
+        // Explicit Scoped registration before the convention scan so the scan skips IRatingService.
+        // Scoped is correct: RatingService depends on Db (DbContext) which is Scoped.
+        services.AddScoped<IRatingService, RatingService>();
+
         services.ForInterfacesMatching("^I(?!.*Processor$).*")
             .OfAssemblies(Assembly.GetExecutingAssembly())
             .AddTransients();
-
-        services.AddScoped<IRatingService, RatingService>();
 
         services.AddStackExchangeRedisCache(options =>
         {

--- a/Backend/SorobanSecurityPortalApi/Startup.cs
+++ b/Backend/SorobanSecurityPortalApi/Startup.cs
@@ -44,6 +44,12 @@ public class Startup
         services.ForInterfacesMatching("^I.*Processor$")
             .OfAssemblies(Assembly.GetExecutingAssembly())
             .AddScoped();
+        // ContentFilterService is registered before the convention scan so the scan skips it (sees it already registered).
+        // Singleton is safe: ModerationLogProcessor uses IDbContextFactory (creates its own DbContext per call),
+        // IExtendedConfig and ICacheAccessor are also singleton-safe. The expensive file I/O and sanitizer
+        // construction are handled by static Lazy fields inside the service.
+        services.AddSingleton<IContentFilterService, ContentFilterService>();
+
         services.ForInterfacesMatching("^I(?!.*Processor$).*")
             .OfAssemblies(Assembly.GetExecutingAssembly())
             .AddTransients();

--- a/Backend/SorobanSecurityPortalApi/appsettings.json
+++ b/Backend/SorobanSecurityPortalApi/appsettings.json
@@ -6,7 +6,7 @@
 		}
 	},
 	"AllowedHosts": "*",
-	"ProductVersion": "1.17",
+	"ProductVersion": "1.18",
 	"DbConnectionTimeout": 300,
 	"DbServer": "localhost",
 	"DbPort": 5449,

--- a/Backend/SorobanSecurityPortalApi/appsettings.json
+++ b/Backend/SorobanSecurityPortalApi/appsettings.json
@@ -6,7 +6,7 @@
 		}
 	},
 	"AllowedHosts": "*",
-	"ProductVersion": "1.16",
+	"ProductVersion": "1.17",
 	"DbConnectionTimeout": 300,
 	"DbServer": "localhost",
 	"DbPort": 5449,

--- a/UI/src/api/soroban-security-portal/models/badge.ts
+++ b/UI/src/api/soroban-security-portal/models/badge.ts
@@ -24,7 +24,7 @@ export interface Badge {
 }
 
 export interface UserBadge extends Badge {
-    awardedAt: Date;
+    awardedAt: string; // ISO date string from JSON API; parse with new Date(awardedAt) before display
     progress?: number; // 0-100 for in-progress badges
     isLocked?: boolean; // true if not yet earned
 }

--- a/UI/src/api/soroban-security-portal/soroban-security-portal-api.ts
+++ b/UI/src/api/soroban-security-portal/soroban-security-portal-api.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import RestApi from '../rest-api';
 import { UserItem, CreateUserItem, EditUserItem, SelfEditUserItem } from './models/user';
 import { SettingsItem } from './models/settings';
@@ -483,8 +484,18 @@ export const getBookmarkByIdCall = async (bookmarkId: number): Promise<Bookmark>
 
 // --- MODERATION ---
 export const flagContentCall = async (contentType: string, contentId: number, reason: string, comment?: string): Promise<boolean> => {
-    const client = await getRestClient();
-    const response = await client.request('api/v1/content-flags', 'POST', { contentType, contentId, reason, comment });
+    // Calls axios directly (bypassing RestApi) ONLY so the caller can read error.response.status —
+    // RestApi.request swallows the HTTP status, which the 409 "already reported" handling needs.
+    const authHeader = getAuthHeader();
+    const response = await axios.request({
+        url: `${environment.apiUrl}/api/v1/content-flags`,
+        method: 'POST',
+        data: { contentType, contentId, reason, comment },
+        headers: {
+            'Content-Type': 'application/json',
+            ...(authHeader ? { Authorization: authHeader } : {}),
+        },
+    });
     return response.data as boolean;
 };
 
@@ -529,11 +540,16 @@ const createEntityFormData = (dataFieldName: string, entityData: object, imageBa
     return formData;
 };
 
+// Builds the Authorization header value from the stored access token.
+// Single source of truth for the auth scheme used by all API calls.
+const getAuthHeader = (): string => {
+    const accessToken = getAccessToken();
+    return accessToken ? `Bearer ${accessToken}` : '';
+};
+
 // Rest client
 const getRestClient = async (): Promise<RestApi> => {
-    const accessToken = getAccessToken();
-    const authHeader = accessToken ? `Bearer ${accessToken}` : '';
-    const restClient = new RestApi(environment.apiUrl, authHeader);
+    const restClient = new RestApi(environment.apiUrl, getAuthHeader());
     return restClient;
 };
 

--- a/UI/src/api/soroban-security-portal/soroban-security-portal-api.ts
+++ b/UI/src/api/soroban-security-portal/soroban-security-portal-api.ts
@@ -12,6 +12,7 @@ import { ProtocolItem } from './models/protocol';
 import { TagItem } from './models/tag';
 import { CompanyItem } from './models/company';
 import { Bookmark, CreateBookmark } from './models/bookmark';
+import { FlaggedContent, ModerationStats } from '../../features/moderation/types';
 
 // --- TAGS ---
 export const getTagsCall = async (): Promise<TagItem[]> => {
@@ -478,6 +479,35 @@ export const getBookmarkByIdCall = async (bookmarkId: number): Promise<Bookmark>
     const client = await getRestClient();
     const response = await client.request(`api/v1/bookmarks/${bookmarkId}`, 'GET');
     return response.data as Bookmark;
+};
+
+// --- MODERATION ---
+export const flagContentCall = async (contentType: string, contentId: number, reason: string, comment?: string): Promise<boolean> => {
+    const client = await getRestClient();
+    const response = await client.request('api/v1/content-flags', 'POST', { contentType, contentId, reason, comment });
+    return response.data as boolean;
+};
+
+export const getModerationQueueCall = async (status?: string, contentType?: string, page = 1): Promise<FlaggedContent[]> => {
+    const client = await getRestClient();
+    const qs = new URLSearchParams();
+    if (status) qs.set('status', status);
+    if (contentType) qs.set('contentType', contentType);
+    qs.set('page', String(page));
+    const response = await client.request(`api/v1/moderation/queue?${qs.toString()}`, 'GET');
+    return response.data as FlaggedContent[];
+};
+
+export const takeModerationActionCall = async (contentType: string, contentId: number, action: string, reason?: string): Promise<boolean> => {
+    const client = await getRestClient();
+    const response = await client.request('api/v1/moderation/action', 'POST', { contentType, contentId, action, reason });
+    return response.data as boolean;
+};
+
+export const getModerationStatsCall = async (): Promise<ModerationStats> => {
+    const client = await getRestClient();
+    const response = await client.request('api/v1/moderation/stats', 'GET');
+    return response.data as ModerationStats;
 };
 
 // Helper function to create FormData for entity operations with image support

--- a/UI/src/components/BadgeIcon.tsx
+++ b/UI/src/components/BadgeIcon.tsx
@@ -1,4 +1,5 @@
 import { Tooltip, Box } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import { UserBadge, BadgeRarity } from '../api/soroban-security-portal/models/badge';
 import { format } from 'date-fns';
 
@@ -22,11 +23,18 @@ const sizeMap = {
 };
 
 export function BadgeIcon({ badge, size = 'medium', showTooltip = true }: BadgeIconProps) {
+    const theme = useTheme();
     const badgeSize = sizeMap[size];
     const isLocked = badge.isLocked || false;
 
+    // L-5: use badge.color when present, fall back to rarity-based color
+    const activeColor = badge.color || rarityColors[badge.rarity];
+
     const badgeElement = (
         <Box
+            role="img"
+            aria-label={`${badge.name}: ${badge.description}`}
+            tabIndex={0}
             sx={{
                 width: badgeSize,
                 height: badgeSize,
@@ -34,17 +42,20 @@ export function BadgeIcon({ badge, size = 'medium', showTooltip = true }: BadgeI
                 display: 'flex',
                 alignItems: 'center',
                 justifyContent: 'center',
-                backgroundColor: isLocked ? '#E0E0E0' : rarityColors[badge.rarity],
-                color: '#fff',
+                // M-3: locked bg uses theme token instead of hardcoded #E0E0E0
+                backgroundColor: isLocked ? theme.palette.action.disabledBackground : activeColor,
+                // Locked bg is a light gray; white text would be unreadable, so use a theme token.
+                // Earned badge has a colored circle bg where white reads well.
+                color: isLocked ? theme.palette.text.disabled : '#fff',
                 fontWeight: 'bold',
                 fontSize: badgeSize * 0.5,
-                boxShadow: isLocked ? 'none' : `0 2px 8px ${rarityColors[badge.rarity]}40`,
+                boxShadow: isLocked ? 'none' : `0 2px 8px ${activeColor}40`,
                 transition: 'transform 0.2s ease, box-shadow 0.2s ease',
                 cursor: 'pointer',
                 opacity: isLocked ? 0.5 : 1,
                 '&:hover': {
                     transform: isLocked ? 'none' : 'scale(1.1)',
-                    boxShadow: isLocked ? 'none' : `0 4px 12px ${rarityColors[badge.rarity]}60`,
+                    boxShadow: isLocked ? 'none' : `0 4px 12px ${activeColor}60`,
                 },
             }}
         >
@@ -61,12 +72,14 @@ export function BadgeIcon({ badge, size = 'medium', showTooltip = true }: BadgeI
             <Box sx={{ fontWeight: 'bold', mb: 0.5 }}>{badge.name}</Box>
             <Box sx={{ fontSize: '0.875rem', mb: 0.5 }}>{badge.description}</Box>
             {!badge.isLocked && (
-                <Box sx={{ fontSize: '0.75rem', color: '#B0B0B0', mt: 0.5 }}>
+                // M-3: replaced hardcoded #B0B0B0 with theme token
+                <Box sx={{ fontSize: '0.75rem', color: 'text.disabled', mt: 0.5 }}>
                     Awarded: {format(new Date(badge.awardedAt), 'MMM dd, yyyy')}
                 </Box>
             )}
             {badge.isLocked && badge.progress !== undefined && (
-                <Box sx={{ fontSize: '0.75rem', color: '#B0B0B0', mt: 0.5 }}>
+                // M-3: replaced hardcoded #B0B0B0 with theme token
+                <Box sx={{ fontSize: '0.75rem', color: 'text.disabled', mt: 0.5 }}>
                     Progress: {badge.progress}%
                 </Box>
             )}

--- a/UI/src/components/BadgeShowcase.tsx
+++ b/UI/src/components/BadgeShowcase.tsx
@@ -32,12 +32,13 @@ export function BadgeShowcase({ badges }: BadgeShowcaseProps) {
             </Typography>
 
             <Box sx={{ mb: 3 }}>
+                {/* L-6: denominator uses filteredBadges.length (respects category filter) */}
                 <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                    {earnedBadges.length} / {badges.length} Badges Earned
+                    {earnedBadges.length} / {filteredBadges.length} Badges Earned
                 </Typography>
                 <LinearProgress
                     variant="determinate"
-                    value={badges.length > 0 ? (earnedBadges.length / badges.length) * 100 : 0}
+                    value={filteredBadges.length > 0 ? (earnedBadges.length / filteredBadges.length) * 100 : 0}
                     sx={{ height: 8, borderRadius: 4 }}
                 />
             </Box>
@@ -120,9 +121,10 @@ export function BadgeShowcase({ badges }: BadgeShowcaseProps) {
                                 }}
                             >
                                 <BadgeIcon badge={badge} size="large" />
+                                {/* M-3: replaced hardcoded #999 with theme token */}
                                 <Typography
                                     variant="body2"
-                                    sx={{ fontWeight: 'bold', textAlign: 'center', color: '#999' }}
+                                    sx={{ fontWeight: 'bold', textAlign: 'center', color: 'text.disabled' }}
                                 >
                                     {badge.name}
                                 </Typography>

--- a/UI/src/components/FlagButton.tsx
+++ b/UI/src/components/FlagButton.tsx
@@ -1,0 +1,143 @@
+import { FC, useState } from 'react';
+import {
+    IconButton,
+    Tooltip,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    Select,
+    MenuItem,
+    TextField,
+    FormControl,
+    InputLabel,
+    Stack,
+    SelectChangeEvent,
+} from '@mui/material';
+import OutlinedFlagIcon from '@mui/icons-material/OutlinedFlag';
+import FlagIcon from '@mui/icons-material/Flag';
+import { flagContentCall } from '../api/soroban-security-portal/soroban-security-portal-api';
+import { showError } from '../features/dialog-handler/dialog-handler';
+
+interface FlagButtonProps {
+    contentType: 'vulnerability' | 'report';
+    contentId: number;
+}
+
+const REASON_OPTIONS: { value: string; label: string }[] = [
+    { value: 'spam', label: 'Spam' },
+    { value: 'harassment', label: 'Harassment' },
+    { value: 'inappropriate', label: 'Inappropriate' },
+    { value: 'misinformation', label: 'Misinformation' },
+    { value: 'other', label: 'Other' },
+];
+
+export const FlagButton: FC<FlagButtonProps> = ({ contentType, contentId }) => {
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [reason, setReason] = useState('spam');
+    const [comment, setComment] = useState('');
+    const [reported, setReported] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
+
+    const handleOpenDialog = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        e.preventDefault();
+        if (!reported) {
+            setDialogOpen(true);
+        }
+    };
+
+    const handleCancel = () => {
+        setDialogOpen(false);
+        setReason('spam');
+        setComment('');
+    };
+
+    const handleReport = async () => {
+        setSubmitting(true);
+        try {
+            await flagContentCall(contentType, contentId, reason, comment || undefined);
+            setReported(true);
+            setDialogOpen(false);
+        } catch (err: unknown) {
+            const status = (err as { response?: { status?: number } })?.response?.status;
+            if (status === 409) {
+                // Already reported by this user — treat as success silently
+                setReported(true);
+                setDialogOpen(false);
+            } else {
+                const message =
+                    (err as { message?: string })?.message ?? 'Failed to report content.';
+                showError(message);
+                setDialogOpen(false);
+            }
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const tooltipText = reported ? 'Reported' : 'Report content';
+
+    return (
+        <>
+            <Tooltip title={tooltipText} arrow>
+                <span>
+                    <IconButton
+                        onClick={handleOpenDialog}
+                        disabled={reported}
+                        sx={{
+                            color: 'action.active',
+                            '&:hover': {
+                                color: 'error.main',
+                            },
+                        }}
+                        aria-label={tooltipText}
+                    >
+                        {reported ? <FlagIcon color="error" /> : <OutlinedFlagIcon />}
+                    </IconButton>
+                </span>
+            </Tooltip>
+
+            <Dialog open={dialogOpen} onClose={handleCancel} fullWidth maxWidth="xs">
+                <DialogTitle>Report content</DialogTitle>
+                <DialogContent>
+                    <Stack spacing={2} sx={{ mt: 1 }}>
+                        <FormControl fullWidth>
+                            <InputLabel id="flag-reason-label">Reason</InputLabel>
+                            <Select
+                                labelId="flag-reason-label"
+                                id="flag-reason-select"
+                                value={reason}
+                                label="Reason"
+                                onChange={(e: SelectChangeEvent) => setReason(e.target.value)}
+                            >
+                                {REASON_OPTIONS.map((opt) => (
+                                    <MenuItem key={opt.value} value={opt.value}>
+                                        {opt.label}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                        </FormControl>
+                        <TextField
+                            label="Comment (optional)"
+                            multiline
+                            rows={3}
+                            value={comment}
+                            onChange={(e) => setComment(e.target.value)}
+                            fullWidth
+                        />
+                    </Stack>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleCancel} disabled={submitting}>
+                        Cancel
+                    </Button>
+                    <Button onClick={handleReport} disabled={submitting} variant="contained" color="error">
+                        Report
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </>
+    );
+};

--- a/UI/src/components/UserBadges.tsx
+++ b/UI/src/components/UserBadges.tsx
@@ -27,10 +27,11 @@ export function UserBadges({ badges, mode = 'compact', maxBadges, size = 'small'
                     <BadgeIcon key={badge.id} badge={badge} size={size} />
                 ))}
                 {maxBadges && badges.length > maxBadges && (
+                    // M-3: replaced hardcoded #666 with theme token
                     <Box
                         sx={{
                             fontSize: '0.75rem',
-                            color: '#666',
+                            color: 'text.secondary',
                             ml: 0.5,
                         }}
                     >
@@ -60,11 +61,12 @@ export function UserBadges({ badges, mode = 'compact', maxBadges, size = 'small'
                     }}
                 >
                     <BadgeIcon badge={badge} size={size} />
+                    {/* M-3: replaced hardcoded #999/#333 with theme tokens */}
                     <Box
                         sx={{
                             fontSize: '0.75rem',
                             textAlign: 'center',
-                            color: badge.isLocked ? '#999' : '#333',
+                            color: badge.isLocked ? 'text.disabled' : 'text.primary',
                         }}
                     >
                         {badge.name}

--- a/UI/src/components/__tests__/BadgeIcon.test.tsx
+++ b/UI/src/components/__tests__/BadgeIcon.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect } from 'vitest';
 import { BadgeIcon } from '../BadgeIcon';
 import { UserBadge, BadgeCategory, BadgeRarity } from '../../api/soroban-security-portal/models/badge';
@@ -12,7 +13,7 @@ describe('BadgeIcon', () => {
         rarity: BadgeRarity.RARE,
         icon: '🏆',
         color: '#2196F3',
-        awardedAt: new Date('2024-01-15'),
+        awardedAt: '2024-01-15T00:00:00.000Z',
         isLocked: false,
     };
 
@@ -21,10 +22,12 @@ describe('BadgeIcon', () => {
         expect(screen.getByText('🏆')).toBeInTheDocument();
     });
 
-    it('shows tooltip with badge name and description', async () => {
-        const { container } = render(<BadgeIcon badge={mockBadge} />);
-        const badgeElement = container.firstChild;
-        expect(badgeElement).toBeInTheDocument();
+    it('shows tooltip with badge name and description on hover', async () => {
+        const user = userEvent.setup();
+        render(<BadgeIcon badge={mockBadge} />);
+        await user.hover(screen.getByRole('img', { name: /Test Badge/ }));
+        expect(await screen.findByText('Test Badge')).toBeVisible();
+        expect(await screen.findByText('A test badge')).toBeVisible();
     });
 
     it('renders locked badge with reduced opacity', () => {
@@ -34,10 +37,12 @@ describe('BadgeIcon', () => {
         expect(badgeElement).toHaveStyle({ opacity: 0.5 });
     });
 
-    it('shows progress for locked badges', () => {
+    it('shows progress for locked badges in tooltip', async () => {
+        const user = userEvent.setup();
         const lockedBadge = { ...mockBadge, isLocked: true, progress: 75 };
         render(<BadgeIcon badge={lockedBadge} />);
-        // Tooltip content is tested via integration tests
+        await user.hover(screen.getByRole('img', { name: /Test Badge/ }));
+        expect(await screen.findByText('Progress: 75%')).toBeVisible();
     });
 
     it('renders different sizes correctly', () => {

--- a/UI/src/components/__tests__/FlagButton.test.tsx
+++ b/UI/src/components/__tests__/FlagButton.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { FlagButton } from '../FlagButton';
+
+// Mock the API module
+vi.mock('../../api/soroban-security-portal/soroban-security-portal-api', () => ({
+    flagContentCall: vi.fn(),
+}));
+
+// Mock the dialog-handler module
+vi.mock('../../features/dialog-handler/dialog-handler', () => ({
+    showError: vi.fn(),
+}));
+
+import { flagContentCall } from '../../api/soroban-security-portal/soroban-security-portal-api';
+import { showError } from '../../features/dialog-handler/dialog-handler';
+
+const theme = createTheme();
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+const mockFlagContentCall = vi.mocked(flagContentCall);
+const mockShowError = vi.mocked(showError);
+
+describe('FlagButton', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders the flag icon button with "Report content" tooltip/aria-label', () => {
+        render(<FlagButton contentType="vulnerability" contentId={1} />, { wrapper });
+        expect(screen.getByRole('button', { name: /report content/i })).toBeInTheDocument();
+    });
+
+    it('clicking the button opens the dialog', () => {
+        render(<FlagButton contentType="vulnerability" contentId={1} />, { wrapper });
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: /report content/i }));
+
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText('Report content')).toBeInTheDocument();
+    });
+
+    it('dialog has Cancel and Report buttons', () => {
+        render(<FlagButton contentType="vulnerability" contentId={1} />, { wrapper });
+        fireEvent.click(screen.getByRole('button', { name: /report content/i }));
+
+        expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^report$/i })).toBeInTheDocument();
+    });
+
+    it('Cancel button closes the dialog without calling API', async () => {
+        render(<FlagButton contentType="vulnerability" contentId={1} />, { wrapper });
+        fireEvent.click(screen.getByRole('button', { name: /report content/i }));
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+        expect(mockFlagContentCall).not.toHaveBeenCalled();
+    });
+
+    it('clicking Report calls flagContentCall with correct args and closes dialog on success', async () => {
+        mockFlagContentCall.mockResolvedValue(true);
+
+        render(<FlagButton contentType="vulnerability" contentId={1} />, { wrapper });
+        fireEvent.click(screen.getByRole('button', { name: /report content/i }));
+
+        // Default reason is 'spam'
+        fireEvent.click(screen.getByRole('button', { name: /^report$/i }));
+
+        await waitFor(() => {
+            expect(mockFlagContentCall).toHaveBeenCalledWith('vulnerability', 1, 'spam', undefined);
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+
+    it('disables the Report button while the request is in flight', async () => {
+        let resolveFlag: (value: boolean) => void = () => {};
+        mockFlagContentCall.mockReturnValue(
+            new Promise<boolean>((resolve) => {
+                resolveFlag = resolve;
+            })
+        );
+
+        render(<FlagButton contentType="vulnerability" contentId={1} />, { wrapper });
+        fireEvent.click(screen.getByRole('button', { name: /report content/i }));
+
+        const reportButton = screen.getByRole('button', { name: /^report$/i });
+        fireEvent.click(reportButton);
+
+        // While the promise is pending, the Report button should be disabled
+        await waitFor(() => {
+            expect(reportButton).toBeDisabled();
+        });
+
+        // Resolve the request and confirm the dialog closes
+        resolveFlag(true);
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+    });
+
+    it('button is disabled and shows "Reported" tooltip after successful flag', async () => {
+        mockFlagContentCall.mockResolvedValue(true);
+
+        render(<FlagButton contentType="vulnerability" contentId={1} />, { wrapper });
+        fireEvent.click(screen.getByRole('button', { name: /report content/i }));
+        fireEvent.click(screen.getByRole('button', { name: /^report$/i }));
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+
+        const btn = screen.getByRole('button', { name: /reported/i });
+        expect(btn).toBeDisabled();
+    });
+
+    it('when flagContentCall rejects with 409, sets reported=true and does NOT call showError', async () => {
+        const err409 = Object.assign(new Error('Conflict'), { response: { status: 409 } });
+        mockFlagContentCall.mockRejectedValue(err409);
+
+        render(<FlagButton contentType="vulnerability" contentId={1} />, { wrapper });
+        fireEvent.click(screen.getByRole('button', { name: /report content/i }));
+        fireEvent.click(screen.getByRole('button', { name: /^report$/i }));
+
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+
+        const btn = screen.getByRole('button', { name: /reported/i });
+        expect(btn).toBeDisabled();
+        expect(mockShowError).not.toHaveBeenCalled();
+    });
+
+    it('when flagContentCall rejects with non-409 error, calls showError', async () => {
+        const err500 = Object.assign(new Error('Server Error'), { response: { status: 500 } });
+        mockFlagContentCall.mockRejectedValue(err500);
+
+        render(<FlagButton contentType="vulnerability" contentId={1} />, { wrapper });
+        fireEvent.click(screen.getByRole('button', { name: /report content/i }));
+        fireEvent.click(screen.getByRole('button', { name: /^report$/i }));
+
+        await waitFor(() => {
+            expect(mockShowError).toHaveBeenCalled();
+        });
+
+        // Dialog should be closed
+        await waitFor(() => {
+            expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        });
+        // Button should NOT be in reported state
+        expect(screen.queryByRole('button', { name: /reported/i })).not.toBeInTheDocument();
+    });
+
+    it('works for report contentType', async () => {
+        mockFlagContentCall.mockResolvedValue(true);
+
+        render(<FlagButton contentType="report" contentId={42} />, { wrapper });
+        fireEvent.click(screen.getByRole('button', { name: /report content/i }));
+        fireEvent.click(screen.getByRole('button', { name: /^report$/i }));
+
+        await waitFor(() => {
+            expect(mockFlagContentCall).toHaveBeenCalledWith('report', 42, 'spam', undefined);
+        });
+    });
+});

--- a/UI/src/features/moderation/components/ModerationItem.tsx
+++ b/UI/src/features/moderation/components/ModerationItem.tsx
@@ -71,7 +71,7 @@ export const ModerationItem = ({ item, onAction }: ModerationItemProps) => {
                 <Typography variant="body1">
                     {expanded ? item.fullContent : item.contentPreview}
                 </Typography>
-                {item.fullContent.length > item.contentPreview.length && (
+                {item.fullContent !== item.contentPreview && (
                     <Button
                         size="small"
                         onClick={() => setExpanded(!expanded)}
@@ -100,57 +100,69 @@ export const ModerationItem = ({ item, onAction }: ModerationItemProps) => {
                     ))}
             </Stack>
 
-            <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 2 }}>
-                <Button
-                    startIcon={<Check />}
-                    variant="outlined"
-                    color="success"
-                    onClick={() => onAction(item.id, 'approve')}
-                >
-                    Approve
-                </Button>
-                <Button
-                    startIcon={<VisibilityOff />}
-                    variant="outlined"
-                    color="warning"
-                    onClick={() => setShowReasonInput(showReasonInput === 'hide' ? null : 'hide')}
-                >
-                    Hide
-                </Button>
-                <Button
-                    startIcon={<Delete />}
-                    variant="outlined"
-                    color="error"
-                    onClick={() => setShowReasonInput(showReasonInput === 'delete' ? null : 'delete')}
-                >
-                    Delete
-                </Button>
-            </Box>
-
-            <Collapse in={!!showReasonInput}>
-                <Box sx={{ mt: 2, pt: 2, borderTop: `1px dashed ${theme.palette.divider}` }}>
-                    <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                        Reason for {showReasonInput === 'hide' ? 'hiding' : 'deleting'} content:
-                    </Typography>
-                    <Box sx={{ display: 'flex', gap: 2 }}>
-                        <TextField
-                            fullWidth
-                            size="small"
-                            placeholder="Enter moderation reason..."
-                            value={actionReason}
-                            onChange={(e) => setActionReason(e.target.value)}
-                        />
+            {item.status === 'pending' ? (
+                <>
+                    <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 2 }}>
                         <Button
-                            variant="contained"
-                            color={showReasonInput === 'delete' ? 'error' : 'warning'}
-                            disabled={!actionReason}
-                            onClick={handleConfirmAction}
+                            startIcon={<Check />}
+                            variant="outlined"
+                            color="success"
+                            onClick={() => onAction(item.id, 'approve')}
                         >
-                            Confirm
+                            Approve
+                        </Button>
+                        <Button
+                            startIcon={<VisibilityOff />}
+                            variant="outlined"
+                            color="warning"
+                            onClick={() => setShowReasonInput(showReasonInput === 'hide' ? null : 'hide')}
+                        >
+                            Hide
+                        </Button>
+                        <Button
+                            startIcon={<Delete />}
+                            variant="outlined"
+                            color="error"
+                            onClick={() => setShowReasonInput(showReasonInput === 'delete' ? null : 'delete')}
+                        >
+                            Delete
                         </Button>
                     </Box>
+
+                    <Collapse in={!!showReasonInput}>
+                        <Box sx={{ mt: 2, pt: 2, borderTop: `1px dashed ${theme.palette.divider}` }}>
+                            <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                                Reason for {showReasonInput === 'hide' ? 'hiding' : 'deleting'} content:
+                            </Typography>
+                            <Box sx={{ display: 'flex', gap: 2 }}>
+                                <TextField
+                                    fullWidth
+                                    size="small"
+                                    placeholder="Enter moderation reason..."
+                                    value={actionReason}
+                                    onChange={(e) => setActionReason(e.target.value)}
+                                />
+                                <Button
+                                    variant="contained"
+                                    color={showReasonInput === 'delete' ? 'error' : 'warning'}
+                                    disabled={!actionReason}
+                                    onClick={handleConfirmAction}
+                                >
+                                    Confirm
+                                </Button>
+                            </Box>
+                        </Box>
+                    </Collapse>
+                </>
+            ) : (
+                <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 1 }}>
+                    <Chip
+                        label={`${item.status.charAt(0).toUpperCase() + item.status.slice(1)}${item.lastAction?.reason ? ` — ${item.lastAction.reason}` : ''}`}
+                        color={item.status === 'approved' ? 'success' : item.status === 'hidden' ? 'warning' : 'error'}
+                        variant="outlined"
+                    />
                 </Box>
-            </Collapse>
+            )}
         </Paper>
     );
 };

--- a/UI/src/features/moderation/components/ModerationItem.tsx
+++ b/UI/src/features/moderation/components/ModerationItem.tsx
@@ -4,8 +4,7 @@ import {
     Collapse, TextField, Stack, useTheme
 } from '@mui/material';
 import {
-    Check, Delete, VisibilityOff, ExpandMore,
-    ExpandLess, AccessTime, OpenInNew
+    Check, Delete, VisibilityOff, AccessTime, OpenInNew
 } from '@mui/icons-material';
 import { Link as RouterLink } from 'react-router-dom';
 import { FlaggedContent, FlagReason } from '../types';
@@ -19,7 +18,6 @@ interface ModerationItemProps {
 
 export const ModerationItem = ({ item, onAction }: ModerationItemProps) => {
     const theme = useTheme();
-    const [expanded, setExpanded] = useState(false);
     const [actionReason, setActionReason] = useState('');
     const [showReasonInput, setShowReasonInput] = useState<'hide' | 'delete' | null>(null);
 
@@ -84,22 +82,15 @@ export const ModerationItem = ({ item, onAction }: ModerationItemProps) => {
             </Box>
 
             <Box sx={{ mb: 2, p: 2, bgcolor: theme.palette.action.hover, borderRadius: 2 }}>
-                <Typography variant="body1">
-                    {expanded ? item.fullContent : item.contentPreview}
+                <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                    {item.contentPreview}
                 </Typography>
-                {item.fullContent !== item.contentPreview && (
-                    <Button
-                        size="small"
-                        onClick={() => setExpanded(!expanded)}
-                        endIcon={expanded ? <ExpandLess /> : <ExpandMore />}
-                        sx={{ mt: 1 }}
-                    >
-                        {expanded ? 'Show Less' : 'Show More'}
-                    </Button>
-                )}
+                <Typography variant="caption" color="text.secondary">
+                    Use "View {item.contentType}" above to open the full content.
+                </Typography>
             </Box>
 
-            <Stack direction="row" spacing={1} sx={{ mb: 3 }}>
+            <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: 'wrap', gap: 1 }}>
                 <Typography variant="body2" sx={{ fontWeight: 'bold', mr: 1, alignSelf: 'center' }}>
                     Flags ({item.flagCount}):
                 </Typography>
@@ -115,6 +106,29 @@ export const ModerationItem = ({ item, onAction }: ModerationItemProps) => {
                         />
                     ))}
             </Stack>
+
+            {item.flags && item.flags.length > 0 && (
+                <Box sx={{ mb: 3 }}>
+                    <Typography variant="body2" sx={{ fontWeight: 'bold', mb: 1 }}>
+                        Reports:
+                    </Typography>
+                    <Stack spacing={1}>
+                        {item.flags.map((f, i) => (
+                            <Box key={i} sx={{ pl: 1.5, borderLeft: `3px solid ${theme.palette.divider}` }}>
+                                <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'capitalize' }}>
+                                    {f.reason}
+                                </Typography>
+                                <Typography
+                                    variant="body2"
+                                    sx={{ fontStyle: f.comment ? 'normal' : 'italic', color: f.comment ? 'text.primary' : 'text.secondary' }}
+                                >
+                                    {f.comment || 'No note provided'}
+                                </Typography>
+                            </Box>
+                        ))}
+                    </Stack>
+                </Box>
+            )}
 
             {item.status === 'pending' ? (
                 <>

--- a/UI/src/features/moderation/components/ModerationItem.tsx
+++ b/UI/src/features/moderation/components/ModerationItem.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import {
     Box, Paper, Typography, Button, Avatar, Chip,
-    Collapse, TextField, Stack, useTheme
+    Collapse, TextField, Stack, Link, useTheme
 } from '@mui/material';
 import {
     Check, Delete, VisibilityOff, AccessTime, OpenInNew
@@ -41,120 +41,121 @@ export const ModerationItem = ({ item, onAction }: ModerationItemProps) => {
         }
     };
 
+    // The global theme forces every Button to a heavy blue; override per-action so the
+    // three moderation choices read as distinct (positive / neutral / destructive).
+    const baseBtn = { fontWeight: 600, fontSize: '0.8125rem', boxShadow: 'none' };
+    const approveSx = {
+        ...baseBtn, bgcolor: 'success.main', color: '#fff',
+        '&:hover': { bgcolor: 'success.dark', boxShadow: 'none' },
+    };
+    const hideSx = {
+        ...baseBtn, bgcolor: 'transparent', color: 'text.secondary', border: '1px solid', borderColor: 'divider',
+        '&:hover': { bgcolor: 'action.hover', borderColor: 'text.secondary', color: 'text.primary' },
+    };
+    const deleteSx = {
+        ...baseBtn, bgcolor: 'transparent', color: 'error.main', border: '1px solid', borderColor: 'error.main',
+        '&:hover': { bgcolor: 'error.main', color: '#fff' },
+    };
+    const confirmSx = showReasonInput === 'delete'
+        ? { ...baseBtn, bgcolor: 'error.main', color: '#fff', '&:hover': { bgcolor: 'error.dark' } }
+        : { ...baseBtn, bgcolor: 'warning.main', color: '#fff', '&:hover': { bgcolor: 'warning.dark' } };
+
     return (
-        <Paper elevation={0} sx={{ p: 3, border: `1px solid ${theme.palette.divider}`, mb: 2 }}>
-            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 2 }}>
-                <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
-                    <Avatar src={item.author.avatarUrl} alt={item.author.name} />
-                    <Box>
-                        <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
+        <Paper elevation={0} sx={{ p: 2.5, border: `1px solid ${theme.palette.divider}`, borderRadius: 2, mb: 2 }}>
+            {/* Header: who is involved + when/what — compact and muted */}
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 2, mb: 1.5 }}>
+                <Box sx={{ display: 'flex', gap: 1.5, alignItems: 'center', minWidth: 0 }}>
+                    <Avatar src={item.author.avatarUrl} alt={item.author.name} sx={{ width: 40, height: 40 }} />
+                    <Box sx={{ minWidth: 0 }}>
+                        <Typography variant="subtitle2" sx={{ fontWeight: 700, lineHeight: 1.2 }} noWrap>
                             {item.author.name}
                         </Typography>
-                        <Typography variant="caption" color="text.secondary">
-                            Reputation: {item.author.reputationScore}
+                        <Typography variant="caption" color="text.secondary" noWrap>
+                            Reputation {item.author.reputationScore}
                         </Typography>
                     </Box>
                 </Box>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <Chip
-                        icon={<AccessTime sx={{ fontSize: 16 }} />}
-                        label={formatDistance(new Date(item.lastFlaggedAt), new Date(), { addSuffix: true })}
-                        size="small"
-                        variant="outlined"
-                    />
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.25, flexShrink: 0 }}>
                     <Chip
                         label={item.contentType}
                         size="small"
-                        color="primary"
+                        sx={{ textTransform: 'capitalize', bgcolor: 'action.selected', color: 'text.secondary', fontWeight: 600 }}
                     />
-                    <Button
-                        component={RouterLink}
-                        to={detailPath}
-                        target="_blank"
-                        rel="noopener"
-                        size="small"
-                        variant="outlined"
-                        endIcon={<OpenInNew sx={{ fontSize: 16 }} />}
-                    >
-                        View {item.contentType}
-                    </Button>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, color: 'text.secondary' }}>
+                        <AccessTime sx={{ fontSize: 14 }} />
+                        <Typography variant="caption" noWrap>
+                            {formatDistance(new Date(item.lastFlaggedAt), new Date(), { addSuffix: true })}
+                        </Typography>
+                    </Box>
                 </Box>
             </Box>
 
-            <Box sx={{ mb: 2, p: 2, bgcolor: theme.palette.action.hover, borderRadius: 2 }}>
-                <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                    {item.contentPreview}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                    Use "View {item.contentType}" above to open the full content.
-                </Typography>
-            </Box>
+            {/* The flagged content — the title is the link that opens it in context */}
+            <Link
+                component={RouterLink}
+                to={detailPath}
+                target="_blank"
+                rel="noopener"
+                underline="hover"
+                sx={{
+                    display: 'inline-flex', alignItems: 'center', gap: 0.5,
+                    color: 'text.primary', fontWeight: 600, fontSize: '1.05rem', lineHeight: 1.35,
+                    '&:hover': { color: 'secondary.main' },
+                }}
+            >
+                {item.contentPreview}
+                <OpenInNew sx={{ fontSize: 16, opacity: 0.7, flexShrink: 0 }} />
+            </Link>
 
-            <Stack direction="row" spacing={1} sx={{ mb: 2, flexWrap: 'wrap', gap: 1 }}>
-                <Typography variant="body2" sx={{ fontWeight: 'bold', mr: 1, alignSelf: 'center' }}>
-                    Flags ({item.flagCount}):
+            {/* Flag summary */}
+            <Box sx={{ display: 'flex', alignItems: 'center', mt: 2, mb: 1.5, flexWrap: 'wrap', gap: 1 }}>
+                <Typography variant="caption" sx={{ fontWeight: 700, color: 'text.secondary', textTransform: 'uppercase', letterSpacing: 0.5 }}>
+                    {item.flagCount} {item.flagCount === 1 ? 'report' : 'reports'}
                 </Typography>
                 {Object.entries(item.reasons)
                     .filter(([, count]) => count > 0)
                     .map(([reason, count]) => (
                         <Chip
                             key={reason}
-                            label={`${reason} (${count})`}
+                            label={`${reason} ${count}`}
                             size="small"
                             color={getReasonColor(reason as FlagReason)}
                             variant="outlined"
+                            sx={{ textTransform: 'capitalize' }}
                         />
                     ))}
-            </Stack>
+            </Box>
 
+            {/* Each report: reason + the note the flagger wrote */}
             {item.flags && item.flags.length > 0 && (
-                <Box sx={{ mb: 3 }}>
-                    <Typography variant="body2" sx={{ fontWeight: 'bold', mb: 1 }}>
-                        Reports:
-                    </Typography>
-                    <Stack spacing={1}>
-                        {item.flags.map((f, i) => (
-                            <Box key={i} sx={{ pl: 1.5, borderLeft: `3px solid ${theme.palette.divider}` }}>
-                                <Typography variant="caption" color="text.secondary" sx={{ textTransform: 'capitalize' }}>
-                                    {f.reason}
-                                </Typography>
-                                <Typography
-                                    variant="body2"
-                                    sx={{ fontStyle: f.comment ? 'normal' : 'italic', color: f.comment ? 'text.primary' : 'text.secondary' }}
-                                >
-                                    {f.comment || 'No note provided'}
-                                </Typography>
-                            </Box>
-                        ))}
-                    </Stack>
-                </Box>
+                <Stack spacing={1.25} sx={{ mb: 2.5 }}>
+                    {item.flags.map((f, i) => (
+                        <Box key={i} sx={{ pl: 1.5, borderLeft: `2px solid ${theme.palette.divider}` }}>
+                            <Typography variant="caption" sx={{ fontWeight: 700, color: 'text.secondary', textTransform: 'capitalize' }}>
+                                {f.reason}
+                            </Typography>
+                            <Typography
+                                variant="body2"
+                                sx={{ color: f.comment ? 'text.primary' : 'text.disabled', fontStyle: f.comment ? 'normal' : 'italic' }}
+                            >
+                                {f.comment || 'No note provided'}
+                            </Typography>
+                        </Box>
+                    ))}
+                </Stack>
             )}
 
+            {/* Actions (pending) or the resolution chip (history) */}
             {item.status === 'pending' ? (
                 <>
-                    <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 2 }}>
-                        <Button
-                            startIcon={<Check />}
-                            variant="outlined"
-                            color="success"
-                            onClick={() => onAction(item.id, 'approve')}
-                        >
+                    <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1.5 }}>
+                        <Button size="small" startIcon={<Check />} onClick={() => onAction(item.id, 'approve')} sx={approveSx}>
                             Approve
                         </Button>
-                        <Button
-                            startIcon={<VisibilityOff />}
-                            variant="outlined"
-                            color="warning"
-                            onClick={() => setShowReasonInput(showReasonInput === 'hide' ? null : 'hide')}
-                        >
+                        <Button size="small" startIcon={<VisibilityOff />} onClick={() => setShowReasonInput(showReasonInput === 'hide' ? null : 'hide')} sx={hideSx}>
                             Hide
                         </Button>
-                        <Button
-                            startIcon={<Delete />}
-                            variant="outlined"
-                            color="error"
-                            onClick={() => setShowReasonInput(showReasonInput === 'delete' ? null : 'delete')}
-                        >
+                        <Button size="small" startIcon={<Delete />} onClick={() => setShowReasonInput(showReasonInput === 'delete' ? null : 'delete')} sx={deleteSx}>
                             Delete
                         </Button>
                     </Box>
@@ -162,9 +163,9 @@ export const ModerationItem = ({ item, onAction }: ModerationItemProps) => {
                     <Collapse in={!!showReasonInput}>
                         <Box sx={{ mt: 2, pt: 2, borderTop: `1px dashed ${theme.palette.divider}` }}>
                             <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                                Reason for {showReasonInput === 'hide' ? 'hiding' : 'deleting'} content:
+                                Reason for {showReasonInput === 'hide' ? 'hiding' : 'deleting'} this content:
                             </Typography>
-                            <Box sx={{ display: 'flex', gap: 2 }}>
+                            <Box sx={{ display: 'flex', gap: 1.5 }}>
                                 <TextField
                                     fullWidth
                                     size="small"
@@ -172,12 +173,7 @@ export const ModerationItem = ({ item, onAction }: ModerationItemProps) => {
                                     value={actionReason}
                                     onChange={(e) => setActionReason(e.target.value)}
                                 />
-                                <Button
-                                    variant="contained"
-                                    color={showReasonInput === 'delete' ? 'error' : 'warning'}
-                                    disabled={!actionReason}
-                                    onClick={handleConfirmAction}
-                                >
+                                <Button disabled={!actionReason} onClick={handleConfirmAction} sx={confirmSx}>
                                     Confirm
                                 </Button>
                             </Box>
@@ -185,11 +181,12 @@ export const ModerationItem = ({ item, onAction }: ModerationItemProps) => {
                     </Collapse>
                 </>
             ) : (
-                <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 1 }}>
+                <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
                     <Chip
                         label={`${item.status.charAt(0).toUpperCase() + item.status.slice(1)}${item.lastAction?.reason ? ` — ${item.lastAction.reason}` : ''}`}
                         color={item.status === 'approved' ? 'success' : item.status === 'hidden' ? 'warning' : 'error'}
                         variant="outlined"
+                        size="small"
                     />
                 </Box>
             )}

--- a/UI/src/features/moderation/components/ModerationItem.tsx
+++ b/UI/src/features/moderation/components/ModerationItem.tsx
@@ -5,9 +5,11 @@ import {
 } from '@mui/material';
 import {
     Check, Delete, VisibilityOff, ExpandMore,
-    ExpandLess, AccessTime
+    ExpandLess, AccessTime, OpenInNew
 } from '@mui/icons-material';
+import { Link as RouterLink } from 'react-router-dom';
 import { FlaggedContent, FlagReason } from '../types';
+import { environment } from '../../../environments/environment';
 import { formatDistance } from 'date-fns';
 
 interface ModerationItemProps {
@@ -20,6 +22,9 @@ export const ModerationItem = ({ item, onAction }: ModerationItemProps) => {
     const [expanded, setExpanded] = useState(false);
     const [actionReason, setActionReason] = useState('');
     const [showReasonInput, setShowReasonInput] = useState<'hide' | 'delete' | null>(null);
+
+    // Link to the actual flagged content so a moderator can open it in context.
+    const detailPath = `${environment.basePath}/${item.contentType === 'report' ? 'report' : 'vulnerability'}/${item.contentId}`;
 
     const handleConfirmAction = () => {
         if (showReasonInput && actionReason) {
@@ -64,6 +69,17 @@ export const ModerationItem = ({ item, onAction }: ModerationItemProps) => {
                         size="small"
                         color="primary"
                     />
+                    <Button
+                        component={RouterLink}
+                        to={detailPath}
+                        target="_blank"
+                        rel="noopener"
+                        size="small"
+                        variant="outlined"
+                        endIcon={<OpenInNew sx={{ fontSize: 16 }} />}
+                    >
+                        View {item.contentType}
+                    </Button>
                 </Box>
             </Box>
 

--- a/UI/src/features/moderation/hooks/__tests__/useModerationQueue.test.ts
+++ b/UI/src/features/moderation/hooks/__tests__/useModerationQueue.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useModerationQueue } from '../useModerationQueue';
+
+// Use fake timers to control the simulated API timeout
+beforeEach(() => {
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+/** Helper: render the hook and advance past the 1-second mock delay. */
+async function renderAndLoad() {
+    const hook = renderHook(() => useModerationQueue());
+    // Advance the simulated setTimeout(…, 1000) to resolve the mock load
+    await act(async () => {
+        vi.advanceTimersByTime(1000);
+    });
+    return hook;
+}
+
+describe('useModerationQueue', () => {
+    describe('initial state', () => {
+        it('starts in loading state with empty items and null stats', () => {
+            const { result } = renderHook(() => useModerationQueue());
+            expect(result.current.loading).toBe(true);
+            expect(result.current.items).toHaveLength(0);
+            expect(result.current.stats).toBeNull();
+        });
+
+        it('loads mock data after the simulated delay', async () => {
+            const { result } = await renderAndLoad();
+            expect(result.current.loading).toBe(false);
+            expect(result.current.items.length).toBeGreaterThan(0);
+            expect(result.current.stats).not.toBeNull();
+        });
+
+        it('all initial items have pending status', async () => {
+            const { result } = await renderAndLoad();
+            expect(result.current.items.every(i => i.status === 'pending')).toBe(true);
+        });
+    });
+
+    describe('handleAction — status transitions', () => {
+        it('approve: moves item from pending to approved', async () => {
+            const { result } = await renderAndLoad();
+            const targetId = result.current.items[0].id;
+
+            act(() => {
+                result.current.handleAction(targetId, 'approve');
+            });
+
+            const updated = result.current.items.find(i => i.id === targetId)!;
+            expect(updated.status).toBe('approved');
+        });
+
+        it('hide: moves item from pending to hidden', async () => {
+            const { result } = await renderAndLoad();
+            const targetId = result.current.items[0].id;
+
+            act(() => {
+                result.current.handleAction(targetId, 'hide', 'spam');
+            });
+
+            const updated = result.current.items.find(i => i.id === targetId)!;
+            expect(updated.status).toBe('hidden');
+        });
+
+        it('delete: moves item from pending to deleted', async () => {
+            const { result } = await renderAndLoad();
+            const targetId = result.current.items[0].id;
+
+            act(() => {
+                result.current.handleAction(targetId, 'delete', 'harassment');
+            });
+
+            const updated = result.current.items.find(i => i.id === targetId)!;
+            expect(updated.status).toBe('deleted');
+        });
+
+        it('only affects the targeted item; others remain pending', async () => {
+            const { result } = await renderAndLoad();
+            const allIds = result.current.items.map(i => i.id);
+            const targetId = allIds[0];
+            const otherIds = allIds.slice(1);
+
+            act(() => {
+                result.current.handleAction(targetId, 'approve');
+            });
+
+            otherIds.forEach(id => {
+                const item = result.current.items.find(i => i.id === id)!;
+                expect(item.status).toBe('pending');
+            });
+        });
+    });
+
+    describe('handleAction — reason stored in lastAction', () => {
+        it('stores the reason on the item when hiding', async () => {
+            const { result } = await renderAndLoad();
+            const targetId = result.current.items[0].id;
+
+            act(() => {
+                result.current.handleAction(targetId, 'hide', 'spam');
+            });
+
+            const updated = result.current.items.find(i => i.id === targetId)!;
+            expect(updated.lastAction?.action).toBe('hide');
+            expect(updated.lastAction?.reason).toBe('spam');
+        });
+
+        it('stores the reason on the item when deleting', async () => {
+            const { result } = await renderAndLoad();
+            const targetId = result.current.items[0].id;
+
+            act(() => {
+                result.current.handleAction(targetId, 'delete', 'misinformation');
+            });
+
+            const updated = result.current.items.find(i => i.id === targetId)!;
+            expect(updated.lastAction?.action).toBe('delete');
+            expect(updated.lastAction?.reason).toBe('misinformation');
+        });
+
+        it('stores action without reason for approve', async () => {
+            const { result } = await renderAndLoad();
+            const targetId = result.current.items[0].id;
+
+            act(() => {
+                result.current.handleAction(targetId, 'approve');
+            });
+
+            const updated = result.current.items.find(i => i.id === targetId)!;
+            expect(updated.lastAction?.action).toBe('approve');
+            expect(updated.lastAction?.reason).toBeUndefined();
+        });
+    });
+
+    describe('status transitions remove items from the pending set', () => {
+        it('after hiding one item, the hidden item no longer has pending status', async () => {
+            const { result } = await renderAndLoad();
+            const targetId = result.current.items[0].id;
+
+            act(() => {
+                result.current.handleAction(targetId, 'hide', 'spam');
+            });
+
+            const pendingItems = result.current.items.filter(i => i.status === 'pending');
+            expect(pendingItems.find(i => i.id === targetId)).toBeUndefined();
+        });
+
+        it('after approving all items, zero remain pending', async () => {
+            const { result } = await renderAndLoad();
+            const ids = result.current.items.map(i => i.id);
+
+            act(() => {
+                ids.forEach(id => result.current.handleAction(id, 'approve'));
+            });
+
+            const pending = result.current.items.filter(i => i.status === 'pending');
+            expect(pending.length).toBe(0);
+        });
+    });
+
+    describe('stats recalculation', () => {
+        it('stats.queueSize equals number of pending items initially', async () => {
+            const { result } = await renderAndLoad();
+            const pendingCount = result.current.items.filter(i => i.status === 'pending').length;
+            expect(result.current.stats!.queueSize).toBe(pendingCount);
+        });
+
+        it('stats.queueSize decrements after approving one item', async () => {
+            const { result } = await renderAndLoad();
+            const initialQueue = result.current.stats!.queueSize;
+            const targetId = result.current.items[0].id;
+
+            act(() => {
+                result.current.handleAction(targetId, 'approve');
+            });
+
+            expect(result.current.stats!.queueSize).toBe(initialQueue - 1);
+        });
+
+        it('actionsToday increments after each action', async () => {
+            const { result } = await renderAndLoad();
+            const baseline = result.current.stats!.actionsToday;
+            const targetId = result.current.items[0].id;
+
+            act(() => {
+                result.current.handleAction(targetId, 'hide', 'spam');
+            });
+
+            expect(result.current.stats!.actionsToday).toBe(baseline + 1);
+        });
+
+        it('actionsThisWeek and actionsThisMonth also increment after an action', async () => {
+            const { result } = await renderAndLoad();
+            const baseWeek = result.current.stats!.actionsThisWeek;
+            const baseMonth = result.current.stats!.actionsThisMonth;
+            const targetId = result.current.items[0].id;
+
+            act(() => {
+                result.current.handleAction(targetId, 'delete', 'spam');
+            });
+
+            expect(result.current.stats!.actionsThisWeek).toBe(baseWeek + 1);
+            expect(result.current.stats!.actionsThisMonth).toBe(baseMonth + 1);
+        });
+
+        it('stats are null while loading', () => {
+            const { result } = renderHook(() => useModerationQueue());
+            expect(result.current.stats).toBeNull();
+        });
+    });
+
+    describe('mock avatar URLs (L-7)', () => {
+        it('no item author has a third-party avatar URL', async () => {
+            const { result } = await renderAndLoad();
+            result.current.items.forEach(item => {
+                const url = item.author.avatarUrl ?? '';
+                expect(url).not.toMatch(/^https?:\/\//);
+            });
+        });
+    });
+});

--- a/UI/src/features/moderation/hooks/__tests__/useModerationQueue.test.ts
+++ b/UI/src/features/moderation/hooks/__tests__/useModerationQueue.test.ts
@@ -1,25 +1,91 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { useModerationQueue } from '../useModerationQueue';
+import type { FlaggedContent, ModerationStats } from '../../types';
 
-// Use fake timers to control the simulated API timeout
+vi.mock('../../../../api/soroban-security-portal/soroban-security-portal-api', () => ({
+    getModerationQueueCall: vi.fn(),
+    getModerationStatsCall: vi.fn(),
+    takeModerationActionCall: vi.fn(),
+}));
+
+// Also mock the dialog handler so showError doesn't try to dispatch to a real Redux store
+vi.mock('../../../dialog-handler/dialog-handler', () => ({
+    showError: vi.fn(),
+}));
+
+import {
+    getModerationQueueCall,
+    getModerationStatsCall,
+    takeModerationActionCall,
+} from '../../../../api/soroban-security-portal/soroban-security-portal-api';
+import { showError } from '../../../dialog-handler/dialog-handler';
+
+const mockGetQueue = getModerationQueueCall as ReturnType<typeof vi.fn>;
+const mockGetStats = getModerationStatsCall as ReturnType<typeof vi.fn>;
+const mockTakeAction = takeModerationActionCall as ReturnType<typeof vi.fn>;
+const mockShowError = showError as ReturnType<typeof vi.fn>;
+
+const MOCK_ITEMS: FlaggedContent[] = [
+    {
+        id: 'vulnerability:5',
+        contentType: 'vulnerability',
+        contentId: '5',
+        contentPreview: 'A flagged vulnerability',
+        fullContent: 'Full content here',
+        author: {
+            id: 'u1',
+            name: 'TestUser',
+            email: 'test@example.com',
+            reputationScore: 50,
+            avatarUrl: '',
+        },
+        flagCount: 3,
+        reasons: { spam: 1, harassment: 0, inappropriate: 0, misinformation: 2, other: 0 },
+        firstFlaggedAt: new Date().toISOString(),
+        lastFlaggedAt: new Date().toISOString(),
+        status: 'pending',
+        moderationHistory: [],
+    },
+    {
+        id: 'report:10',
+        contentType: 'report',
+        contentId: '10',
+        contentPreview: 'A flagged report',
+        fullContent: 'Full report content',
+        author: {
+            id: 'u2',
+            name: 'AnotherUser',
+            email: 'another@example.com',
+            reputationScore: 20,
+            avatarUrl: '',
+        },
+        flagCount: 1,
+        reasons: { spam: 1, harassment: 0, inappropriate: 0, misinformation: 0, other: 0 },
+        firstFlaggedAt: new Date().toISOString(),
+        lastFlaggedAt: new Date().toISOString(),
+        status: 'pending',
+        moderationHistory: [],
+    },
+];
+
+const MOCK_STATS: ModerationStats = {
+    queueSize: 2,
+    actionsToday: 5,
+    actionsThisWeek: 20,
+    actionsThisMonth: 80,
+};
+
 beforeEach(() => {
-    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockGetQueue.mockResolvedValue(MOCK_ITEMS);
+    mockGetStats.mockResolvedValue(MOCK_STATS);
+    mockTakeAction.mockResolvedValue(true);
 });
 
 afterEach(() => {
-    vi.useRealTimers();
+    vi.restoreAllMocks();
 });
-
-/** Helper: render the hook and advance past the 1-second mock delay. */
-async function renderAndLoad() {
-    const hook = renderHook(() => useModerationQueue());
-    // Advance the simulated setTimeout(…, 1000) to resolve the mock load
-    await act(async () => {
-        vi.advanceTimersByTime(1000);
-    });
-    return hook;
-}
 
 describe('useModerationQueue', () => {
     describe('initial state', () => {
@@ -30,198 +96,88 @@ describe('useModerationQueue', () => {
             expect(result.current.stats).toBeNull();
         });
 
-        it('loads mock data after the simulated delay', async () => {
-            const { result } = await renderAndLoad();
-            expect(result.current.loading).toBe(false);
-            expect(result.current.items.length).toBeGreaterThan(0);
-            expect(result.current.stats).not.toBeNull();
+        it('loads items from getModerationQueueCall on mount', async () => {
+            const { result } = renderHook(() => useModerationQueue());
+            await waitFor(() => expect(result.current.loading).toBe(false));
+            expect(mockGetQueue).toHaveBeenCalledTimes(1);
+            expect(result.current.items).toHaveLength(MOCK_ITEMS.length);
+            expect(result.current.items[0].id).toBe('vulnerability:5');
         });
 
-        it('all initial items have pending status', async () => {
-            const { result } = await renderAndLoad();
-            expect(result.current.items.every(i => i.status === 'pending')).toBe(true);
-        });
-    });
-
-    describe('handleAction — status transitions', () => {
-        it('approve: moves item from pending to approved', async () => {
-            const { result } = await renderAndLoad();
-            const targetId = result.current.items[0].id;
-
-            act(() => {
-                result.current.handleAction(targetId, 'approve');
-            });
-
-            const updated = result.current.items.find(i => i.id === targetId)!;
-            expect(updated.status).toBe('approved');
-        });
-
-        it('hide: moves item from pending to hidden', async () => {
-            const { result } = await renderAndLoad();
-            const targetId = result.current.items[0].id;
-
-            act(() => {
-                result.current.handleAction(targetId, 'hide', 'spam');
-            });
-
-            const updated = result.current.items.find(i => i.id === targetId)!;
-            expect(updated.status).toBe('hidden');
-        });
-
-        it('delete: moves item from pending to deleted', async () => {
-            const { result } = await renderAndLoad();
-            const targetId = result.current.items[0].id;
-
-            act(() => {
-                result.current.handleAction(targetId, 'delete', 'harassment');
-            });
-
-            const updated = result.current.items.find(i => i.id === targetId)!;
-            expect(updated.status).toBe('deleted');
-        });
-
-        it('only affects the targeted item; others remain pending', async () => {
-            const { result } = await renderAndLoad();
-            const allIds = result.current.items.map(i => i.id);
-            const targetId = allIds[0];
-            const otherIds = allIds.slice(1);
-
-            act(() => {
-                result.current.handleAction(targetId, 'approve');
-            });
-
-            otherIds.forEach(id => {
-                const item = result.current.items.find(i => i.id === id)!;
-                expect(item.status).toBe('pending');
-            });
-        });
-    });
-
-    describe('handleAction — reason stored in lastAction', () => {
-        it('stores the reason on the item when hiding', async () => {
-            const { result } = await renderAndLoad();
-            const targetId = result.current.items[0].id;
-
-            act(() => {
-                result.current.handleAction(targetId, 'hide', 'spam');
-            });
-
-            const updated = result.current.items.find(i => i.id === targetId)!;
-            expect(updated.lastAction?.action).toBe('hide');
-            expect(updated.lastAction?.reason).toBe('spam');
-        });
-
-        it('stores the reason on the item when deleting', async () => {
-            const { result } = await renderAndLoad();
-            const targetId = result.current.items[0].id;
-
-            act(() => {
-                result.current.handleAction(targetId, 'delete', 'misinformation');
-            });
-
-            const updated = result.current.items.find(i => i.id === targetId)!;
-            expect(updated.lastAction?.action).toBe('delete');
-            expect(updated.lastAction?.reason).toBe('misinformation');
-        });
-
-        it('stores action without reason for approve', async () => {
-            const { result } = await renderAndLoad();
-            const targetId = result.current.items[0].id;
-
-            act(() => {
-                result.current.handleAction(targetId, 'approve');
-            });
-
-            const updated = result.current.items.find(i => i.id === targetId)!;
-            expect(updated.lastAction?.action).toBe('approve');
-            expect(updated.lastAction?.reason).toBeUndefined();
-        });
-    });
-
-    describe('status transitions remove items from the pending set', () => {
-        it('after hiding one item, the hidden item no longer has pending status', async () => {
-            const { result } = await renderAndLoad();
-            const targetId = result.current.items[0].id;
-
-            act(() => {
-                result.current.handleAction(targetId, 'hide', 'spam');
-            });
-
-            const pendingItems = result.current.items.filter(i => i.status === 'pending');
-            expect(pendingItems.find(i => i.id === targetId)).toBeUndefined();
-        });
-
-        it('after approving all items, zero remain pending', async () => {
-            const { result } = await renderAndLoad();
-            const ids = result.current.items.map(i => i.id);
-
-            act(() => {
-                ids.forEach(id => result.current.handleAction(id, 'approve'));
-            });
-
-            const pending = result.current.items.filter(i => i.status === 'pending');
-            expect(pending.length).toBe(0);
-        });
-    });
-
-    describe('stats recalculation', () => {
-        it('stats.queueSize equals number of pending items initially', async () => {
-            const { result } = await renderAndLoad();
-            const pendingCount = result.current.items.filter(i => i.status === 'pending').length;
-            expect(result.current.stats!.queueSize).toBe(pendingCount);
-        });
-
-        it('stats.queueSize decrements after approving one item', async () => {
-            const { result } = await renderAndLoad();
-            const initialQueue = result.current.stats!.queueSize;
-            const targetId = result.current.items[0].id;
-
-            act(() => {
-                result.current.handleAction(targetId, 'approve');
-            });
-
-            expect(result.current.stats!.queueSize).toBe(initialQueue - 1);
-        });
-
-        it('actionsToday increments after each action', async () => {
-            const { result } = await renderAndLoad();
-            const baseline = result.current.stats!.actionsToday;
-            const targetId = result.current.items[0].id;
-
-            act(() => {
-                result.current.handleAction(targetId, 'hide', 'spam');
-            });
-
-            expect(result.current.stats!.actionsToday).toBe(baseline + 1);
-        });
-
-        it('actionsThisWeek and actionsThisMonth also increment after an action', async () => {
-            const { result } = await renderAndLoad();
-            const baseWeek = result.current.stats!.actionsThisWeek;
-            const baseMonth = result.current.stats!.actionsThisMonth;
-            const targetId = result.current.items[0].id;
-
-            act(() => {
-                result.current.handleAction(targetId, 'delete', 'spam');
-            });
-
-            expect(result.current.stats!.actionsThisWeek).toBe(baseWeek + 1);
-            expect(result.current.stats!.actionsThisMonth).toBe(baseMonth + 1);
+        it('loads stats from getModerationStatsCall on mount', async () => {
+            const { result } = renderHook(() => useModerationQueue());
+            await waitFor(() => expect(result.current.loading).toBe(false));
+            expect(mockGetStats).toHaveBeenCalledTimes(1);
+            expect(result.current.stats).toEqual(MOCK_STATS);
         });
 
         it('stats are null while loading', () => {
+            // Delay resolution so loading stays true during check
+            mockGetQueue.mockReturnValue(new Promise(() => {}));
+            mockGetStats.mockReturnValue(new Promise(() => {}));
             const { result } = renderHook(() => useModerationQueue());
             expect(result.current.stats).toBeNull();
         });
     });
 
-    describe('mock avatar URLs (L-7)', () => {
-        it('no item author has a third-party avatar URL', async () => {
-            const { result } = await renderAndLoad();
-            result.current.items.forEach(item => {
-                const url = item.author.avatarUrl ?? '';
-                expect(url).not.toMatch(/^https?:\/\//);
+    describe('handleAction', () => {
+        it('calls takeModerationActionCall with split contentType and numeric contentId', async () => {
+            const { result } = renderHook(() => useModerationQueue());
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            await act(async () => {
+                await result.current.handleAction('vulnerability:5', 'hide', 'spam');
             });
+
+            expect(mockTakeAction).toHaveBeenCalledWith('vulnerability', 5, 'hide', 'spam');
+        });
+
+        it('refetches queue after a successful action', async () => {
+            const { result } = renderHook(() => useModerationQueue());
+            await waitFor(() => expect(result.current.loading).toBe(false));
+            // At this point queue was called once (mount)
+            expect(mockGetQueue).toHaveBeenCalledTimes(1);
+
+            await act(async () => {
+                await result.current.handleAction('vulnerability:5', 'approve');
+            });
+
+            // Should have been called again after the action
+            expect(mockGetQueue).toHaveBeenCalledTimes(2);
+        });
+
+        it('passes reason=undefined when not provided', async () => {
+            const { result } = renderHook(() => useModerationQueue());
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            await act(async () => {
+                await result.current.handleAction('report:10', 'approve');
+            });
+
+            expect(mockTakeAction).toHaveBeenCalledWith('report', 10, 'approve', undefined);
+        });
+
+        it('rejects a malformed id without calling the API', async () => {
+            const { result } = renderHook(() => useModerationQueue());
+            await waitFor(() => expect(result.current.loading).toBe(false));
+
+            await act(async () => {
+                await result.current.handleAction('not-a-valid-id', 'hide', 'spam');
+            });
+
+            expect(mockTakeAction).not.toHaveBeenCalled();
+            expect(mockShowError).toHaveBeenCalledWith('Invalid moderation item');
+        });
+    });
+
+    describe('error handling', () => {
+        it('stops loading and shows an error when the queue fetch fails', async () => {
+            mockGetQueue.mockRejectedValue(new Error('boom'));
+            const { result } = renderHook(() => useModerationQueue());
+
+            await waitFor(() => expect(result.current.loading).toBe(false));
+            expect(result.current.loading).toBe(false);
+            expect(mockShowError).toHaveBeenCalled();
         });
     });
 });

--- a/UI/src/features/moderation/hooks/useModerationQueue.ts
+++ b/UI/src/features/moderation/hooks/useModerationQueue.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { FlaggedContent, ModerationStats } from '../types';
 
 const MOCK_DATA: FlaggedContent[] = [
@@ -13,7 +13,7 @@ const MOCK_DATA: FlaggedContent[] = [
             name: 'AngryUser99',
             email: 'angry@example.com',
             reputationScore: 12,
-            avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Angry'
+            avatarUrl: ''
         },
         flagCount: 5,
         reasons: { spam: 1, misinformation: 3, harassment: 1, inappropriate: 0, other: 0 },
@@ -33,7 +33,7 @@ const MOCK_DATA: FlaggedContent[] = [
             name: 'SecurityResearcher',
             email: 'sec@research.com',
             reputationScore: 150,
-            avatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=Sec'
+            avatarUrl: ''
         },
         flagCount: 1,
         reasons: { spam: 1, misinformation: 0, harassment: 0, inappropriate: 0, other: 0 },
@@ -63,24 +63,20 @@ const MOCK_DATA: FlaggedContent[] = [
     }
 ];
 
-const MOCK_STATS: ModerationStats = {
-    queueSize: 3,
+const BASE_STATS = {
     actionsToday: 12,
     actionsThisWeek: 45,
     actionsThisMonth: 128,
-    flagBreakdown: { spam: 65, harassment: 12, inappropriate: 15, misinformation: 8, other: 5 }
 };
 
 export const useModerationQueue = () => {
     const [items, setItems] = useState<FlaggedContent[]>([]);
-    const [stats, setStats] = useState<ModerationStats | null>(null);
     const [loading, setLoading] = useState(true);
 
     useEffect(() => {
         // Simulate API call
         setTimeout(() => {
             setItems(MOCK_DATA);
-            setStats(MOCK_STATS);
             setLoading(false);
         }, 1000);
     }, []);
@@ -94,32 +90,25 @@ export const useModerationQueue = () => {
                     case 'hide': newStatus = 'hidden'; break;
                     case 'delete': newStatus = 'deleted'; break;
                 }
-                return { ...item, status: newStatus };
+                return { ...item, status: newStatus, lastAction: { action, reason } };
             }
             return item;
         }));
         // TODO: Backend Integration (Issue #87)
         // This will be replaced with: await api.moderation.takeAction(id, action, reason);
-        void reason; // Suppress unused var check for mock
     };
 
-    // Update stats when items change
-    useEffect(() => {
-        if (!loading && stats) {
-            const pendingCount = items.filter(i => i.status === 'pending').length;
-            const processedCount = items.filter(i => i.status !== 'pending').length;
-
-            setStats(prev => {
-                if (!prev) return null;
-                return {
-                    ...prev,
-                    queueSize: pendingCount,
-                    actionsToday: MOCK_STATS.actionsToday + processedCount,
-                    actionsThisWeek: MOCK_STATS.actionsThisWeek + processedCount,
-                    actionsThisMonth: MOCK_STATS.actionsThisMonth + processedCount
-                };
-            });
-        }
+    // Derive stats purely from items — no stale-closure risk
+    const stats: ModerationStats | null = useMemo(() => {
+        if (loading) return null;
+        const pendingCount = items.filter(i => i.status === 'pending').length;
+        const processedCount = items.filter(i => i.status !== 'pending').length;
+        return {
+            queueSize: pendingCount,
+            actionsToday: BASE_STATS.actionsToday + processedCount,
+            actionsThisWeek: BASE_STATS.actionsThisWeek + processedCount,
+            actionsThisMonth: BASE_STATS.actionsThisMonth + processedCount,
+        };
     }, [items, loading]);
 
     return { items, stats, loading, handleAction };

--- a/UI/src/features/moderation/hooks/useModerationQueue.ts
+++ b/UI/src/features/moderation/hooks/useModerationQueue.ts
@@ -20,7 +20,7 @@ export const useModerationQueue = () => {
             ]);
             setItems(queueItems);
             setStats(queueStats);
-        } catch (error) {
+        } catch {
             showError('Failed to load moderation queue. Please try again.');
         } finally {
             setLoading(false);
@@ -41,7 +41,7 @@ export const useModerationQueue = () => {
         try {
             await takeModerationActionCall(contentType, contentId, action, reason);
             await refetch();
-        } catch (error) {
+        } catch {
             showError('Failed to perform moderation action. Please try again.');
         }
     };

--- a/UI/src/features/moderation/hooks/useModerationQueue.ts
+++ b/UI/src/features/moderation/hooks/useModerationQueue.ts
@@ -1,115 +1,50 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { FlaggedContent, ModerationStats } from '../types';
-
-const MOCK_DATA: FlaggedContent[] = [
-    {
-        id: '1',
-        contentType: 'comment',
-        contentId: 'c123',
-        contentPreview: 'This project is a scam!',
-        fullContent: 'This project is a complete scam, do not invest! I heard the devs are running away.',
-        author: {
-            id: 'u1',
-            name: 'AngryUser99',
-            email: 'angry@example.com',
-            reputationScore: 12,
-            avatarUrl: ''
-        },
-        flagCount: 5,
-        reasons: { spam: 1, misinformation: 3, harassment: 1, inappropriate: 0, other: 0 },
-        firstFlaggedAt: new Date(Date.now() - 86400000 * 2).toISOString(),
-        lastFlaggedAt: new Date(Date.now() - 3600000).toISOString(),
-        status: 'pending',
-        moderationHistory: []
-    },
-    {
-        id: '2',
-        contentType: 'report',
-        contentId: 'r456',
-        contentPreview: 'Vulnerability in Smart Contract',
-        fullContent: 'I found a critical vulnerability...',
-        author: {
-            id: 'u2',
-            name: 'SecurityResearcher',
-            email: 'sec@research.com',
-            reputationScore: 150,
-            avatarUrl: ''
-        },
-        flagCount: 1,
-        reasons: { spam: 1, misinformation: 0, harassment: 0, inappropriate: 0, other: 0 },
-        firstFlaggedAt: new Date(Date.now() - 86400000).toISOString(),
-        lastFlaggedAt: new Date(Date.now() - 86400000).toISOString(),
-        status: 'pending',
-        moderationHistory: []
-    },
-    {
-        id: '3',
-        contentType: 'user_profile',
-        contentId: 'u789',
-        contentPreview: 'Bot Account 123',
-        fullContent: 'Bio with spam links: visit myspamlink.com',
-        author: {
-            id: 'u3',
-            name: 'BotAccount123',
-            email: 'bot@spam.com',
-            reputationScore: 0,
-        },
-        flagCount: 15,
-        reasons: { spam: 15, misinformation: 0, harassment: 0, inappropriate: 0, other: 0 },
-        firstFlaggedAt: new Date(Date.now() - 86400000 * 5).toISOString(),
-        lastFlaggedAt: new Date(Date.now() - 10000).toISOString(),
-        status: 'pending',
-        moderationHistory: []
-    }
-];
-
-const BASE_STATS = {
-    actionsToday: 12,
-    actionsThisWeek: 45,
-    actionsThisMonth: 128,
-};
+import {
+    getModerationQueueCall,
+    getModerationStatsCall,
+    takeModerationActionCall,
+} from '../../../api/soroban-security-portal/soroban-security-portal-api';
+import { showError } from '../../dialog-handler/dialog-handler';
 
 export const useModerationQueue = () => {
     const [items, setItems] = useState<FlaggedContent[]>([]);
+    const [stats, setStats] = useState<ModerationStats | null>(null);
     const [loading, setLoading] = useState(true);
 
-    useEffect(() => {
-        // Simulate API call
-        setTimeout(() => {
-            setItems(MOCK_DATA);
+    const refetch = useCallback(async () => {
+        try {
+            const [queueItems, queueStats] = await Promise.all([
+                getModerationQueueCall(),
+                getModerationStatsCall(),
+            ]);
+            setItems(queueItems);
+            setStats(queueStats);
+        } catch (error) {
+            showError('Failed to load moderation queue. Please try again.');
+        } finally {
             setLoading(false);
-        }, 1000);
+        }
     }, []);
 
-    const handleAction = (id: string, action: 'approve' | 'hide' | 'delete', reason?: string) => {
-        setItems(prev => prev.map(item => {
-            if (item.id === id) {
-                let newStatus: 'approved' | 'hidden' | 'deleted' | 'pending' = 'pending';
-                switch (action) {
-                    case 'approve': newStatus = 'approved'; break;
-                    case 'hide': newStatus = 'hidden'; break;
-                    case 'delete': newStatus = 'deleted'; break;
-                }
-                return { ...item, status: newStatus, lastAction: { action, reason } };
-            }
-            return item;
-        }));
-        // TODO: Backend Integration (Issue #87)
-        // This will be replaced with: await api.moderation.takeAction(id, action, reason);
+    useEffect(() => {
+        refetch();
+    }, [refetch]);
+
+    const handleAction = async (id: string, action: 'approve' | 'hide' | 'delete', reason?: string) => {
+        const [contentType, contentIdStr] = id.split(':');
+        const contentId = Number(contentIdStr);
+        if (!contentType || Number.isNaN(contentId)) {
+            showError('Invalid moderation item');
+            return;
+        }
+        try {
+            await takeModerationActionCall(contentType, contentId, action, reason);
+            await refetch();
+        } catch (error) {
+            showError('Failed to perform moderation action. Please try again.');
+        }
     };
 
-    // Derive stats purely from items — no stale-closure risk
-    const stats: ModerationStats | null = useMemo(() => {
-        if (loading) return null;
-        const pendingCount = items.filter(i => i.status === 'pending').length;
-        const processedCount = items.filter(i => i.status !== 'pending').length;
-        return {
-            queueSize: pendingCount,
-            actionsToday: BASE_STATS.actionsToday + processedCount,
-            actionsThisWeek: BASE_STATS.actionsThisWeek + processedCount,
-            actionsThisMonth: BASE_STATS.actionsThisMonth + processedCount,
-        };
-    }, [items, loading]);
-
-    return { items, stats, loading, handleAction };
+    return { items, stats, loading, handleAction, refetch };
 };

--- a/UI/src/features/moderation/pages/ModerationDashboard.tsx
+++ b/UI/src/features/moderation/pages/ModerationDashboard.tsx
@@ -56,9 +56,17 @@ export const ModerationDashboard = () => {
                     <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 2, mb: 3 }}>
                         <Button
                             size="small"
-                            variant="outlined"
                             startIcon={<RefreshIcon />}
                             onClick={() => refetch()}
+                            sx={{
+                                fontWeight: 600,
+                                bgcolor: 'transparent',
+                                color: 'text.secondary',
+                                border: '1px solid',
+                                borderColor: 'divider',
+                                boxShadow: 'none',
+                                '&:hover': { bgcolor: 'action.hover', borderColor: 'text.secondary', color: 'text.primary' },
+                            }}
                         >
                             Refresh
                         </Button>

--- a/UI/src/features/moderation/pages/ModerationDashboard.tsx
+++ b/UI/src/features/moderation/pages/ModerationDashboard.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import {
     Box, Container, Typography, Tab, Tabs,
     FormControl, InputLabel, Select, MenuItem, Paper,
-    CircularProgress, Alert
+    CircularProgress
 } from '@mui/material';
 import { useModerationQueue } from '../hooks/useModerationQueue';
 import { ModerationStats } from '../components/ModerationStats';
@@ -30,9 +30,6 @@ export const ModerationDashboard = () => {
 
     return (
         <Container maxWidth="lg" sx={{ py: 4 }}>
-            <Alert severity="info" sx={{ mb: 3 }}>
-                Demo data — moderation backend pending. Actions are not yet persisted.
-            </Alert>
             <Box sx={{ mb: 4 }}>
                 <Typography variant="h4" sx={{ fontWeight: 'bold' }} gutterBottom>
                     Moderation Dashboard

--- a/UI/src/features/moderation/pages/ModerationDashboard.tsx
+++ b/UI/src/features/moderation/pages/ModerationDashboard.tsx
@@ -78,10 +78,8 @@ export const ModerationDashboard = () => {
                                 onChange={(e) => setContentTypeFilter(e.target.value as ContentType | 'all')}
                             >
                                 <MenuItem value="all">All Content</MenuItem>
-                                <MenuItem value="comment">Comments</MenuItem>
-                                <MenuItem value="report">Reports</MenuItem>
-                                <MenuItem value="user_profile">User Profiles</MenuItem>
                                 <MenuItem value="vulnerability">Vulnerabilities</MenuItem>
+                                <MenuItem value="report">Reports</MenuItem>
                             </Select>
                         </FormControl>
                     </Box>

--- a/UI/src/features/moderation/pages/ModerationDashboard.tsx
+++ b/UI/src/features/moderation/pages/ModerationDashboard.tsx
@@ -2,15 +2,16 @@ import { useState } from 'react';
 import {
     Box, Container, Typography, Tab, Tabs,
     FormControl, InputLabel, Select, MenuItem, Paper,
-    CircularProgress
+    CircularProgress, Button
 } from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
 import { useModerationQueue } from '../hooks/useModerationQueue';
 import { ModerationStats } from '../components/ModerationStats';
 import { ModerationItem } from '../components/ModerationItem';
 import { ContentType, ModerationStatus } from '../types';
 
 export const ModerationDashboard = () => {
-    const { items, stats, loading, handleAction } = useModerationQueue();
+    const { items, stats, loading, handleAction, refetch } = useModerationQueue();
     const [currentTab, setCurrentTab] = useState<ModerationStatus>('pending');
     const [contentTypeFilter, setContentTypeFilter] = useState<ContentType | 'all'>('all');
 
@@ -52,7 +53,15 @@ export const ModerationDashboard = () => {
                 </Box>
 
                 <Box sx={{ p: 3 }}>
-                    <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 3 }}>
+                    <Box sx={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', gap: 2, mb: 3 }}>
+                        <Button
+                            size="small"
+                            variant="outlined"
+                            startIcon={<RefreshIcon />}
+                            onClick={() => refetch()}
+                        >
+                            Refresh
+                        </Button>
                         <FormControl size="small" sx={{ minWidth: 200 }}>
                             <InputLabel>Content Type</InputLabel>
                             <Select

--- a/UI/src/features/moderation/pages/ModerationDashboard.tsx
+++ b/UI/src/features/moderation/pages/ModerationDashboard.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import {
     Box, Container, Typography, Tab, Tabs,
     FormControl, InputLabel, Select, MenuItem, Paper,
-    CircularProgress
+    CircularProgress, Alert
 } from '@mui/material';
 import { useModerationQueue } from '../hooks/useModerationQueue';
 import { ModerationStats } from '../components/ModerationStats';
@@ -30,6 +30,9 @@ export const ModerationDashboard = () => {
 
     return (
         <Container maxWidth="lg" sx={{ py: 4 }}>
+            <Alert severity="info" sx={{ mb: 3 }}>
+                Demo data — moderation backend pending. Actions are not yet persisted.
+            </Alert>
             <Box sx={{ mb: 4 }}>
                 <Typography variant="h4" sx={{ fontWeight: 'bold' }} gutterBottom>
                     Moderation Dashboard

--- a/UI/src/features/moderation/pages/__tests__/ModerationDashboard.test.tsx
+++ b/UI/src/features/moderation/pages/__tests__/ModerationDashboard.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { MemoryRouter } from 'react-router-dom';
 import { ModerationDashboard } from '../ModerationDashboard';
 import { FlaggedContent, ModerationStats } from '../../types';
 
@@ -79,6 +80,7 @@ vi.mock('../../hooks/useModerationQueue', () => ({
         stats: STATS,
         loading: false,
         handleAction: mockHandleAction,
+        refetch: vi.fn(),
     }),
 }));
 
@@ -86,9 +88,11 @@ const theme = createTheme();
 
 const renderComponent = () =>
     render(
-        <ThemeProvider theme={theme}>
-            <ModerationDashboard />
-        </ThemeProvider>
+        <MemoryRouter>
+            <ThemeProvider theme={theme}>
+                <ModerationDashboard />
+            </ThemeProvider>
+        </MemoryRouter>
     );
 
 describe('ModerationDashboard - filtering', () => {

--- a/UI/src/features/moderation/pages/__tests__/ModerationDashboard.test.tsx
+++ b/UI/src/features/moderation/pages/__tests__/ModerationDashboard.test.tsx
@@ -24,11 +24,11 @@ const baseReasons = { spam: 1, harassment: 0, inappropriate: 0, misinformation: 
 const ITEMS: FlaggedContent[] = [
     {
         id: 'c1',
-        contentType: 'comment',
+        contentType: 'vulnerability',
         contentId: 'cid1',
-        contentPreview: 'A flagged comment',
-        fullContent: 'A flagged comment',
-        author: baseAuthor('CommentAuthor'),
+        contentPreview: 'A flagged vulnerability',
+        fullContent: 'A flagged vulnerability',
+        author: baseAuthor('VulnAuthor'),
         flagCount: 1,
         reasons: baseReasons,
         firstFlaggedAt: new Date().toISOString(),
@@ -52,10 +52,10 @@ const ITEMS: FlaggedContent[] = [
     },
     {
         id: 'h1',
-        contentType: 'comment',
+        contentType: 'vulnerability',
         contentId: 'cid2',
-        contentPreview: 'An already-hidden comment',
-        fullContent: 'An already-hidden comment',
+        contentPreview: 'An already-hidden vulnerability',
+        fullContent: 'An already-hidden vulnerability',
         author: baseAuthor('HiddenAuthor'),
         flagCount: 1,
         reasons: baseReasons,
@@ -102,17 +102,17 @@ describe('ModerationDashboard - filtering', () => {
 
     it('default pending tab shows both pending items and hides the hidden one', () => {
         renderComponent();
-        expect(screen.getByText('CommentAuthor')).toBeInTheDocument();
+        expect(screen.getByText('VulnAuthor')).toBeInTheDocument();
         expect(screen.getByText('ReportAuthor')).toBeInTheDocument();
         expect(screen.queryByText('HiddenAuthor')).not.toBeInTheDocument();
     });
 
-    it('content-type filter "Reports" shows the report item and hides the comment item', async () => {
+    it('content-type filter "Reports" shows the report item and hides the vulnerability item', async () => {
         const user = userEvent.setup();
         renderComponent();
 
         // Both pending items visible initially
-        expect(screen.getByText('CommentAuthor')).toBeInTheDocument();
+        expect(screen.getByText('VulnAuthor')).toBeInTheDocument();
         expect(screen.getByText('ReportAuthor')).toBeInTheDocument();
 
         // Open the Content Type select and choose Reports
@@ -124,10 +124,10 @@ describe('ModerationDashboard - filtering', () => {
 
         // Now only the report item should remain
         expect(screen.getByText('ReportAuthor')).toBeInTheDocument();
-        expect(screen.queryByText('CommentAuthor')).not.toBeInTheDocument();
+        expect(screen.queryByText('VulnAuthor')).not.toBeInTheDocument();
     });
 
-    it('content-type filter "Comments" shows the comment item and hides the report item', async () => {
+    it('content-type filter "Vulnerabilities" shows the vulnerability item and hides the report item', async () => {
         const user = userEvent.setup();
         renderComponent();
 
@@ -135,9 +135,9 @@ describe('ModerationDashboard - filtering', () => {
         // programmatically associated, so target it by role).
         await user.click(screen.getByRole('combobox'));
         const listbox = within(screen.getByRole('listbox'));
-        await user.click(listbox.getByText('Comments'));
+        await user.click(listbox.getByText('Vulnerabilities'));
 
-        expect(screen.getByText('CommentAuthor')).toBeInTheDocument();
+        expect(screen.getByText('VulnAuthor')).toBeInTheDocument();
         expect(screen.queryByText('ReportAuthor')).not.toBeInTheDocument();
     });
 
@@ -148,11 +148,11 @@ describe('ModerationDashboard - filtering', () => {
         await user.click(screen.getByRole('tab', { name: /History \(Hidden\)/i }));
 
         expect(screen.getByText('HiddenAuthor')).toBeInTheDocument();
-        expect(screen.queryByText('CommentAuthor')).not.toBeInTheDocument();
+        expect(screen.queryByText('VulnAuthor')).not.toBeInTheDocument();
         expect(screen.queryByText('ReportAuthor')).not.toBeInTheDocument();
     });
 
-    it('combining the Hidden tab with the Comments filter narrows to the hidden comment', async () => {
+    it('combining the Hidden tab with the Vulnerabilities filter narrows to the hidden vulnerability', async () => {
         const user = userEvent.setup();
         renderComponent();
 
@@ -161,9 +161,9 @@ describe('ModerationDashboard - filtering', () => {
         // programmatically associated, so target it by role).
         await user.click(screen.getByRole('combobox'));
         const listbox = within(screen.getByRole('listbox'));
-        await user.click(listbox.getByText('Comments'));
+        await user.click(listbox.getByText('Vulnerabilities'));
 
-        // The hidden item is a comment, so it remains
+        // The hidden item is a vulnerability, so it remains
         expect(screen.getByText('HiddenAuthor')).toBeInTheDocument();
     });
 

--- a/UI/src/features/moderation/pages/__tests__/ModerationDashboard.test.tsx
+++ b/UI/src/features/moderation/pages/__tests__/ModerationDashboard.test.tsx
@@ -96,11 +96,6 @@ describe('ModerationDashboard - filtering', () => {
         vi.clearAllMocks();
     });
 
-    it('shows the demo-data banner', () => {
-        renderComponent();
-        expect(screen.getByText(/Demo data/i)).toBeInTheDocument();
-    });
-
     it('default pending tab shows both pending items and hides the hidden one', () => {
         renderComponent();
         expect(screen.getByText('CommentAuthor')).toBeInTheDocument();

--- a/UI/src/features/moderation/pages/__tests__/ModerationDashboard.test.tsx
+++ b/UI/src/features/moderation/pages/__tests__/ModerationDashboard.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ModerationDashboard } from '../ModerationDashboard';
+import { FlaggedContent, ModerationStats } from '../../types';
+
+// The tab + content-type filter logic lives in ModerationDashboard.tsx
+// (items.filter(...)). We mock the hook to supply a deterministic, already
+// loaded data set so the test exercises the REAL filter, not the mock delay.
+const mockHandleAction = vi.fn();
+
+const baseAuthor = (name: string) => ({
+    id: `author-${name}`,
+    name,
+    email: `${name}@example.com`,
+    reputationScore: 10,
+    avatarUrl: '',
+});
+
+const baseReasons = { spam: 1, harassment: 0, inappropriate: 0, misinformation: 0, other: 0 };
+
+const ITEMS: FlaggedContent[] = [
+    {
+        id: 'c1',
+        contentType: 'comment',
+        contentId: 'cid1',
+        contentPreview: 'A flagged comment',
+        fullContent: 'A flagged comment',
+        author: baseAuthor('CommentAuthor'),
+        flagCount: 1,
+        reasons: baseReasons,
+        firstFlaggedAt: new Date().toISOString(),
+        lastFlaggedAt: new Date().toISOString(),
+        status: 'pending',
+        moderationHistory: [],
+    },
+    {
+        id: 'r1',
+        contentType: 'report',
+        contentId: 'rid1',
+        contentPreview: 'A flagged report',
+        fullContent: 'A flagged report',
+        author: baseAuthor('ReportAuthor'),
+        flagCount: 1,
+        reasons: baseReasons,
+        firstFlaggedAt: new Date().toISOString(),
+        lastFlaggedAt: new Date().toISOString(),
+        status: 'pending',
+        moderationHistory: [],
+    },
+    {
+        id: 'h1',
+        contentType: 'comment',
+        contentId: 'cid2',
+        contentPreview: 'An already-hidden comment',
+        fullContent: 'An already-hidden comment',
+        author: baseAuthor('HiddenAuthor'),
+        flagCount: 1,
+        reasons: baseReasons,
+        firstFlaggedAt: new Date().toISOString(),
+        lastFlaggedAt: new Date().toISOString(),
+        status: 'hidden',
+        moderationHistory: [],
+        lastAction: { action: 'hide', reason: 'spam' },
+    },
+];
+
+const STATS: ModerationStats = {
+    queueSize: 2,
+    actionsToday: 5,
+    actionsThisWeek: 10,
+    actionsThisMonth: 20,
+};
+
+vi.mock('../../hooks/useModerationQueue', () => ({
+    useModerationQueue: () => ({
+        items: ITEMS,
+        stats: STATS,
+        loading: false,
+        handleAction: mockHandleAction,
+    }),
+}));
+
+const theme = createTheme();
+
+const renderComponent = () =>
+    render(
+        <ThemeProvider theme={theme}>
+            <ModerationDashboard />
+        </ThemeProvider>
+    );
+
+describe('ModerationDashboard - filtering', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('shows the demo-data banner', () => {
+        renderComponent();
+        expect(screen.getByText(/Demo data/i)).toBeInTheDocument();
+    });
+
+    it('default pending tab shows both pending items and hides the hidden one', () => {
+        renderComponent();
+        expect(screen.getByText('CommentAuthor')).toBeInTheDocument();
+        expect(screen.getByText('ReportAuthor')).toBeInTheDocument();
+        expect(screen.queryByText('HiddenAuthor')).not.toBeInTheDocument();
+    });
+
+    it('content-type filter "Reports" shows the report item and hides the comment item', async () => {
+        const user = userEvent.setup();
+        renderComponent();
+
+        // Both pending items visible initially
+        expect(screen.getByText('CommentAuthor')).toBeInTheDocument();
+        expect(screen.getByText('ReportAuthor')).toBeInTheDocument();
+
+        // Open the Content Type select and choose Reports
+        // The MUI Select renders a single combobox (its InputLabel is not
+        // programmatically associated, so target it by role).
+        await user.click(screen.getByRole('combobox'));
+        const listbox = within(screen.getByRole('listbox'));
+        await user.click(listbox.getByText('Reports'));
+
+        // Now only the report item should remain
+        expect(screen.getByText('ReportAuthor')).toBeInTheDocument();
+        expect(screen.queryByText('CommentAuthor')).not.toBeInTheDocument();
+    });
+
+    it('content-type filter "Comments" shows the comment item and hides the report item', async () => {
+        const user = userEvent.setup();
+        renderComponent();
+
+        // The MUI Select renders a single combobox (its InputLabel is not
+        // programmatically associated, so target it by role).
+        await user.click(screen.getByRole('combobox'));
+        const listbox = within(screen.getByRole('listbox'));
+        await user.click(listbox.getByText('Comments'));
+
+        expect(screen.getByText('CommentAuthor')).toBeInTheDocument();
+        expect(screen.queryByText('ReportAuthor')).not.toBeInTheDocument();
+    });
+
+    it('switching to the Hidden history tab shows hidden items and hides pending ones', async () => {
+        const user = userEvent.setup();
+        renderComponent();
+
+        await user.click(screen.getByRole('tab', { name: /History \(Hidden\)/i }));
+
+        expect(screen.getByText('HiddenAuthor')).toBeInTheDocument();
+        expect(screen.queryByText('CommentAuthor')).not.toBeInTheDocument();
+        expect(screen.queryByText('ReportAuthor')).not.toBeInTheDocument();
+    });
+
+    it('combining the Hidden tab with the Comments filter narrows to the hidden comment', async () => {
+        const user = userEvent.setup();
+        renderComponent();
+
+        await user.click(screen.getByRole('tab', { name: /History \(Hidden\)/i }));
+        // The MUI Select renders a single combobox (its InputLabel is not
+        // programmatically associated, so target it by role).
+        await user.click(screen.getByRole('combobox'));
+        const listbox = within(screen.getByRole('listbox'));
+        await user.click(listbox.getByText('Comments'));
+
+        // The hidden item is a comment, so it remains
+        expect(screen.getByText('HiddenAuthor')).toBeInTheDocument();
+    });
+
+    it('an empty queue (e.g. Approved tab with no items) shows the empty-state message', async () => {
+        const user = userEvent.setup();
+        renderComponent();
+
+        await user.click(screen.getByRole('tab', { name: /History \(Approved\)/i }));
+
+        expect(screen.getByText(/No items found in this queue/i)).toBeInTheDocument();
+    });
+});

--- a/UI/src/features/moderation/types/index.ts
+++ b/UI/src/features/moderation/types/index.ts
@@ -1,4 +1,6 @@
-export type ContentType = 'comment' | 'report' | 'user_profile' | 'vulnerability';
+// Only vulnerabilities and reports can be flagged/moderated today (no comment entity exists,
+// and there's no UI to view another user's profile). Keep this in sync with the backend.
+export type ContentType = 'report' | 'vulnerability';
 
 export type FlagReason = 'spam' | 'harassment' | 'inappropriate' | 'misinformation' | 'other';
 

--- a/UI/src/features/moderation/types/index.ts
+++ b/UI/src/features/moderation/types/index.ts
@@ -25,6 +25,7 @@ export interface FlaggedContent {
     lastFlaggedAt: string; // ISO Date
     status: ModerationStatus;
     moderationHistory: ModerationAction[];
+    lastAction?: { action: 'approve' | 'hide' | 'delete'; reason?: string };
 }
 
 export interface ModerationAction {
@@ -41,7 +42,6 @@ export interface ModerationStats {
     actionsToday: number;
     actionsThisWeek: number;
     actionsThisMonth: number;
-    flagBreakdown: Record<FlagReason, number>;
 }
 
 export interface ModerationFilters {

--- a/UI/src/features/moderation/types/index.ts
+++ b/UI/src/features/moderation/types/index.ts
@@ -12,6 +12,12 @@ export interface Author {
     reputationScore: number;
 }
 
+export interface ContentFlagDetail {
+    reason: string;
+    comment?: string;
+    createdAt: string;
+}
+
 export interface FlaggedContent {
     id: string;
     contentType: ContentType;
@@ -21,6 +27,7 @@ export interface FlaggedContent {
     author: Author;
     flagCount: number;
     reasons: Record<FlagReason, number>; // e.g. { spam: 2, harassment: 1 }
+    flags?: ContentFlagDetail[]; // individual reports: each flagger's reason + note
     firstFlaggedAt: string; // ISO Date
     lastFlaggedAt: string; // ISO Date
     status: ModerationStatus;

--- a/UI/src/features/pages/regular/main-window/main-window.tsx
+++ b/UI/src/features/pages/regular/main-window/main-window.tsx
@@ -37,6 +37,7 @@ import { ProtocolDetails } from '../protocol-details/protocol-details';
 import { ReportDetails } from '../report-details/report-details';
 import { AuditorDetails } from '../auditor-details/auditor-details';
 import { CompanyDetails } from '../company-details/company-details';
+import { BadgeDemoPage } from '../../BadgeDemoPage';
 import { useTheme } from '../../../../contexts/ThemeContext';
 import { useToolbarAvatar } from '../../../../hooks/useToolbarAvatar';
 import { getUserInitials } from '../../../../utils/user-utils';
@@ -355,6 +356,7 @@ export const MainWindow: FC = () => {
             <Route path={`${environment.basePath}/report/:id`} element={<ReportDetails />} />
             <Route path={`${environment.basePath}/auditor/:id`} element={<AuditorDetails />} />
             <Route path={`${environment.basePath}/company/:id`} element={<CompanyDetails />} />
+            <Route path={`${environment.basePath}/badge-demo`} element={<BadgeDemoPage />} />
           </Routes>
         </Box>
       </Box>

--- a/UI/src/features/pages/regular/profile/profile.tsx
+++ b/UI/src/features/pages/regular/profile/profile.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Button, Paper, Typography, Box, Tabs, Tab, IconButton, List, ListItem, ListItemIcon, ListItemSecondaryAction } from '@mui/material';
+import { Alert, Button, Paper, Typography, Box, Tabs, Tab, IconButton, List, ListItem, ListItemIcon, ListItemSecondaryAction } from '@mui/material';
 import { useProfile } from './hooks';
 import { styled } from '@mui/material/styles';
 import { showError, showSuccess } from '../../../dialog-handler/dialog-handler';
@@ -16,6 +16,9 @@ import { useBookmarks } from '../../../../contexts/BookmarkContext';
 import { BookmarkType } from '../../../../api/soroban-security-portal/models/bookmark';
 import { StyledAvatar } from '../../../../components/common/StyledAvatar';
 import { getUserInitials } from '../../../../utils/user-utils';
+import { BadgeShowcase } from '../../../../components/BadgeShowcase';
+// TODO: replace mockBadges with real badge API (no backend badge endpoint yet)
+import { MOCK_BADGES } from '../../../../utils/mockBadges';
 
 const ProfileContainer = styled(Box)(({ theme }) => ({
   minHeight: '100vh',
@@ -266,6 +269,7 @@ export const Profile: React.FC = () => {
           >
             <Tab label="Profile" {...a11yProps(0)} />
             <Tab label="Bookmarks" {...a11yProps(1)} />
+            <Tab label="Badges" {...a11yProps(2)} />
           </Tabs>
         </Box>
 
@@ -387,6 +391,14 @@ export const Profile: React.FC = () => {
                 ))}
               </List>
             )}
+          </TabPanel>
+
+          <TabPanel value={tabValue} index={2}>
+            {/* Badges — TODO: replace mockBadges with real badge API (no backend badge endpoint yet) */}
+            <Alert severity="info" sx={{ mb: 3 }}>
+              Badge preview — achievement tracking is coming soon. These are sample badges, not earned achievements.
+            </Alert>
+            <BadgeShowcase badges={MOCK_BADGES} />
           </TabPanel>
         </ContentSection>
 

--- a/UI/src/features/pages/regular/report-details/report-details.tsx
+++ b/UI/src/features/pages/regular/report-details/report-details.tsx
@@ -40,6 +40,7 @@ import {
   VulnerabilityCategory,
 } from '../../../../api/soroban-security-portal/models/vulnerability';
 import { BookmarkButton } from '../../../../components/BookmarkButton';
+import { FlagButton } from '../../../../components/FlagButton';
 import { BookmarkType } from '../../../../api/soroban-security-portal/models/bookmark';
 import { useBookmarks } from '../../../../contexts/BookmarkContext';
 import { downloadReportPDF } from '../../../../api/soroban-security-portal/soroban-security-portal-api';
@@ -233,12 +234,15 @@ export const ReportDetails: FC = () => {
               }
               headerExtra={
                 auth.isAuthenticated && (
-                  <BookmarkButton
-                    itemId={report.id ?? 0}
-                    bookmarkType={BookmarkType.Report}
-                    isBookmarked={isBookmarked(report.id ?? 0, BookmarkType.Report)}
-                    onToggle={toggleBookmark}
-                  />
+                  <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                    <FlagButton contentType="report" contentId={report.id ?? 0} />
+                    <BookmarkButton
+                      itemId={report.id ?? 0}
+                      bookmarkType={BookmarkType.Report}
+                      isBookmarked={isBookmarked(report.id ?? 0, BookmarkType.Report)}
+                      onToggle={toggleBookmark}
+                    />
+                  </Stack>
                 )
               }
             />

--- a/UI/src/features/pages/regular/vulnerability-details/vulnerability-details.tsx
+++ b/UI/src/features/pages/regular/vulnerability-details/vulnerability-details.tsx
@@ -24,6 +24,7 @@ import { getCategoryLabel, getCategoryImage } from '../../../../api/soroban-secu
 import { environment } from '../../../../environments/environment';
 import { MarkdownView } from '../../../../components/MarkdownView';
 import { BookmarkButton } from '../../../../components/BookmarkButton';
+import { FlagButton } from '../../../../components/FlagButton';
 import { BookmarkType } from '../../../../api/soroban-security-portal/models/bookmark';
 import { useBookmarks } from '../../../../contexts/BookmarkContext';
 import { useAppAuth } from '../../../authentication/useAppAuth';
@@ -118,12 +119,15 @@ export const VulnerabilityDetails: FC = () => {
                 </Typography>
               </Box>
               {isAuthenticated && (
-                <BookmarkButton
-                  itemId={vulnerabilityId}
-                  bookmarkType={BookmarkType.Vulnerability}
-                  isBookmarked={isBookmarked(vulnerabilityId, BookmarkType.Vulnerability)}
-                  onToggle={toggleBookmark}
-                />
+                <Stack direction="row" spacing={0.5} sx={{ alignItems: 'center' }}>
+                  <FlagButton contentType="vulnerability" contentId={vulnerabilityId} />
+                  <BookmarkButton
+                    itemId={vulnerabilityId}
+                    bookmarkType={BookmarkType.Vulnerability}
+                    isBookmarked={isBookmarked(vulnerabilityId, BookmarkType.Vulnerability)}
+                    onToggle={toggleBookmark}
+                  />
+                </Stack>
               )}
             </Box>
 

--- a/UI/src/utils/mockBadges.ts
+++ b/UI/src/utils/mockBadges.ts
@@ -9,7 +9,7 @@ export const MOCK_BADGES: UserBadge[] = [
         rarity: BadgeRarity.COMMON,
         icon: '💬',
         color: '#4CAF50',
-        awardedAt: new Date('2024-01-15'),
+        awardedAt: '2024-01-15T00:00:00.000Z',
         isLocked: false,
     },
     {
@@ -20,7 +20,7 @@ export const MOCK_BADGES: UserBadge[] = [
         rarity: BadgeRarity.RARE,
         icon: '🔍',
         color: '#2196F3',
-        awardedAt: new Date('2024-02-20'),
+        awardedAt: '2024-02-20T00:00:00.000Z',
         isLocked: false,
     },
     {
@@ -31,7 +31,7 @@ export const MOCK_BADGES: UserBadge[] = [
         rarity: BadgeRarity.EPIC,
         icon: '🛡️',
         color: '#9C27B0',
-        awardedAt: new Date('2024-03-10'),
+        awardedAt: '2024-03-10T00:00:00.000Z',
         isLocked: false,
     },
     {
@@ -42,7 +42,7 @@ export const MOCK_BADGES: UserBadge[] = [
         rarity: BadgeRarity.LEGENDARY,
         icon: '👑',
         color: '#FF9800',
-        awardedAt: new Date('2024-04-05'),
+        awardedAt: '2024-04-05T00:00:00.000Z',
         isLocked: false,
     },
     {
@@ -53,7 +53,7 @@ export const MOCK_BADGES: UserBadge[] = [
         rarity: BadgeRarity.RARE,
         icon: '📝',
         color: '#2196F3',
-        awardedAt: new Date(),
+        awardedAt: '2024-05-01T00:00:00.000Z',
         isLocked: true,
         progress: 60,
     },
@@ -65,7 +65,7 @@ export const MOCK_BADGES: UserBadge[] = [
         rarity: BadgeRarity.EPIC,
         icon: '🐛',
         color: '#9C27B0',
-        awardedAt: new Date(),
+        awardedAt: '2024-05-01T00:00:00.000Z',
         isLocked: true,
         progress: 40,
     },

--- a/docs/audits/trustless-work-runtime-verification.md
+++ b/docs/audits/trustless-work-runtime-verification.md
@@ -17,12 +17,10 @@ Some public Smart Escrow functions accept the parameter `trustless_work_address:
 
 However, both `resolve_dispute` and `release_funds` are access-restricted. In the case of `release_funds`, only the `release_signer` can sign the function call, while for `resolve_dispute`, only the `dispute_resolver` can sign the function call.
 
-**## Recommendation**
-
+## Recommendation
 We recommend hard-coding the address of Trustless Work into the Smart Contract or using some other secure method to query the address at runtime.
 
-**## Status**
-
+## Status
 The client has addressed this finding by hard-coding the Trustless Work address into the contract and using it internally instead of requiring it as an input parameter. The modification was already implemented in another version of the contract, which was deployed for testing.
 
 
@@ -62,12 +60,10 @@ let net_approver_funds = if total_resolved_funds > 0 {
 
 Here, the variable `net_approver_funds` will be negative in case `total_fees` is bigger than `total_resolved_funds`.
 
-**## Recommendation**
-
+## Recommendation
 We recommend that during both initialization and Smart Escrow update, the sum of the `trustless_work_fee` and `platform_fee` is validated to be less than 100%.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`1da344e`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/1da344e) in branch `single-release-develop`.
 
 
@@ -82,14 +78,12 @@ At initialization, an `Escrow` object is passed that defines the Smart Escrow pr
 
 This function does not check whether any passed milestone already has the `approved` flag set to `true`. This allows the contract initializer to circumvent the `approver` role.
 
-**## Recommendation**
-
+## Recommendation
 We recommend to either:
 - validate during initialization and smart escrow update that the passed `Escrow` object has all `approved` flags set to `false`
 - override during initialization and smart escrow update the passed `Escrow` object and set all `approved` flags to `false`
 
-**## Status**
-
+## Status
 This finding has been partially addressed in commit ID [`6d979b5`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/6d979b5) in branch `single-release-develop`.
 
 
@@ -108,12 +102,10 @@ However, in contrast to the initialization, no validation is performed on the pa
 
 Notice that, even though the initialization endpoint and the update endpoint have extremely similar purposes (modifying the escrow state), the set of validations performed by each endpoint is different. This creates opportunities for unpredictable behaviors, as, for instance, an escrow can be updated to have more than 10 milestones, even though its initialization enforces that this shouldn't be possible. Similarly, an escrow can be updated for its amount to be zero, even though its initialization enforces that this shouldn't be possible.
 
-**## Recommendation**
-
+## Recommendation
 We recommend to use the same function `validate_initialize_escrow_conditions` that is used during initialization to validate the Escrow properties in the `update_escrow` function.
 
-**## Status**
-
+## Status
 This finding has been partially addressed in finding [`6d979b5`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/6d979b5) in branch `single-release-develop`. `validate_escrow_property_change_conditions` and `validate_initialize_escrow_conditions` still have distinct implementations.
 
 
@@ -132,12 +124,10 @@ This allows a malicious `platform` actor to try to front-run a pending user tran
 
 In particular, the changeable properties include the roles, meaning the malicious `platform` actor could change the roles and subsequently steal the funds.
 
-**## Recommendation**
-
+## Recommendation
 Require the user to specify the `Escrow` struct as a parameter in `fund_escrow` and validate in `fund_escrow` that the passed `Escrow` struct matches the stored `Escrow` struct. In case of a mismatch, revert, as the user might not want to fund a Smart Escrow with different properties.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`6d979b5`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/6d979b5) in branch `single-release-develop`.
 
 
@@ -172,8 +162,7 @@ The Smart Escrow attribute `amount: i128` specifies the amount to be released in
 
 The Smart Escrow uses the signed integer type `i128` as the type for the `milestone_index` parameter for multiple contract functions. While there are either explicit or implicit bound checks in-place, negative milestone indices might overflow when cast to an unsigned integer.
 
-**## Recommendation**
-
+## Recommendation
 For handling the discussed topics above, our recommendations are, respectively:
 
 1. We suggest that validation of the `platform_fee` attribute during initialization and escrow update prevents negative values. Furthermore, we suggest that the type of `platform_fee` and `TRUSTLESS_WORK_FEE_BPS` be changed to a smaller unsigned integer type, such as `u16`, as the fee attributes have a maximum value as well, which is expected to be less than 10,000 and can therefore be safely represented by a `u16`.
@@ -182,8 +171,7 @@ For handling the discussed topics above, our recommendations are, respectively:
 4. We suggest that validation of the `amount` attribute during initialization and escrow update prevents negative values.
 5. Change the signed integer type to an unsigned integer type for `milestone_index`.
 
-**## Status**
-
+## Status
 This finding has been partially addressed in commit IDs [`6d979b5`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/6d979b5), [`58539ca`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/58539ca), and [`33bfafb`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/33bfafb) in branch `single-release-develop`. Regarding topic 4, the approach used to address the issue was to implement an enforcement that the funding amount should be greater than or equal to `0` when handling escrow via the fund endpoint. Although this is effective for handling the escrow in its intended usage, an escrow can still be initialized with a negative amount. To prevent issues related to this altogether, all instances where `Escrow.amount` is used should be validated against negative values, or more simply, the `Escrow` struct should use an unsigned type for `amount`.
 
 
@@ -198,12 +186,10 @@ The Smart Escrow contract contains a design flaw that exposes it to a griefing a
 
 While this is not a critical vulnerability resulting in direct fund loss, it remains a serious design flaw. A griefing attack is where an actor uses a system's intended features to disrupt without gaining a direct financial advantage. By disapproving a previously approved milestone, the `Approver` can stall the project indefinitely, causing frustration, delaying payments, and, in the case of a multi-source funds escrow, potentially causing the entire crowdsourcing effort to fail. Since the protocol's lifecycle depends on milestones being approved, the ability to revert a milestone's status creates a single point of failure and a denial of service vector for the contract's functionality, which still can be handled by forcing a dispute.
 
-**## Recommendation**
-
+## Recommendation
 We recommend modifying the `approve_milestone` function to prevent this type of attack by removing the `new_flag` parameter or enforcing that it is always set to `true`. Design-wise, suppose a legitimate `Approver` notices a problem with a previously approved milestone. In that case, they can still invoke a dispute, forcing the intervention of an authority that can investigate the issue.
 
-**## Status**
-
+## Status
 This finding has been addressed commit IDs [`fe2623f`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/fe2623f) and [`2b31f1e`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/2b31f1e) in branch `single-release-develop`.
 
 
@@ -220,12 +206,10 @@ For the Multi-Release Smart Escrow, funds are released on a milestone basis, wit
 
 The caveat here comes from finding [A09] Milestones can both be released and dispute-resolved in the multi-release smart escrows, which considers that a milestone can both be released and disputed, meaning that, although incorrectly, the redeemable exceeding balance of a Multi-Release Smart Escrow, in its current state, can be at most the same as its expected release value.
 
-**## Recommendation**
-
+## Recommendation
 The Multi-Release Smart Escrow should implement an additional endpoint exclusively for the `dispute_resolver`, which works similarly to `resolve_dispute` in the Single-Release escrow. This endpoint should work on the condition that all milestones must have either been released or dispute-resolved. Alternatively, the limitations on the withdrawn amounts can be removed, but this introduces the issue of being able to withdraw the full balance of an escrow through a single milestone dispute.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`2f6ef92`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/2f6ef92) in branches `multi-receiver`, `multi-release-develop`, `multi-release-main`, and `stellar-multi-release-audit`.
 
 
@@ -242,14 +226,12 @@ There are no mechanisms in place that disallow a milestone dispute resolution af
 
 In the single-release smart escrow, this is a deliberate design decision that allows withdrawal of exceeding funds. Though this design is not suited for a smart escrow with multiple releases of funds.
 
-**## Recommendation**
-
+## Recommendation
 Add validations that enforce that dispute-resolved milestones cannot be released as well as that released milestones cannot be dispute-resolved.
 
 There is another issue that can cause funds to be permanently locked in the multi-release smart escrows, described in [A08] Exceeding Assets Will Be Permanently Locked in The Multi-Release Smart Escrows. The recommended fix reduces the amount of funds that can be recovered from the smart escrow when locked by the issue described in [A08] Exceeding Assets Will Be Permanently Locked in The Multi-Release Smart Escrows. Therefore it is heavily recommended to implement the recommendations from finding [A08] Exceeding Assets Will Be Permanently Locked in The Multi-Release Smart Escrows.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`bbdfcc4`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/bbdfcc4) in branch `multi-receiver`, `multi-release-develop`, `multi-release-main`, and `stellar-multi-release-audit`.
 
 ---
@@ -442,8 +424,7 @@ if !milestones.is_empty() {
 }
 ```
 
-**## Status**
-
+## Status
 This finding has been addressed in commit IDs [`4ee04c2`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/4ee04c2), [`c87c1a8`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/c87c1a8), [`ecbe0be`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/ecbe0be), [`7b9c2bb`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/7b9c2bb), [`5107d34`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/5107d34), [`7639179`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/7639179), [`af79c87`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/af79c87), [`32c985a`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/32c985a) of the branch `develop`, and in commit IDs [`bba602a`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/bba602a), [`9dd0d39`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/9dd0d39), and [`a97eefe`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/a97eefe) of the branches `multi-release-develop` and `stellar-multi-release-audit`.
 
 
@@ -459,12 +440,10 @@ This function checks whether a maximum length that is hardcoded to `10` is not e
 
 A Smart Escrow with no milestones serves no purpose, and the funds cannot be paid out with `release_funds` either, as this function checks whether the milestone vector is empty. As the other function to retrieve funds, `resolve_dispute`, does not check the length of the milestones vector, so funds are not locked in such a Smart Contract. They can still be retrieved with `resolve_dispute`, albeit with fees.
 
-**## Recommendation**
-
+## Recommendation
 We recommend validating during initialization and Smart Escrow update that the milestone vector is not empty.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit [`ecbe0be`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/ecbe0be) in the branch `develop`.
 
 
@@ -480,12 +459,10 @@ The attribute `decimals: u32` of type `Trustline` is exclusively used in the pub
 
 The decimals that are returned can hold an arbitrary value specified during initialization of the Smart Escrow that might not match the actual decimals value of the respective token used.
 
-**## Recommendation**
-
+## Recommendation
 We recommend that the Smart Escrow fetch the `decimals` attribute at runtime instead by calling `TokenClient::decimals`.
 
-**## Status**
-
+## Status
 The finding has been addressed in the commit ID [`c76c7dd`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/c76c7dd) in the branch `develop`.
 
 
@@ -503,12 +480,10 @@ if escrow.flags.released {
 }
 ```
 
-**## Recommendation**
-
+## Recommendation
 We recommend to create a new error in `ContractError` that indicates that the Smart Escrow was already released and use that error instead.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit IDs [`d77d7ae`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/d77d7ae) and [`5b9344f`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/5b9344f) in the branch `develop`.
 
 
@@ -522,12 +497,10 @@ The function `validate_release_conditions` does not check whether the Smart Escr
 
 At the same time, this error indicates that the intent was to also check that the Smart Escrow has not already been resolved yet with `resolve_dispute`.
 
-**## Recommendation**
-
+## Recommendation
 We recommend adding a missing check in `validate_release_conditions` that the Smart Escrow has already been resolved.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`5b9344f`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/5b9344f) in the branch `develop`.
 
 
@@ -541,12 +514,10 @@ Currently, a Smart Escrow can be initialized and used right away with arbitrary 
 
 In case of a dispute, including scenarios where leftover assets need to be returned, the `dispute_resolver` must act; otherwise, the funds are locked in the Smart Escrow. If the `dispute_resolver` does act, the arbitrarily specified platform fees are enforced.
 
-**## Recommendation**
-
+## Recommendation
 To avoid such a deadlock situation, the `dispute_resolver` could be required to explicitly consent to a given Smart Escrow after initialization or Smart Escrow updates through `update_escrow`. This can be done with a new Smart Escrow public function `EscrowContract::consent(e: Env, dispute_resolver: Address, escrow_properties: Escrow)`. At the same time, `fund_escrow` must fail, in case the Smart Escrow has not been consented to by the `dispute_resolver`.
 
-**## Status**
-
+## Status
 The client has acknowledged this finding.
 
 
@@ -560,12 +531,10 @@ The Smart Escrow, which also has a constructor, has the capabilities of deployin
 
 The coexistence of both a deployer function and a constructor creates redundancy and is an inefficient design pattern. The current constructor is underutilized, as it only sets an `admin` address in storage that is never referenced in subsequent logic. This design choice is problematic because it introduces complexity without providing any functional benefit. It would be more secure and efficient to remove the deployer logic and use the constructor to handle all necessary initialization tasks. This would streamline the contract's deployment process and reduce its attack surface.
 
-**## Recommendation**
-
+## Recommendation
 To resolve this issue, we recommend either of the following two solutions. The first is to completely remove the constructor and refactor the deployer function to handle all contract initialization. The second, and more robust, solution is to remove the unnecessary deployer functionality and adapt the existing constructor to perform all essential setup tasks.
 
-**## Status**
-
+## Status
 The client has acknowledged this finding.
 
 
@@ -580,14 +549,12 @@ The Smart Escrow contract, which can be used for crowdsourcing, has a limitation
 
 Although it may be the case in some scenarios, the `Approver` is not the source of the funds and, as such, should not be the recipient of a refund. This exposes the funders to a potential loss of capital, as they are entirely reliant on the `Approver`'s integrity and willingness to manually return the funds. The contract's current logic does not guarantee the repayment of funds to the rightful owners, leaving funders dependent on trust in what is intended to be a trustless environment.
 
-**## Recommendation**
-
+## Recommendation
 To rectify this, the Smart Escrow contract's dispute resolution logic must be updated. The Smart Escrow and platform must either:
 1. Store the funders' addresses in persistent data, in pairs with their supplied amounts, implementing an endpoint to allow funders to retrieve their supplied amounts in case of a dispute, or;
 2. Keep track of all funders in off-chain storage and find a way to ensure that the `approver` will repay all funders with their due amounts. This approach, although feasible, requires an extra layer of off-chain trust.
 
-**## Status**
-
+## Status
 The client has acknowledged this finding.
 
 
@@ -603,14 +570,12 @@ To prevent a contract from being archived, developers must actively manage its T
 
 Smart Escrows have no means of updating their own TTL according to the implemented business logic, and no `RestoreFootprintOp` is constructed in the platform's backend.
 
-**## Recommendation**
-
+## Recommendation
 To avoid needing to manually reinstate the Smart Escrow data after properly modifying the storage entries from persistent to instance, we recommend extending the time-to-live of the contract data within the contract itself whenever the contract is interacted with. For example, whenever fetching information from Smart Escrows using the `get_escrow` endpoint, extend the contract instance storage TTL.
 
 Additionally, the backend should be able to construct `RestoreFootprintOp` operations to bring back contracts from archival.
 
-**## Status**
-
+## Status
 The client has acknowledged this finding.
 
 
@@ -629,12 +594,10 @@ According to Trustless Work's documentation, the expected lifecycle of an escrow
 
 Although designed to follow this lifecycle, there are no validations in the code enforcing that the Milestone Updates Phase is necessary. Milestones can be approved regardless of whether their status is updated or not.
 
-**## Recommendation**
-
+## Recommendation
 Either recognize the Milestone Updates Phase as optional or enforce its necessity in the contract's business logic.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`93c4c37`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/93c4c37) and [`898097a`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/898097a) in the `multi-release-develop` and `stellar-multi-release-audit` branches.
 
 
@@ -650,12 +613,10 @@ The validations implemented when attempting to update a smart escrow do not cons
 
 This issue is informational because smart escrows cannot be updated after being funded, which narrows the window in which this property could be exploited.
 
-**## Recommendation**
-
+## Recommendation
 Make the `platform` address immutable by enforcing immutability at the contract level.
 
-**## Status**
-
+## Status
 The client has addressed this finding in commit ID [`118a316`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/118a316) of the branch `single-release-develop`.
 
 
@@ -669,12 +630,10 @@ While reviewing the code of the Multi-Release Smart Escrow version, multiple min
 
 One of these differences, however, is more significant. When resolving a milestone dispute in the Multi-Release version, one of the parameters is named `service_provider_funds`, with its naming indicating that it holds the amount of funds to be sent to the `service_provider`. However, tracing the logic shows that these funds are actually sent to the `receiver` instead. In the Single-Release version, this variable is appropriately named `release_funds`.
 
-**## Recommendation**
-
+## Recommendation
 Align the implementations of shared logic across both contract versions to improve maintainability and reduce confusion.
 
-**## Status**
-
+## Status
 This finding has been addressed in the commit ID [`699e25e`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/699e25e) of the branches `multi-release-develop` and `stellar-multi-release-audit`.
 
 ---
@@ -694,8 +653,7 @@ The `PendingWriteQueueService` uses an in-memory `Map<string, PendingWriteItem>(
 3. Memory Leak Risk: Abandoned transactions are never removed from the queue. There's no TTL (Time To Live) mechanism for stale entries, which may cause the queue to grow indefinitely without cleanup.
 4. No Observability: Cannot monitor queue size or processing metrics, no visibility into failed transactions across restarts, making it difficult to debug transaction issues.
 
-**## Recommendation**
-
+## Recommendation
 Replace the in-memory storage with a persistent, distributed solution:
 
 ```ts
@@ -711,8 +669,7 @@ const pendingWriteQueue = new Queue("pending writes", {
 
 Implement proper cleanup mechanisms and monitoring for queue health.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit IDs [`f353f3c`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/f353f3c), [`0bf1ac9`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/0bf1ac9), [`98b61ab`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/98b61ab), and [`4412028`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/4412028).
 
 
@@ -738,8 +695,7 @@ This configuration creates several security vulnerabilities:
 2. Data Theft: Malicious sites can access user data through browser requests
 3. API Abuse: Unauthorized third parties can consume API resources without restriction
 
-**## Recommendation**
-
+## Recommendation
 Restrict CORS to specific, trusted domains:
 
 ```ts
@@ -752,8 +708,7 @@ app.enableCors({
 
 Use environment variables to manage different origins for different environments (development, staging, production).
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`4a82d73`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/4a82d73).
 
 
@@ -777,8 +732,7 @@ Multiple critical endpoints lack proper authentication guards, making them publi
 
 This creates severe security vulnerabilities, as sensitive user data and system operations are exposed to unauthorized users.
 
-**## Recommendation**
-
+## Recommendation
 Add authentication guards to all protected endpoints:
 
 ```ts
@@ -788,8 +742,7 @@ Add authentication guards to all protected endpoints:
 
 Implement role-based access control (RBAC) for different user types and operations. Ensure that users can only access and modify their own data unless they have explicit administrative privileges.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit IDs [`4f7b37e`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/4f7b37e), [`859e8d9`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/859e8d9), [`fe8a6f6`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/fe8a6f6), and [`2e8b7cf`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/2e8b7cf).
 
 
@@ -816,8 +769,7 @@ Security Impact:
 - Data Exposure: Contract data becomes accessible without proper authorization
 - Privilege Escalation: Users can potentially view or interact with high-value escrows
 
-**## Recommendation**
-
+## Recommendation
 Add proper signer validation to the query:
 
 ```ts
@@ -830,8 +782,7 @@ Add proper signer validation to the query:
 
 Implement comprehensive authorization checks throughout the escrow repository to ensure users can only access contracts they are authorized to view or modify.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`f3ac8da`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/f3ac8da).
 
 
@@ -858,8 +809,7 @@ These detailed error messages introduce multiple security vulnerabilities:
 
 This information can be used by malicious actors to map out the user base and system structure, facilitating more targeted attacks.
 
-**## Recommendation**
-
+## Recommendation
 Use generic error messages for client responses while logging detailed information separately for debugging:
 
 ```ts
@@ -875,8 +825,7 @@ Implement a consistent error handling strategy that:
 - Logs detailed information server-side for debugging
 - Avoid exposing internal system details, including whether a specific user exists.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit IDs [`cb5d5f6`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/cb5d5f6), and [`b3f9255`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/b3f9255).
 
 
@@ -896,8 +845,7 @@ Security Risks:
 
 This is particularly concerning for a financial application handling escrow transactions, where data integrity and confidentiality are critical.
 
-**## Recommendation**
-
+## Recommendation
 Configure the application to use HTTPS-only connections in production:
 
 ```ts
@@ -917,8 +865,7 @@ Implement environment-specific configurations that:
 - Allow HTTP only in local development environments
 - Add runtime checks to prevent accidental HTTP usage in production
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`6cc12b5`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/6cc12b5).
 
 
@@ -948,8 +895,7 @@ Security and Design Issues:
 CSRF Vulnerability:
 Websites can use safe requests such as GET to load static resources for websites such as images, e.g.: `<img src="https://www.somewebsite.com/some-image.jpg">`. This can be exploited to make clients of such websites send malicious GET requests to other websites. Cookies that are marked as `SameSite=None` are always sent alongside these requests. Cookies that are marked as `SameSite=Lax` are only added to safe requests such as GET. In case the cookies are to be utilized by the backend, this could be a source of potential security vulnerabilities, as cookies are typically marked as `SameSite=Lax`.
 
-**## Recommendation**
-
+## Recommendation
 Change GET methods to appropriate HTTP methods for state-changing operations:
 
 ```ts
@@ -978,8 +924,7 @@ Follow REST conventions:
 - PUT: Update existing resources (idempotent)
 - DELETE: Remove resources
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`27c7ebe`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/27c7ebe).
 
 
@@ -1023,8 +968,7 @@ Type Safety Impact:
 - Potential runtime errors when accessing properties that may not exist
 - Reduced code maintainability and documentation value
 
-**## Recommendation**
-
+## Recommendation
 Cast `DocumentData` to specific types that match the actual document structure:
 
 ```ts
@@ -1071,8 +1015,7 @@ Benefits of Specific Type Casting:
 - Reduced runtime errors
 - Improved refactoring safety
 
-**## Status**
-
+## Status
 This finding has been addressed in commit IDs [`67c890c`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/67c890c), [`bdf8d64`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/bdf8d64), [`4b5a87a`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/4b5a87a), [`f0b34c3`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/f0b34c3), [`55fa23b`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/55fa23b), and [`01724da`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/01724da).
 
 
@@ -1105,8 +1048,7 @@ This mismatch between the validation decorators and the actual data types create
 3. API Contract Confusion: Unclear whether the API expects strings or numbers
 4. Potential Data Corruption: Inconsistent type handling can lead to incorrect data processing
 
-**## Recommendation**
-
+## Recommendation
 Use the correct validation decorators that match the TypeScript types:
 
 ```ts
@@ -1135,8 +1077,7 @@ amount: number;
 
 Review all DTO classes to ensure validation decorators match their corresponding TypeScript types.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`ee82a6e`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/ee82a6e).
 
 
@@ -1170,8 +1111,7 @@ updatedAt: new Date(),
 createdAt: new Date(),
 ```
 
-**## Recommendation**
-
+## Recommendation
 Replace client-side timestamps with `FieldValue.serverTimestamp()`:
 
 ```ts
@@ -1192,8 +1132,7 @@ Benefits of server timestamps:
 
 Also update milestone timestamps (`approvedAt`, `completedAt`) for consistency.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit IDs [`7942bd4`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/7942bd4), and [`8360e9b`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/8360e9b).
 
 
@@ -1232,8 +1171,7 @@ Security and Reliability Risks:
 2. Data Corruption: Unvalidated inputs can corrupt calculations
 3. Security Vulnerabilities: Malicious inputs might exploit undefined behavior
 
-**## Recommendation**
-
+## Recommendation
 Add explicit type annotations and comprehensive input validation:
 
 ```ts
@@ -1259,8 +1197,7 @@ Implement consistent validation patterns:
 - Format validation for strings
 - Null/undefined checks where appropriate
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`6667272`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/6667272).
 
 
@@ -1304,8 +1241,7 @@ interface RawMultiFlags {
 
 `RawSingleEscrow` and `RawMultiEscrow` share common properties but don't extend a base interface, leading to code duplication.
 
-**## Recommendation**
-
+## Recommendation
 Fix Type Guards to Use Discriminant Field:
 
 ```ts
@@ -1342,8 +1278,7 @@ export interface RawSingleEscrow extends RawEscrow {
 }
 ```
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`3c84811`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/3c84811).
 
 
@@ -1371,8 +1306,7 @@ The `.env.example` file contains inconsistencies with actual code usage:
 
 1. Direct Environment Variable Usage: Code directly accesses `process.env` instead of using NestJS `@nestjs/config` for type safety
 
-**## Recommendation**
-
+## Recommendation
 Fix Environment Configuration:
 
 ```ts
@@ -1394,8 +1328,7 @@ const projectId = this.configService.get<string>('FIREBASE_PROJECT_ID');
 Clean Up Unused Environment Variables:
 Remove unused variables from `.env.example` or implement their usage in the codebase if they are intended for future features.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`702c7ed`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/702c7ed).
 
 
@@ -1472,8 +1405,7 @@ The codebase contains wrong logging and error messages, most likely due to copy 
 
 `src/stellar-contract/queue/pending-write-handler.service.ts:100` defines the variable `completedAt` that should instead be called `lastUpdatedAt` or similar - this variable is updated everytime the status is updated instead of only when the status is complete
 
-**## Recommendation**
-
+## Recommendation
 Improve API Documentation:
 
 ```ts
@@ -1545,8 +1477,7 @@ if (tag === "u64")
 if (tag == "u64")
 ```
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`c8e5a65`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/c8e5a65).
 
 
@@ -1603,8 +1534,7 @@ Whether Firestore interfaces should use flat structures (`Record<string, string>
 
 - `src/config/firebase.config.ts` is not a module, but should be due to providing functions and usage of services
 
-**## Recommendation**
-
+## Recommendation
 Fix Repository Pattern:
 
 ```ts
@@ -1653,8 +1583,7 @@ Keep current flat structure for Firestore queries but improve conversion logic b
 Usage of NestJS modules:
 Use NestJS modules and services when proper.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit IDs [`d005371`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/d005371), [`c8e5a65`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/c8e5a65), [`a4f8570`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/a4f8570), [`9dd6787`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/9dd6787), and [`5cece24`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/5cece24).
 
 
@@ -1680,8 +1609,7 @@ The codebase previously lacked proper development tooling and code quality enfor
 - Manual code review burden increased
 - Potential for committing problematic code
 
-**## Recommendation**
-
+## Recommendation
 Implement comprehensive development tooling, including:
 - ESLint with TypeScript support
 - Husky for pre-commit hooks
@@ -1704,8 +1632,7 @@ npm install --save-dev prettier eslint-config-prettier eslint-plugin-prettier
 npm install --save-dev lint-staged
 ```
 
-**## Status**
-
+## Status
 This finding has been addressed in commit IDs [`67c890c`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/67c890c), [`fc3eb3a`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/fc3eb3a), [`15a3f13`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/15a3f13), [`3a27c6a`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/3a27c6a), [`5329a3b`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/5329a3b), [`35c0cba`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/35c0cba), and [`6c354fe`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/6c354fe).
 
 
@@ -1735,12 +1662,10 @@ if (!pending) {
 }
 ```
 
-**## Recommendation**
-
+## Recommendation
 Check whether the transaction hash is in the `pendingWriteQueue` before submitting the transaction to the blockchain. In case the hash is not in the queue, abort and do not submit the transaction.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`9a4006e`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/9a4006e).
 
 
@@ -1838,8 +1763,7 @@ This means `fee`, `wasmHash`, and `operationFunc` contamination persists across 
 
 This affects all transaction-related operations in the system and can lead to wrong fees, operations on incorrect contracts, or funds released to wrong parties.
 
-**## Recommendation**
-
+## Recommendation
 We recommend implementing either a request-scoped service or a stateless factory pattern to eliminate shared mutable state:
 
 **Option A: Request-Scoped Service**
@@ -1864,8 +1788,7 @@ export class StellarTransactionBuilderFactory {
 
 This ensures each operation gets a fresh, isolated builder instance with no shared state between concurrent requests.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`575a047`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/575a047).
 
 
@@ -1909,8 +1832,7 @@ Security Concerns:
 
 Current Risk Level: While the current usage in `establishTrustline()` method appears to use the key only within the same method scope, storing sensitive cryptographic material in instance variables is an anti-pattern that violates the principle of least exposure.
 
-**## Recommendation**
-
+## Recommendation
 Limit private key scope to local variables within methods and clear references as soon as they are no longer required:
 
 ```ts
@@ -1955,8 +1877,7 @@ Additional Security Improvements:
 3. Clear sensitive data: Explicitly null sensitive variables when operations complete
 4. Audit all services: Review other services for similar private key storage patterns
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`939242c`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/939242c).
 
 
@@ -1997,12 +1918,10 @@ for (const doc of snapshot.docs) {
 }
 ```
 
-**## Recommendation**
-
+## Recommendation
 We recommend to adjust all queries to include all relevant filters beforehand, as Firestore supports expressive queries.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit [`5007e8d`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/5007e8d).
 
 
@@ -2025,16 +1944,14 @@ This issue also applies to the other cron jobs declared in `src/notifications/no
 
 The backend endpoints `notifications/test/*` allow for triggering the notification checks manually for all users. This allows for malicious API users (without any credentials) to spam the endpoint with these notification requests. This will cause the backend to possibly generate multiple notifications per request that are all stored in the database. These endpoints are defined in the file `src/notifications/notifications.controller.ts`.
 
-**## Recommendation**
-
+## Recommendation
 Cron jobs:
 Update a timestamp per notification type that is used to prevent the same notifications from being generated more than once in a given period of time.
 
 Notification endpoints:
 Remove the notification endpoints.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`0652a79`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/0652a79).
 
 
@@ -2050,12 +1967,10 @@ The methods in `src/notifications/notifications.service.ts` that generate user n
 - `checkPendingEscrows`
 - `checkCompletedMilestones`
 
-**## Recommendation**
-
+## Recommendation
 Update these methods to also generate notifications for multi-release escrows for consistent behaviour.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`ee38c9e`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/ee38c9e).
 
 
@@ -2076,12 +1991,10 @@ The codebase dangerously uses `number` to store and calculate critical values su
 - `src/stellar-contract/escrow/Dto/fund-escrow.dto.ts:17`: monetary value `amount`
 - `src/utils/parse.utils.ts:21`: currency conversion using imprecise floating-point arithmetic
 
-**## Recommendation**
-
+## Recommendation
 Review the codebase in regard to usage of `number` and replace `number` with a precise equivalent such as e.g. `BigInt`. Ensure that all arithmetic operations are precise and round towards the correct direction in case rounding is unavoidable. Ensure that serialization and deserialization of numerical values incurs no critical loss of precision.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`ee82a6e`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/ee82a6e).
 
 
@@ -2117,12 +2030,10 @@ There is no format enforced that the API keys must comply with, other than somet
 - No fixed prefix enforced on the API key:
   - Using a fixed prefix that is shared by all API keys allows for detecting leaked API keys on the internet
 
-**## Recommendation**
-
+## Recommendation
 Re-implement the API key mechanisms entirely and follow state-of-the-art recommendations for safe API key handling. Potentially, trusted and verified libraries could be used to ensure that the API key implementation is actually secure. This is especially critical as these implementations typically make use of cryptographic concepts and algorithms that are harder to implement securely.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit IDs [`8360e9b`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/8360e9b), [`9ff80a5`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/9ff80a5), [`2e8b7cf`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/2e8b7cf), [`d439c66`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/d439c66), [`12dfbc2`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/12dfbc2).
 
 
@@ -2138,12 +2049,10 @@ In `src/stellar-contract/escrow/shared/shared-escrow.service.ts:246`, the functi
 
 This can be optimized by using the synchronized state in the database instead. Additionally, such an approach does not prevent race conditions or front-running attacks. Instead, the backend must rely on the smart escrow smart contract to prevent any front-running attacks and submit data in a transactional ordering. Therefore, the database state can be used here.
 
-**## Recommendation**
-
+## Recommendation
 Replace all non-critical occurrences of querying blockchain state with database queries to synchronized blockchain state in the database. It must be ensured that the database state is synchronized properly with the blockchain.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`4298787`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/4298787).
 
 
@@ -2159,12 +2068,10 @@ Some DTOs fields are silently overridden with default values, e.g.:
 - `src/utils/parse.utils.ts:65`
 - `src/utils/parse.utils.ts:115`
 
-**## Recommendation**
-
+## Recommendation
 Change the endpoints and DTOs to either drop fields that are not required by the backend, or alternatively make use of the currently unused fields and values in the DTOs.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`0843d1b`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/0843d1b).
 
 
@@ -2217,16 +2124,14 @@ async login(loginUserDto: LoginUserDto) {
 }
 ```
 
-**## Recommendation**
-
+## Recommendation
 A proper authentication procedure must be implemented and mandatory for all endpoints that require authentication such as login and register endpoints.
 
 As users login with their respective wallet, they must authenticate that they are the respective owner of the wallet. This can be properly implemented by following the SEP-10 standard (https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md), as described in the Stellar documentation (https://developers.stellar.org/docs/build/apps/wallet/sep10).
 
 Additionally, the generated JWT tokens should not be saved in the database. Instead, whenever the user loses the JWT or the JWT becomes invalid, the user is expected to re-authenticate to get a new JWT.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`8360e9b`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/8360e9b), [`2e8b7cf`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/2e8b7cf), [`4f7b37e`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/4f7b37e).
 
 
@@ -2247,14 +2152,12 @@ Additionally, any smart escrow transaction that was not generated by the backend
 
 The backend utilizes the `getTransaction` API endpoint of the Stellar blockchain to confirm the validity of transactions and also to get the contract id from deployment transactions. The Stellar `getTransaction` endpoint only stores transactions for a restricted period of time, the default being 24 hours, see https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/getTransaction. This puts the backend at risk of missing transactions in case of downtime or similar.
 
-**## Recommendation**
-
+## Recommendation
 We recommend to replace the `pendingWriteQueue` design choice with a procedure that queries storage state from smart escrows via the Stellar API and syncs the data with the database. This procedure could be run for smart escrows determined via emitted Soroban events that the backend could periodically query for from the Stellar API. Additionally, an API endpoint could be provided to update the state on a specific given smart escrow, in case the events were missed by the backend due to, e.g., downtime. This is because events are similarly to transactions only stored for a restricted amount of time in Stellar API nodes.
 
 This would deliberately also allow the backend to process smart escrows that were not deployed by the backend. Therefore the backend must check that the wasm hash of the smart escrow is valid. Additionally, we recommend to validate the smart escrow storage state for valid storage values. This is because we assume that smart escrows with invalid storage values (bypassing initialization validation) could potentially be deployed by exploiting Soroban's smart escrow upgrade functionality.
 
-**## Status**
-
+## Status
 This finding will be fixed in the future version of the protocol which will implement a dedicated blockchain indexer.
 
 
@@ -2273,12 +2176,10 @@ In the other case, where the transaction is different from deployment, the trans
 
 Additionally, due to the `finally` in `updateFromTxHash` that removes the respective transaction from the queue, the transaction is always removed from the queue, regardless of whether the transaction was processed by the backend. E.g., it is expected that this might happen when a deployment transaction is processed by `updateFromTxHash` without the blockchain yet having processed the transaction.
 
-**## Recommendation**
-
+## Recommendation
 Add proper validation that the transaction that is being processed in `updateFromTxHash` was actually properly processed by the blockchain with `getTransaction`. Additionally, in case the blockchain did not properly or successfully process the transaction, keep the element in the queue. Of course, as previously discussed in [TS01] In-Memory Queue Storage Causing Data Loss and Scaling Issues, there needs to be a mechanism in place that removes elements from the queue after a specified period of time has passed.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`36ece55`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/36ece55).
 
 
@@ -2289,12 +2190,10 @@ Status: Not addressed by client
 
 The backend requires a Stellar API endpoint to properly function. In case this API endpoint is hosted by a third-party, this third-party could feed wrong and potentially malicious data to the backend.
 
-**## Recommendation**
-
+## Recommendation
 To ensure that data returned by the Stellar API is valid, Stellar nodes could instead be self-hosted. These nodes are then expected to always return valid data, as long as they are hosted securely, properly maintained, and kept up to date.
 
-**## Status**
-
+## Status
 This recommendation was already being considered by the client, and will be fixed in the future implementation of the project outside of the scope of this audit.
 
 
@@ -2309,12 +2208,10 @@ The endpoint `/helper/set-trustline` can be used to set a trustline on a Stellar
 
 This is inherently dangerous for end-users, as they are not supposed to share their private key with other third-parties. This pattern also diverges from the rest of the backend codebase, where an unsigned transaction is prepared on the backend and then sent to the users client. The user can then decide on their client whether to sign the transaction after reviewing it.
 
-**## Recommendation**
-
+## Recommendation
 We recommend to refactor this endpoint to send an unsigned transaction to the users client, similar to how the other endpoints in the backend operate. There should be no endpoint in the backend that accepts a users private key as an argument.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`939242c`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/939242c).
 
 
@@ -2341,8 +2238,7 @@ JwtModule.registerAsync({
 }),
 ```
 
-**## Recommendation**
-
+## Recommendation
 Add an expiration date to JWT tokens by including the following option with a proper value:
 
 ```ts
@@ -2361,8 +2257,7 @@ JwtModule.registerAsync({
 }),
 ```
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`8360e9b`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/8360e9b).
 
 
@@ -2384,10 +2279,8 @@ do {
 } while (getResponse.status === "NOT_FOUND");
 ```
 
-**## Recommendation**
-
+## Recommendation
 Use a timeout or a maximum number of retries before this loop is terminated and an error is returned.
 
-**## Status**
-
+## Status
 This finding has been addressed in commit ID [`1b3bb0c`](https://github.com/Trustless-Work/Trustless-Work-Smart-Escrow/commit/1b3bb0c).


### PR DESCRIPTION
This is a cleanup pass over the problems that turned up across the last round of code reviews. A lot of that work was already merged, but in several cases it didn't actually work end to end, or it shipped with rough edges. This PR makes that stuff work and closes the gaps. Everything here was deployed to the dev cluster and checked by hand, not just unit-tested.

## The urgent one: a public endpoint was handing out emails

The public profile endpoint (`GET /api/v1/profiles/{id}`) had `[AllowAnonymous]` on it and was returning the user's email, full name, and linked accounts — to anyone, no login needed. So you could just walk the ids and scrape every user's email and connected accounts.

Fix: the public endpoint now returns its own response shape with only the safe fields (bio, location, website, expertise tags, reputation). The full profile that includes email/name/linked accounts is still there, but only on the authenticated "my own profile" endpoint. While I was in there I also:

- made the lookup use the login id you actually have, instead of an internal table row id you'd never know;
- rejected junk website values like `javascript:alert(...)` with a clean `400` instead of letting oversized/garbage input fall through to a `500`;
- made sure email/name come back populated right after you create a profile (it was reading them off an entity that hadn't loaded the related login yet).

Here's the anonymous response now — no email, no name, no linked accounts:

<img src="https://review.sorobanshield.ru/pr-fixes-screens/pr125-anon-profile-no-pii.png" width="760">

## Three database migrations that never actually ran

The moderation-log, ratings, and forum migrations were all hand-written and missing the pieces Entity Framework needs to even notice them — no designer file, nothing added to the model snapshot. So they were effectively invisible: the tables were never created on deploy, and any endpoint that touched them just threw `500`.

I regenerated all three the proper way so EF discovers and applies them, and bumped the product version so they actually run on the next deploy (the updater only migrates when that version changes). A few things got fixed along the way:

- the forum migration was back-dated, so it sorted *before* migrations that had already run, and it was quietly rewriting the admin account row on every apply — both gone now;
- its seed dates didn't match the model, so they drifted apart — now consistent;
- switched the forum author foreign keys to "restrict" so deleting a user can't cascade-delete entire threads, including other people's replies.

Verified on dev that all three tables now exist and the ratings endpoints return `200` instead of `500`.

## The content filter wasn't filtering anything

There was a genuinely well-built sanitization / spam / profanity / rate-limit service... that was never actually called on real content. I wired it into the vulnerability submission path, so submissions now get rate-limited and screened, and bad ones are blocked with a clear `400` — while a normal, clean submission goes through untouched. (Flagged-but-not-dangerous content gets logged for moderators rather than hard-blocked.)

A few fixes to the filter itself while it was finally being used:

- profanity matching used a plain substring check, so "class" tripped on "ass" — it matches whole words now;
- the rate limiter was declared `async` but never awaited, and it reset its own time window on every call, so the limit never really kicked in — rewrote it as a proper per-minute window;
- the profanity / trusted-domain settings were stored as a list and showed up in the settings screen as a raw `.NET` type name (and saving would've corrupted them) — they're stored and edited as plain text now;
- the service is registered as a singleton, so it isn't re-reading its word-list file and rebuilding the sanitizer on every single request.

One deliberate call here: a submission's description is Markdown, so the filter runs for its checks but the original Markdown is what gets saved — it doesn't overwrite it with sanitized HTML, which would have double-rendered and broken the edit round-trip.

## Badges that nothing rendered

The badge components were nicely done but used nowhere — the demo page wasn't even routed, so there was no way to see a badge at all. I routed the demo page and added a Badges tab on the profile. There's no badge backend yet, so the tab is honest about that with a small "preview" banner, instead of quietly showing sample badges as if the user earned them. Also fixed the hard-coded greys that were invisible on the dark theme, added proper accessibility labels on the badge, and filled in two tests that weren't actually asserting anything.

<img src="https://review.sorobanshield.ru/pr-fixes-screens/pr117-badge-demo.png" width="760">

<img src="https://review.sorobanshield.ru/pr-fixes-screens/pr117-profile-badges-tab.png" width="760">

## Moderation: a real backend, not fake data

The dashboard looked great, but it was showing hard-coded sample reports to real moderators, with Approve/Hide/Delete buttons that silently did nothing. Instead of just slapping a "demo" label on it, this PR gives moderation a real backend, end to end:

- **Users can flag content.** There's a small flag icon next to the bookmark icon on every vulnerability and report page; it opens a short dialog to pick a reason (spam / harassment / inappropriate / misinformation / other) plus an optional note. One flag per person per item — a repeat just says "already reported", it's not an error.
- **Flags aggregate into a real moderator queue** (`GET /api/v1/moderation/queue`, admin/moderator only) — grouped per piece of content, with the flag count, the reason breakdown, the author (name/reputation), and the full moderation history.
- **Moderators can approve / hide / delete** (`POST /api/v1/moderation/action`). Approve clears the flags and leaves the content visible; hide takes it off the public site; delete is a soft-delete (recoverable). Hide and delete require a reason, which is saved into the history ("Hidden — spam").
- **Hidden/deleted content really disappears from the public side** — the listing, search, the stats counts, the direct detail-by-id URL, and even the report image endpoint all exclude it, so you can't reach hidden content by guessing its id.
- The dashboard now reads all of this from the API — **no more mock data and no more demo banner** — and there's unit-test coverage across the flag service, the queue aggregation, the moderator actions, and the public-visibility filtering. History items are no longer actionable (you can't "approve" something already deleted), the typed reason is kept, and the sample avatars no longer call out to a third-party service.

The flag control, sitting right next to the bookmark icon:

<img src="https://review.sorobanshield.ru/pr-fixes-screens/mod-flag-button-on-vuln.png" width="760">

And the real queue after someone flagged a vulnerability and a moderator hid it — no demo banner, real flag + reason, a "Hidden" status, and the stats counting the action:

<img src="https://review.sorobanshield.ru/pr-fixes-screens/mod-dashboard-real-hidden.png" width="760">

## Trustless audit doc

Small tidy-up: the section headings were wrapped in bold (`**## Recommendation**`), so they rendered as literal text instead of real headings — unwrapped all of them. Moved the 2,400-line document out of the repo root into `docs/audits/`, and dropped a leftover `.gitignore` line that no longer did anything.

## What I left out on purpose

A few review notes were really "build a new feature" — a forum API, a ratings UI, importing the audit findings into the database. Those are follow-ups, not part of this work (the moderation backend started out on that list too, but it's now built — see above). Same for a handful of notes that were about wording in already-merged PR descriptions, which code can't change. And I deliberately didn't touch the two user-profile migrations that already ran in production, since rewriting applied migrations is a good way to break a live database. Flagging is wired for vulnerabilities and reports for now (profiles/comments can come later).

## Testing

Backend and UI suites pass (177 and 666 tests). Beyond that, the whole thing was deployed to the dev cluster and walked through by hand: confirmed the email leak is gone, the migrations actually create their tables, ratings and the content filter behave, the badges render, and the full moderation cycle works end to end — flag a vulnerability from its page, see it land in the moderator queue, hide it, and watch it drop out of the public list, the search, and its own detail URL (404), with the action showing up in the history and the stats.

