### PR TITLE
fix: log in button on report details now redirects to SSO page (#165)

### DIFF
--- a/UI/src/features/pages/regular/report-details/report-details.tsx
+++ b/UI/src/features/pages/regular/report-details/report-details.tsx
@@ -70,7 +70,7 @@ import { PageViewEntityType } from '../../../../api/soroban-security-portal/mode
 
 export const ReportDetails: FC = () => {
   const navigate = useNavigate();
-  const { auth, login } = useAppAuth();
+  const { auth } = useAppAuth();
 
   const {
     report,
@@ -763,7 +763,7 @@ export const ReportDetails: FC = () => {
                       <Button
                         variant="contained"
                         color="primary"
-                        onClick={login}
+                        onClick={() => navigate('/login')}
                       >
                         Log In
                       </Button>

--- a/UI/src/features/pages/regular/report-details/report-details.tsx
+++ b/UI/src/features/pages/regular/report-details/report-details.tsx
@@ -70,7 +70,7 @@ import { PageViewEntityType } from '../../../../api/soroban-security-portal/mode
 
 export const ReportDetails: FC = () => {
   const navigate = useNavigate();
-  const { auth } = useAppAuth();
+  const { auth, login } = useAppAuth();
 
   const {
     report,
@@ -763,7 +763,7 @@ export const ReportDetails: FC = () => {
                       <Button
                         variant="contained"
                         color="primary"
-                        onClick={() => showMessage('Log in to view the full report')}
+                        onClick={login}
                       >
                         Log In
                       </Button>


### PR DESCRIPTION
## Description

When attempting to view a full report (PDF) without being logged in, the "Log In" button on the "Full Report" tab displayed an alert message instead of redirecting to the SSO login page. This fix ensures the button triggers the proper SSO authentication flow via `auth.signinRedirect()`.

## Changes

- **`UI/src/features/pages/regular/report-details/report-details.tsx`**
  - Destructure both `auth` and `login` from `useAppAuth()` (preserves existing `auth` references)
  - Update "Log In" button `onClick` from `showMessage(...)` to `login`

## Testing

- Manual verification required: navigate to a report details page → "Full Report" tab → click "Log In" → should redirect to SSO page
- No existing tests for this component
- All existing `auth` references (`isAuthorized`, `canEdit`, `auth.isAuthenticated`, `auth.user`) continue to work

## Risk

Low. This is a minimal UI fix (2 lines changed, 1 file) with no data layer or architectural changes. Rollback is a single revert.

Closes #165