### PR TITLE
feat: add StarRating, RatingSummary, RatingDialog to social/ratings (…

### DIFF
--- a/UI/src/components/social/ratings/RatingDialog.tsx
+++ b/UI/src/components/social/ratings/RatingDialog.tsx
@@ -1,0 +1,1 @@
+export { RatingDialog } from '../../ratings/RatingDialog';

--- a/UI/src/components/social/ratings/RatingSummary.tsx
+++ b/UI/src/components/social/ratings/RatingSummary.tsx
@@ -1,0 +1,1 @@
+export { RatingSummaryCard as RatingSummary } from '../../ratings/RatingSummaryCard';

--- a/UI/src/components/social/ratings/StarRating.tsx
+++ b/UI/src/components/social/ratings/StarRating.tsx
@@ -1,0 +1,2 @@
+export { RatingStars as StarRating } from '../../ratings/RatingStars';
+export type { RatingStarsProps as StarRatingProps } from '../../ratings/RatingStars';

--- a/UI/src/components/social/ratings/__tests__/social-ratings.test.tsx
+++ b/UI/src/components/social/ratings/__tests__/social-ratings.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StarRating, RatingSummary, RatingDialog } from '../index';
+import { RatingEntityType, RatingSummary as RatingSummaryModel } from '../../../../api/soroban-security-portal/models/rating';
+
+describe('social/ratings barrel exports', () => {
+  it('StarRating renders without crashing', () => {
+    render(<StarRating value={3} readOnly />);
+    // MUI Rating renders radio inputs for each star
+    expect(document.querySelector('.MuiRating-root')).toBeInTheDocument();
+  });
+
+  it('RatingSummary renders average score', () => {
+    const summary: RatingSummaryModel = {
+      entityType: RatingEntityType.Protocol,
+      entityId: 1,
+      averageScore: 4.2,
+      weightedAverageScore: 4.5,
+      totalReviews: 7,
+      distribution: { '1': 0, '2': 0, '3': 1, '4': 3, '5': 3 },
+    };
+    render(<RatingSummary summary={summary} />);
+    expect(screen.getByText('4.2')).toBeInTheDocument();
+    expect(screen.getByText('7 ratings')).toBeInTheDocument();
+  });
+
+  it('RatingDialog renders with correct title', () => {
+    const noop = () => {};
+    render(
+      <RatingDialog
+        open
+        entityLabel="auditor"
+        existing={null}
+        submitting={false}
+        error={null}
+        onClose={noop}
+        onSubmit={noop}
+        onDelete={noop}
+      />,
+    );
+    expect(screen.getByText('Rate this auditor')).toBeInTheDocument();
+  });
+});

--- a/UI/src/components/social/ratings/index.ts
+++ b/UI/src/components/social/ratings/index.ts
@@ -1,0 +1,4 @@
+export { StarRating } from './StarRating';
+export type { StarRatingProps } from './StarRating';
+export { RatingSummary } from './RatingSummary';
+export { RatingDialog } from './RatingDialog';


### PR DESCRIPTION
  pr closes #81 

 The project already had a complete ratings implementation under
  src/components/ratings/ — this PR exposes it at the path specified in the issue
  (src/components/social/ratings/) with the required component names:
  
  - StarRating (wraps RatingStars — interactive stars, hover effects, half-star display,
  small/medium/large sizes, accessibility labels)
  - RatingSummary (wraps RatingSummaryCard — average score, total count, star distribution bars)
  - RatingDialog (submit/update/delete a rating with review text and character cap)
  
  All three are exported from a single index.ts barrel. A test file verifies each component
  renders correctly via the new export path.
