### PR TITLE
fix: dispatch setCurrentPage on ModerationDashboard mount

### DIFF
--- a/UI/src/features/moderation/pages/ModerationDashboard.tsx
+++ b/UI/src/features/moderation/pages/ModerationDashboard.tsx
@@ -1,18 +1,30 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
     Box, Container, Typography, Tab, Tabs,
     FormControl, InputLabel, Select, MenuItem, Paper,
     CircularProgress, Button
 } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
+import { useAppDispatch } from '../../../app/hooks';
+import { setCurrentPage } from '../../pages/admin/admin-main-window/current-page-slice';
 import { useModerationQueue } from '../hooks/useModerationQueue';
 import { ModerationStats } from '../components/ModerationStats';
 import { ModerationItem } from '../components/ModerationItem';
 import { ContentType, ModerationStatus } from '../types';
 
 export const ModerationDashboard = () => {
+    const dispatch = useAppDispatch();
     const { items, stats, loading, handleAction, refetch } = useModerationQueue();
     const [currentTab, setCurrentTab] = useState<ModerationStatus>('pending');
+
+    useEffect(() => {
+        dispatch(setCurrentPage({
+            pageName: 'Moderation',
+            pageCode: 'moderation',
+            pageUrl: window.location.pathname,
+            routePath: 'moderation',
+        }));
+    }, []);
     const [contentTypeFilter, setContentTypeFilter] = useState<ContentType | 'all'>('all');
 
     if (loading || !stats) {

--- a/UI/src/features/moderation/pages/__tests__/ModerationDashboard.test.tsx
+++ b/UI/src/features/moderation/pages/__tests__/ModerationDashboard.test.tsx
@@ -2,7 +2,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
+import currentPageReducer from '../../../pages/admin/admin-main-window/current-page-slice';
+import currentErrorReducer from '../../../pages/admin/admin-main-window/current-error-slice';
 import { ModerationDashboard } from '../ModerationDashboard';
 import { FlaggedContent, ModerationStats } from '../../types';
 
@@ -106,13 +110,19 @@ vi.mock('../../hooks/useModerationQueue', () => ({
 
 const theme = createTheme();
 
+const makeStore = () => configureStore({
+    reducer: { currentPage: currentPageReducer, currentError: currentErrorReducer },
+});
+
 const renderComponent = () =>
     render(
-        <MemoryRouter>
-            <ThemeProvider theme={theme}>
-                <ModerationDashboard />
-            </ThemeProvider>
-        </MemoryRouter>
+        <Provider store={makeStore()}>
+            <MemoryRouter>
+                <ThemeProvider theme={theme}>
+                    <ModerationDashboard />
+                </ThemeProvider>
+            </MemoryRouter>
+        </Provider>
     );
 
 describe('ModerationDashboard - filtering', () => {


### PR DESCRIPTION
Closes #177

---

## Summary

The admin header reads `pageName` from the Redux `currentPage` slice. `ModerationDashboard` never dispatched `setCurrentPage`, so the header kept showing whatever the previous page had set (e.g. "Vulnerabilities").

## Changes

- **ModerationDashboard.tsx**: add `useEffect` that dispatches `setCurrentPage` on mount, matching the pattern used by other admin pages
- **ModerationDashboard.test.tsx**: wrap the component in a Redux `Provider` so `useAppDispatch` resolves correctly in tests

## What was tested

- `tsc --noEmit` passes with no errors
- All 9 existing unit tests continue to pass
- The `end` prop that was previously added to the `/admin` `<Route>` has been removed — it was causing a TS2322 type error and was not needed (react-router v6/v7 already matches `path="/admin"` exactly)