### PR TITLE
Fix DB Backup: store dumps as release assets

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -54,6 +54,7 @@ jobs:
           STAMP=$(date -u +'%Y%m%d-%H%M%S')
           FILE="soroban-db-${STAMP}.dump"
           echo "BACKUP_FILE=$FILE" >> "$GITHUB_ENV"
+          echo "BACKUP_TAG=backup-${STAMP}" >> "$GITHUB_ENV"
 
           echo "Running pg_dump -> $FILE"
           kubectl exec -n "$NAMESPACE" "$POD" -- \
@@ -62,34 +63,33 @@ jobs:
             > "$FILE"
 
           if [ ! -s "$FILE" ]; then
-            echo "::error::pg_dump produced an empty file; aborting before commit"
+            echo "::error::pg_dump produced an empty file; aborting before upload"
             exit 1
           fi
           echo "Backup size: $(du -h "$FILE" | cut -f1)"
 
-      - name: Checkout backup repo
-        uses: actions/checkout@v4.1.3
-        with:
-          repository: ${{ env.BACKUP_REPO }}
-          token: ${{ secrets.SOROBANDB_PAT }}
-          path: backup-repo
-          fetch-depth: 1
-
-      - name: Commit, prune and push
+      - name: Upload backup and prune old releases
+        env:
+          # gh CLI authenticates against the backup repo with this token.
+          # Dumps exceed git's 100 MB limit, so they are stored as release
+          # assets (2 GB/file) instead of committed files.
+          GH_TOKEN: ${{ secrets.SOROBANDB_PAT }}
         run: |
           set -euo pipefail
-          mv "$BACKUP_FILE" "backup-repo/$BACKUP_FILE"
-          cd backup-repo
 
-          # Keep only the newest $RETAIN backups
-          ls -1t soroban-db-*.dump | tail -n +$((RETAIN + 1)) | xargs -r rm -f
+          echo "Creating release $BACKUP_TAG with asset $BACKUP_FILE"
+          gh release create "$BACKUP_TAG" "$BACKUP_FILE" \
+            --repo "$BACKUP_REPO" \
+            --title "$BACKUP_FILE" \
+            --notes "Automated database backup ($BACKUP_FILE)."
 
-          git config user.name  "soroban-db-backup[bot]"
-          git config user.email "soroban-db-backup@users.noreply.github.com"
-          git add -A
-          if git diff --cached --quiet; then
-            echo "Nothing to commit."
-            exit 0
-          fi
-          git commit -m "DB backup ${BACKUP_FILE}"
-          git push
+          echo "Pruning to the newest $RETAIN backups..."
+          gh release list --repo "$BACKUP_REPO" --limit 1000 \
+            --json tagName,createdAt \
+            | jq -r --argjson keep "$RETAIN" \
+                'sort_by(.createdAt) | reverse | .[$keep:] | .[].tagName' \
+            | while read -r tag; do
+                [ -z "$tag" ] && continue
+                echo "Deleting old release $tag"
+                gh release delete "$tag" --repo "$BACKUP_REPO" --yes --cleanup-tag
+              done


### PR DESCRIPTION
The first run of the DB Backup action worked all the way through `pg_dump`, but failed on the final push: the database dump is about 130 MB, and GitHub rejects any file over 100 MB in a normal git push.

This changes where the backup is stored. Instead of committing the dump as a file in the repo, the action now uploads it as a **release asset** in `Inferara/sorobandb`:

- Each backup becomes a release tagged `backup-YYYYMMDD-HHMMSS`, with the dump attached as `soroban-db-YYYYMMDD-HHMMSS.dump`.
- Release assets can be up to 2 GB, so the size limit is no longer a problem, and the git history stays small.
- After uploading, it keeps the 10 most recent backups and deletes the older releases (and their tags).

Everything else stays the same: it still runs daily at 03:00 UTC, can be started manually, and pulls the dump from the production Postgres pod using the existing cluster credentials.
