### PR TITLE
fix: moderation panel header shows 'Vulnerabilities' (#177)

### DIFF
--- a/UI/src/features/moderation/pages/ModerationDashboard.tsx
+++ b/UI/src/features/moderation/pages/ModerationDashboard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
     Box, Container, Typography, Tab, Tabs,
     FormControl, InputLabel, Select, MenuItem, Paper,
@@ -9,11 +9,28 @@ import { useModerationQueue } from '../hooks/useModerationQueue';
 import { ModerationStats } from '../components/ModerationStats';
 import { ModerationItem } from '../components/ModerationItem';
 import { ContentType, ModerationStatus } from '../types';
+import { useAppDispatch } from '../../../app/hooks';
+import { setCurrentPage } from '../../pages/admin/admin-main-window/current-page-slice';
 
 export const ModerationDashboard = () => {
+    const dispatch = useAppDispatch();
     const { items, stats, loading, handleAction, refetch } = useModerationQueue();
     const [currentTab, setCurrentTab] = useState<ModerationStatus>('pending');
     const [contentTypeFilter, setContentTypeFilter] = useState<ContentType | 'all'>('all');
+
+    const currentPageState = useMemo(
+        () => ({
+            pageName: 'Moderation',
+            pageCode: 'moderation',
+            pageUrl: window.location.pathname,
+            routePath: 'admin/moderation',
+        }),
+        [],
+    );
+
+    useEffect(() => {
+        dispatch(setCurrentPage(currentPageState));
+    }, [dispatch, currentPageState]);
 
     if (loading || !stats) {
         return (

--- a/UI/src/features/moderation/pages/__tests__/ModerationDashboard.test.tsx
+++ b/UI/src/features/moderation/pages/__tests__/ModerationDashboard.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import currentPageReducer from '../../../../features/pages/admin/admin-main-window/current-page-slice';
+import currentErrorReducer from '../../../../features/pages/admin/admin-main-window/current-error-slice';
 import { ModerationDashboard } from '../ModerationDashboard';
 import { FlaggedContent, ModerationStats } from '../../types';
 
@@ -106,13 +110,19 @@ vi.mock('../../hooks/useModerationQueue', () => ({
 
 const theme = createTheme();
 
+const makeStore = () => configureStore({
+    reducer: { currentPage: currentPageReducer, currentError: currentErrorReducer },
+});
+
 const renderComponent = () =>
     render(
-        <MemoryRouter>
-            <ThemeProvider theme={theme}>
-                <ModerationDashboard />
-            </ThemeProvider>
-        </MemoryRouter>
+        <Provider store={makeStore()}>
+            <MemoryRouter>
+                <ThemeProvider theme={theme}>
+                    <ModerationDashboard />
+                </ThemeProvider>
+            </MemoryRouter>
+        </Provider>
     );
 
 describe('ModerationDashboard - filtering', () => {

--- a/UI/src/features/pages/admin/admin-main-window/admin-main-window.tsx
+++ b/UI/src/features/pages/admin/admin-main-window/admin-main-window.tsx
@@ -262,7 +262,7 @@ export const AdminMainWindow: FC = () => {
       <Main leftMenuOpen={leftMenuOpen} isTemporary={isMobile} className="mainWindowMain">
         <DrawerHeader />
         <Routes>
-          <Route path={`${environment.basePath}/admin`} element={<VulnerabilityManagement />} />
+          <Route path={`${environment.basePath}/admin`} element={<VulnerabilityManagement />} end />
 
           <Route path={`${environment.basePath}/admin/settings`} element={<Settings />} />
 


### PR DESCRIPTION
## Summary
Fixes #177 — the admin toolbar header was stuck showing "Vulnerabilities" when navigating to the Moderation panel.

## Root cause
`ModerationDashboard` never dispatched `setCurrentPage`, so the Redux store retained the stale value set by the previously visited `VulnerabilityManagement` page.

## Changes
- **`ModerationDashboard.tsx`** — dispatch `setCurrentPage({ pageName: 'Moderation', ... })` on mount via `useEffect`
- **`ModerationDashboard.test.tsx`** — wrap render with Redux `<Provider>` (required by the new `useAppDispatch` call); all 9 tests pass
- **`admin-main-window.tsx`** — add `end` prop to the default `/admin` route to prevent it matching sub-paths