### PR TITLE
feat: implement forum API endpoints and services

### DIFF
--- a/Backend/SorobanSecurityPortalApi/Controllers/ForumController.cs
+++ b/Backend/SorobanSecurityPortalApi/Controllers/ForumController.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Models.ViewModels;
+using SorobanSecurityPortalApi.Services.ControllersServices;
+
+namespace SorobanSecurityPortalApi.Controllers
+{
+    [ApiController]
+    [Route("api/v1/forum")]
+    public class ForumController : ControllerBase
+    {
+        private readonly IForumService _forumService;
+        private readonly IUserContextAccessor _userContextAccessor;
+
+        public ForumController(IForumService forumService, IUserContextAccessor userContextAccessor)
+        {
+            _forumService = forumService;
+            _userContextAccessor = userContextAccessor;
+        }
+
+        /// <summary>
+        /// GET /api/v1/forum/categories
+        /// List all forum categories with thread counts
+        /// </summary>
+        [HttpGet("categories")]
+        public async Task<IActionResult> GetCategories()
+        {
+            try
+            {
+                var result = await _forumService.GetCategories();
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+        }
+
+        /// <summary>
+        /// GET /api/v1/forum/categories/{slug}/threads
+        /// List paginated threads for a category
+        /// </summary>
+        [HttpGet("categories/{slug}/threads")]
+        public async Task<IActionResult> GetThreadsByCategory(
+            string slug,
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 20)
+        {
+            if (string.IsNullOrWhiteSpace(slug))
+                return BadRequest("Category slug must not be empty.");
+            if (page < 1)
+                return BadRequest("Page must be at least 1.");
+            if (pageSize < 1 || pageSize > 100)
+                return BadRequest("Page size must be between 1 and 100.");
+
+            try
+            {
+                var result = await _forumService.GetThreadsByCategory(slug, page, pageSize);
+                Response.Headers.Add("X-Total-Count", result.TotalCount.ToString());
+                return Ok(result);
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+        }
+
+        /// <summary>
+        /// GET /api/v1/forum/threads/{slug}
+        /// Get a thread with paginated posts
+        /// </summary>
+        [HttpGet("threads/{slug}")]
+        public async Task<IActionResult> GetThreadBySlug(
+            string slug,
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 20)
+        {
+            if (string.IsNullOrWhiteSpace(slug))
+                return BadRequest("Thread slug must not be empty.");
+            if (page < 1)
+                return BadRequest("Page must be at least 1.");
+            if (pageSize < 1 || pageSize > 100)
+                return BadRequest("Page size must be between 1 and 100.");
+
+            try
+            {
+                var result = await _forumService.GetThreadBySlug(slug, page, pageSize);
+
+                // Record view with rate limiting
+                var visitorId = await _userContextAccessor.GetLoginIdOrNullAsync();
+                var visitorIdentifier = visitorId?.ToString() ?? Request.HttpContext.Connection.RemoteIpAddress?.ToString();
+                await _forumService.RecordThreadView(result.Id, visitorIdentifier);
+
+                Response.Headers.Add("X-Total-Count", result.TotalPosts.ToString());
+                return Ok(result);
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+        }
+
+        /// <summary>
+        /// POST /api/v1/forum/threads
+        /// Create a new thread (which creates the first post)
+        /// </summary>
+        [HttpPost("threads")]
+        [Authorize]
+        public async Task<IActionResult> CreateThread([FromBody] CreateThreadRequest request)
+        {
+            if (request == null)
+                return BadRequest("Request body cannot be null.");
+            if (request.CategoryId <= 0)
+                return BadRequest("CategoryId must be a positive integer.");
+            if (string.IsNullOrWhiteSpace(request.Title))
+                return BadRequest("Title must not be empty.");
+            if (request.Title.Length > 200)
+                return BadRequest("Title must not exceed 200 characters.");
+            if (string.IsNullOrWhiteSpace(request.Content))
+                return BadRequest("Content must not be empty.");
+            if (request.Content.Length > 10000)
+                return BadRequest("Content must not exceed 10000 characters.");
+
+            try
+            {
+                var result = await _forumService.CreateThread(request);
+                return CreatedAtAction(nameof(GetThreadBySlug), new { slug = result.Slug }, result);
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return Unauthorized(new { message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+        }
+
+        /// <summary>
+        /// POST /api/v1/forum/threads/{id}/posts
+        /// Reply to a thread (create a new post)
+        /// </summary>
+        [HttpPost("threads/{id}/posts")]
+        [Authorize]
+        public async Task<IActionResult> CreatePost(int id, [FromBody] CreatePostRequest request)
+        {
+            if (id <= 0)
+                return BadRequest("Thread ID must be a positive integer.");
+            if (request == null)
+                return BadRequest("Request body cannot be null.");
+            if (string.IsNullOrWhiteSpace(request.Content))
+                return BadRequest("Content must not be empty.");
+            if (request.Content.Length > 10000)
+                return BadRequest("Content must not exceed 10000 characters.");
+
+            try
+            {
+                var result = await _forumService.CreatePost(id, request);
+                return CreatedAtAction(nameof(GetThreadBySlug), result);
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return Unauthorized(new { message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+        }
+
+        /// <summary>
+        /// PUT /api/v1/forum/posts/{id}
+        /// Edit a forum post
+        /// </summary>
+        [HttpPut("posts/{id}")]
+        [Authorize]
+        public async Task<IActionResult> UpdatePost(int id, [FromBody] UpdatePostRequest request)
+        {
+            if (id <= 0)
+                return BadRequest("Post ID must be a positive integer.");
+            if (request == null)
+                return BadRequest("Request body cannot be null.");
+            if (string.IsNullOrWhiteSpace(request.Content))
+                return BadRequest("Content must not be empty.");
+            if (request.Content.Length > 10000)
+                return BadRequest("Content must not exceed 10000 characters.");
+
+            try
+            {
+                var result = await _forumService.UpdatePost(id, request);
+                return Ok(result);
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return Forbid();
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+        }
+
+        /// <summary>
+        /// POST /api/v1/forum/posts/{id}/vote
+        /// Vote on a forum post (upvote, downvote, or remove vote)
+        /// </summary>
+        [HttpPost("posts/{id}/vote")]
+        [Authorize]
+        public async Task<IActionResult> VoteOnPost(int id, [FromBody] ForumVoteRequest request)
+        {
+            if (id <= 0)
+                return BadRequest("Post ID must be a positive integer.");
+            if (request == null)
+                return BadRequest("Request body cannot be null.");
+            if (string.IsNullOrWhiteSpace(request.VoteType))
+                return BadRequest("VoteType must not be empty.");
+
+            try
+            {
+                var result = await _forumService.VoteOnPost(id, request.VoteType);
+                return Ok(result);
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                return Unauthorized(new { message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Data/Processors/ForumProcessor.cs
+++ b/Backend/SorobanSecurityPortalApi/Data/Processors/ForumProcessor.cs
@@ -1,0 +1,207 @@
+using Microsoft.EntityFrameworkCore;
+using SorobanSecurityPortalApi.Common.Data;
+using SorobanSecurityPortalApi.Models.DbModels;
+
+namespace SorobanSecurityPortalApi.Data.Processors
+{
+    public class ForumProcessor : IForumProcessor
+    {
+        private readonly IDbContextFactory<Db> _dbFactory;
+
+        public ForumProcessor(IDbContextFactory<Db> dbFactory)
+        {
+            _dbFactory = dbFactory;
+        }
+
+        public async Task<List<ForumCategoryModel>> GetCategories()
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ForumCategory.AsNoTracking()
+                .OrderBy(c => c.SortOrder)
+                .ToListAsync();
+        }
+
+        public async Task<ForumCategoryModel?> GetCategoryBySlug(string slug)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ForumCategory.AsNoTracking()
+                .FirstOrDefaultAsync(c => c.Slug == slug);
+        }
+
+        public async Task<ForumCategoryModel?> GetCategoryById(int id)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ForumCategory.AsNoTracking()
+                .FirstOrDefaultAsync(c => c.Id == id);
+        }
+
+        public async Task<int> GetThreadCountForCategory(int categoryId)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ForumThread.AsNoTracking()
+                .CountAsync(t => t.CategoryId == categoryId);
+        }
+
+        public async Task<List<ForumThreadModel>> GetThreadsByCategory(int categoryId, int page, int pageSize)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ForumThread.AsNoTracking()
+                .Where(t => t.CategoryId == categoryId)
+                .OrderByDescending(t => t.IsPinned)
+                .ThenByDescending(t => t.UpdatedAt ?? t.CreatedAt)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync();
+        }
+
+        public async Task<ForumThreadModel?> GetThreadBySlug(string slug)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ForumThread.AsNoTracking()
+                .FirstOrDefaultAsync(t => t.Slug == slug);
+        }
+
+        public async Task<ForumThreadModel?> GetThreadById(int id)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ForumThread.AsNoTracking()
+                .FirstOrDefaultAsync(t => t.Id == id);
+        }
+
+        public async Task<int> GetPostCountForThread(int threadId)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ForumPost.AsNoTracking()
+                .CountAsync(p => p.ThreadId == threadId);
+        }
+
+        public async Task<List<ForumPostModel>> GetPostsByThread(int threadId, int page, int pageSize)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ForumPost.AsNoTracking()
+                .Where(p => p.ThreadId == threadId)
+                .OrderBy(p => p.CreatedAt)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .ToListAsync();
+        }
+
+        public async Task<ForumPostModel?> GetPostById(int id)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ForumPost.AsNoTracking()
+                .FirstOrDefaultAsync(p => p.Id == id);
+        }
+
+        public async Task<ForumThreadModel> CreateThread(ForumThreadModel thread)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            db.ForumThread.Add(thread);
+            await db.SaveChangesAsync();
+            return thread;
+        }
+
+        public async Task<ForumPostModel> CreatePost(ForumPostModel post)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            db.ForumPost.Add(post);
+            
+            // Update thread's UpdatedAt timestamp
+            var thread = await db.ForumThread.FirstOrDefaultAsync(t => t.Id == post.ThreadId);
+            if (thread != null)
+            {
+                thread.UpdatedAt = DateTime.UtcNow;
+            }
+            
+            await db.SaveChangesAsync();
+            return post;
+        }
+
+        public async Task<ForumPostModel?> UpdatePost(int id, string content, string contentHtml)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var post = await db.ForumPost.FirstOrDefaultAsync(p => p.Id == id);
+            if (post == null) return null;
+            
+            post.Content = content;
+            post.ContentHtml = contentHtml;
+            post.IsEdited = true;
+            post.UpdatedAt = DateTime.UtcNow;
+            
+            // Update thread's UpdatedAt timestamp
+            var thread = await db.ForumThread.FirstOrDefaultAsync(t => t.Id == post.ThreadId);
+            if (thread != null)
+            {
+                thread.UpdatedAt = DateTime.UtcNow;
+            }
+            
+            await db.SaveChangesAsync();
+            return post;
+        }
+
+        public async Task IncrementViewCount(int threadId)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var thread = await db.ForumThread.FirstOrDefaultAsync(t => t.Id == threadId);
+            if (thread != null)
+            {
+                thread.ViewCount++;
+                await db.SaveChangesAsync();
+            }
+        }
+
+        public async Task<ForumPostModel?> UpdatePostVotes(int postId, int voteDelta)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var post = await db.ForumPost.FirstOrDefaultAsync(p => p.Id == postId);
+            if (post == null) return null;
+            
+            post.Votes += voteDelta;
+            await db.SaveChangesAsync();
+            return post;
+        }
+
+        public async Task<Dictionary<int, string>> GetAuthorNames(List<int> userIds)
+        {
+            if (userIds == null || userIds.Count == 0) return new Dictionary<int, string>();
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var rows = await db.Login.AsNoTracking()
+                .Where(l => userIds.Contains(l.LoginId))
+                .Select(l => new { l.LoginId, l.FullName, l.Login })
+                .ToListAsync();
+            return rows.ToDictionary(
+                r => r.LoginId,
+                r => !string.IsNullOrWhiteSpace(r.FullName) ? r.FullName : r.Login);
+        }
+
+        public async Task<ForumPostModel?> GetLastPostForThread(int threadId)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            return await db.ForumPost.AsNoTracking()
+                .Where(p => p.ThreadId == threadId)
+                .OrderByDescending(p => p.CreatedAt)
+                .FirstOrDefaultAsync();
+        }
+    }
+
+    public interface IForumProcessor
+    {
+        Task<List<ForumCategoryModel>> GetCategories();
+        Task<ForumCategoryModel?> GetCategoryBySlug(string slug);
+        Task<ForumCategoryModel?> GetCategoryById(int id);
+        Task<int> GetThreadCountForCategory(int categoryId);
+        Task<List<ForumThreadModel>> GetThreadsByCategory(int categoryId, int page, int pageSize);
+        Task<ForumThreadModel?> GetThreadBySlug(string slug);
+        Task<ForumThreadModel?> GetThreadById(int id);
+        Task<int> GetPostCountForThread(int threadId);
+        Task<List<ForumPostModel>> GetPostsByThread(int threadId, int page, int pageSize);
+        Task<ForumPostModel?> GetPostById(int id);
+        Task<ForumThreadModel> CreateThread(ForumThreadModel thread);
+        Task<ForumPostModel> CreatePost(ForumPostModel post);
+        Task<ForumPostModel?> UpdatePost(int id, string content, string contentHtml);
+        Task IncrementViewCount(int threadId);
+        Task<ForumPostModel?> UpdatePostVotes(int postId, int voteDelta);
+        Task<Dictionary<int, string>> GetAuthorNames(List<int> userIds);
+        Task<ForumPostModel?> GetLastPostForThread(int threadId);
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Data/Processors/VoteProcessor.cs
+++ b/Backend/SorobanSecurityPortalApi/Data/Processors/VoteProcessor.cs
@@ -16,10 +16,20 @@ namespace SorobanSecurityPortalApi.Data.Processors
         public VoteType? CurrentUserVote { get; set; }
     }
 
+    public class ForumVoteOutcome
+    {
+        public bool IsSelfVote { get; set; }
+        public bool BelowDownvoteThreshold { get; set; }
+        public int VoteCount { get; set; }
+        public VoteType? CurrentUserVote { get; set; }
+    }
+
     public interface IVoteProcessor
     {
         Task<VoteOutcome?> SetCommentVote(int commentId, int userId, VoteType? newVote);
         Task<Dictionary<int, VoteType>> GetUserVotesForComments(int userId, List<int> commentIds);
+        Task<ForumVoteOutcome?> SetForumPostVote(int postId, int userId, VoteType? newVote);
+        Task<Dictionary<int, VoteType>> GetUserVotesForForumPosts(int userId, List<int> postIds);
     }
 
     public class VoteProcessor : IVoteProcessor
@@ -120,6 +130,91 @@ namespace SorobanSecurityPortalApi.Data.Processors
             await using var db = await _dbFactory.CreateDbContextAsync();
             var rows = await db.Vote.AsNoTracking()
                 .Where(v => v.UserId == userId && v.EntityType == VotableEntityType.Comment && commentIds.Contains(v.EntityId))
+                .Select(v => new { v.EntityId, v.VoteType })
+                .ToListAsync();
+            return rows.ToDictionary(r => r.EntityId, r => r.VoteType);
+        }
+
+        public async Task<ForumVoteOutcome?> SetForumPostVote(int postId, int userId, VoteType? newVote)
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var post = await db.ForumPost.FirstOrDefaultAsync(p => p.Id == postId);
+            if (post == null) return null;
+
+            // Voting on your own post is not allowed
+            if (post.AuthorId == userId)
+                return new ForumVoteOutcome { IsSelfVote = true, VoteCount = post.Votes };
+
+            var existing = await db.Vote.FirstOrDefaultAsync(
+                v => v.UserId == userId && v.EntityType == VotableEntityType.ForumPost && v.EntityId == postId);
+
+            var oldVote = existing?.VoteType;
+
+            // Min-reputation gate: only applies when newly casting a downvote
+            if (newVote == VoteType.Downvote && oldVote != VoteType.Downvote)
+            {
+                var voterRep = await db.UserProfiles.AsNoTracking()
+                    .Where(p => p.LoginId == userId)
+                    .Select(p => (int?)p.ReputationScore)
+                    .FirstOrDefaultAsync() ?? 0;
+                if (voterRep < MinReputationToDownvote)
+                    return new ForumVoteOutcome
+                    {
+                        BelowDownvoteThreshold = true,
+                        VoteCount = post.Votes,
+                        CurrentUserVote = oldVote
+                    };
+            }
+
+            if (newVote == null)
+            {
+                if (existing != null) db.Vote.Remove(existing);
+            }
+            else if (existing != null)
+            {
+                existing.VoteType = newVote.Value;
+            }
+            else
+            {
+                db.Vote.Add(new VoteModel
+                {
+                    UserId = userId,
+                    EntityType = VotableEntityType.ForumPost,
+                    EntityId = postId,
+                    VoteType = newVote.Value
+                });
+            }
+
+            // Recompute vote count from the authoritative vote rows
+            var upVotes = await db.Vote.CountAsync(v => v.EntityType == VotableEntityType.ForumPost
+                && v.EntityId == postId && v.VoteType == VoteType.Upvote);
+            var downVotes = await db.Vote.CountAsync(v => v.EntityType == VotableEntityType.ForumPost
+                && v.EntityId == postId && v.VoteType == VoteType.Downvote);
+            post.Votes = upVotes - downVotes;
+
+            // Author earns +1 reputation per upvote on their post
+            var repDelta = (newVote == VoteType.Upvote ? 1 : 0) - (oldVote == VoteType.Upvote ? 1 : 0);
+            if (repDelta != 0)
+            {
+                var authorProfile = await db.UserProfiles.FirstOrDefaultAsync(p => p.LoginId == post.AuthorId);
+                if (authorProfile != null) authorProfile.ReputationScore += repDelta;
+            }
+
+            await db.SaveChangesAsync();
+            return new ForumVoteOutcome
+            {
+                IsSelfVote = false,
+                VoteCount = post.Votes,
+                CurrentUserVote = newVote
+            };
+        }
+
+        public async Task<Dictionary<int, VoteType>> GetUserVotesForForumPosts(int userId, List<int> postIds)
+        {
+            if (postIds == null || postIds.Count == 0) return new Dictionary<int, VoteType>();
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var rows = await db.Vote.AsNoTracking()
+                .Where(v => v.UserId == userId && v.EntityType == VotableEntityType.ForumPost && postIds.Contains(v.EntityId))
                 .Select(v => new { v.EntityId, v.VoteType })
                 .ToListAsync();
             return rows.ToDictionary(r => r.EntityId, r => r.VoteType);

--- a/Backend/SorobanSecurityPortalApi/Models/DbModels/ForumPostModel.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/DbModels/ForumPostModel.cs
@@ -19,7 +19,10 @@ namespace SorobanSecurityPortalApi.Models.DbModels
         [Required]
         public string Content { get; set; } = string.Empty;
 
+        public string ContentHtml { get; set; } = string.Empty;
+
         public bool IsFirstPost { get; set; }
+        public bool IsEdited { get; set; }
         public int Votes { get; set; }
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/Backend/SorobanSecurityPortalApi/Models/Mapping/ForumModelProfile.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/Mapping/ForumModelProfile.cs
@@ -1,0 +1,27 @@
+using SorobanSecurityPortalApi.Models.ViewModels;
+using AutoMapper;
+using SorobanSecurityPortalApi.Models.DbModels;
+
+namespace SorobanSecurityPortalApi.Models.Mapping;
+
+public class ForumModelProfile : Profile
+{
+    public ForumModelProfile()
+    {
+        CreateMap<ForumCategoryModel, ForumCategoryViewModel>();
+        CreateMap<ForumCategoryViewModel, ForumCategoryModel>();
+        
+        CreateMap<ForumThreadModel, ForumThreadViewModel>();
+        CreateMap<ForumThreadViewModel, ForumThreadModel>();
+        
+        CreateMap<ForumThreadModel, ForumThreadDetailViewModel>();
+        CreateMap<ForumThreadDetailViewModel, ForumThreadModel>();
+        
+        CreateMap<ForumPostModel, ForumPostViewModel>();
+        CreateMap<ForumPostViewModel, ForumPostModel>();
+        
+        CreateMap<CreateThreadRequest, ForumThreadModel>();
+        CreateMap<CreatePostRequest, ForumPostModel>();
+        CreateMap<UpdatePostRequest, ForumPostModel>();
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Models/ViewModels/ForumViewModels.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/ViewModels/ForumViewModels.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+
+namespace SorobanSecurityPortalApi.Models.ViewModels
+{
+    public class ForumCategoryViewModel
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string Slug { get; set; } = string.Empty;
+        public int SortOrder { get; set; }
+        public bool IsLocked { get; set; }
+        public int ThreadCount { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+
+    public class ForumThreadViewModel
+    {
+        public int Id { get; set; }
+        public int CategoryId { get; set; }
+        public string CategoryName { get; set; } = string.Empty;
+        public string CategorySlug { get; set; } = string.Empty;
+        public int AuthorId { get; set; }
+        public string AuthorName { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Slug { get; set; } = string.Empty;
+        public bool IsPinned { get; set; }
+        public bool IsLocked { get; set; }
+        public int ViewCount { get; set; }
+        public int PostCount { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? UpdatedAt { get; set; }
+        public ForumPostViewModel? LastPost { get; set; }
+    }
+
+    public class ForumPostViewModel
+    {
+        public int Id { get; set; }
+        public int ThreadId { get; set; }
+        public int AuthorId { get; set; }
+        public string AuthorName { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+        public string ContentHtml { get; set; } = string.Empty;
+        public bool IsFirstPost { get; set; }
+        public int Votes { get; set; }
+        public bool IsEdited { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? UpdatedAt { get; set; }
+        public string? CurrentUserVote { get; set; }
+        public bool IsOwn { get; set; }
+    }
+
+    public class ForumThreadDetailViewModel
+    {
+        public int Id { get; set; }
+        public int CategoryId { get; set; }
+        public string CategoryName { get; set; } = string.Empty;
+        public string CategorySlug { get; set; } = string.Empty;
+        public int AuthorId { get; set; }
+        public string AuthorName { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Slug { get; set; } = string.Empty;
+        public bool IsPinned { get; set; }
+        public bool IsLocked { get; set; }
+        public int ViewCount { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public DateTime? UpdatedAt { get; set; }
+        public List<ForumPostViewModel> Posts { get; set; } = new();
+        public int TotalPosts { get; set; }
+        public int CurrentPage { get; set; }
+        public int PageSize { get; set; }
+        public int TotalPages { get; set; }
+    }
+
+    public class CreateThreadRequest
+    {
+        public int CategoryId { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+    }
+
+    public class CreatePostRequest
+    {
+        public string Content { get; set; } = string.Empty;
+    }
+
+    public class UpdatePostRequest
+    {
+        public string Content { get; set; } = string.Empty;
+    }
+
+    public class ForumVoteRequest
+    {
+        public string VoteType { get; set; } = string.Empty;
+    }
+
+    public class ForumVoteResultViewModel
+    {
+        public int Votes { get; set; }
+        public string? CurrentUserVote { get; set; }
+    }
+
+    public class PaginatedResult<T>
+    {
+        public List<T> Items { get; set; } = new();
+        public int TotalCount { get; set; }
+        public int CurrentPage { get; set; }
+        public int PageSize { get; set; }
+        public int TotalPages { get; set; }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ForumService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/ForumService.cs
@@ -1,0 +1,448 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using AutoMapper;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Data.Processors;
+using SorobanSecurityPortalApi.Models.DbModels;
+using SorobanSecurityPortalApi.Models.ViewModels;
+using SorobanSecurityPortalApi.Services.Moderation;
+
+namespace SorobanSecurityPortalApi.Services.ControllersServices
+{
+    public interface IForumService
+    {
+        Task<List<ForumCategoryViewModel>> GetCategories();
+        Task<PaginatedResult<ForumThreadViewModel>> GetThreadsByCategory(string categorySlug, int page, int pageSize);
+        Task<ForumThreadDetailViewModel> GetThreadBySlug(string slug, int page, int pageSize);
+        Task<ForumThreadViewModel> CreateThread(CreateThreadRequest request);
+        Task<ForumPostViewModel> CreatePost(int threadId, CreatePostRequest request);
+        Task<ForumPostViewModel> UpdatePost(int postId, UpdatePostRequest request);
+        Task<ForumVoteResultViewModel> VoteOnPost(int postId, string voteType);
+        Task RecordThreadView(int threadId, string? visitorIdentifier);
+    }
+
+    public class ForumService : IForumService
+    {
+        private const int EditWindowMinutes = 30;
+        private const int MaxTitleLength = 200;
+        private const int MaxContentLength = 10000;
+        private const int DefaultPageSize = 20;
+
+        private readonly IForumProcessor _processor;
+        private readonly IContentFilterService _contentFilter;
+        private readonly IUserContextAccessor _userContext;
+        private readonly IMapper _mapper;
+        private readonly IDistributedCache _cache;
+        private readonly IVoteProcessor _voteProcessor;
+        private readonly ILogger<ForumService> _logger;
+
+        public ForumService(
+            IForumProcessor processor,
+            IContentFilterService contentFilter,
+            IUserContextAccessor userContext,
+            IMapper mapper,
+            IDistributedCache cache,
+            IVoteProcessor voteProcessor,
+            ILogger<ForumService> logger)
+        {
+            _processor = processor;
+            _contentFilter = contentFilter;
+            _userContext = userContext;
+            _mapper = mapper;
+            _cache = cache;
+            _voteProcessor = voteProcessor;
+            _logger = logger;
+        }
+
+        public async Task<List<ForumCategoryViewModel>> GetCategories()
+        {
+            var categories = await _processor.GetCategories();
+            var result = new List<ForumCategoryViewModel>();
+
+            foreach (var category in categories)
+            {
+                var threadCount = await _processor.GetThreadCountForCategory(category.Id);
+                var vm = _mapper.Map<ForumCategoryViewModel>(category);
+                vm.ThreadCount = threadCount;
+                result.Add(vm);
+            }
+
+            return result;
+        }
+
+        public async Task<PaginatedResult<ForumThreadViewModel>> GetThreadsByCategory(string categorySlug, int page, int pageSize)
+        {
+            page = Math.Max(1, page);
+            pageSize = Math.Max(1, Math.Min(100, pageSize));
+
+            var category = await _processor.GetCategoryBySlug(categorySlug);
+            if (category == null)
+                throw new KeyNotFoundException($"Category with slug '{categorySlug}' not found.");
+
+            if (category.IsLocked)
+                throw new InvalidOperationException("This category is locked and cannot be viewed.");
+
+            var threads = await _processor.GetThreadsByCategory(category.Id, page, pageSize);
+            var totalCount = await _processor.GetThreadCountForCategory(category.Id);
+
+            var authorIds = threads.Select(t => t.AuthorId).Distinct().ToList();
+            var authorNames = await _processor.GetAuthorNames(authorIds);
+
+            var lastPostThreadIds = threads.Select(t => t.Id).ToList();
+            var lastPosts = new Dictionary<int, ForumPostModel>();
+            foreach (var threadId in lastPostThreadIds)
+            {
+                var lastPost = await _processor.GetLastPostForThread(threadId);
+                if (lastPost != null)
+                    lastPosts[threadId] = lastPost;
+            }
+
+            var lastPostAuthorIds = lastPosts.Values.Select(p => p.AuthorId).Distinct().ToList();
+            var lastPostAuthorNames = await _processor.GetAuthorNames(lastPostAuthorIds);
+
+            var items = new List<ForumThreadViewModel>();
+            foreach (var thread in threads)
+            {
+                var vm = _mapper.Map<ForumThreadViewModel>(thread);
+                vm.CategoryName = category.Name;
+                vm.CategorySlug = category.Slug;
+                vm.AuthorName = authorNames.TryGetValue(thread.AuthorId, out var name) && !string.IsNullOrWhiteSpace(name) 
+                    ? name 
+                    : "Anonymous";
+                vm.PostCount = await _processor.GetPostCountForThread(thread.Id);
+
+                if (lastPosts.TryGetValue(thread.Id, out var lastPost))
+                {
+                    vm.LastPost = _mapper.Map<ForumPostViewModel>(lastPost);
+                    vm.LastPost.AuthorName = lastPostAuthorNames.TryGetValue(lastPost.AuthorId, out var lpName) 
+                        && !string.IsNullOrWhiteSpace(lpName) 
+                        ? lpName 
+                        : "Anonymous";
+                }
+
+                items.Add(vm);
+            }
+
+            return new PaginatedResult<ForumThreadViewModel>
+            {
+                Items = items,
+                TotalCount = totalCount,
+                CurrentPage = page,
+                PageSize = pageSize,
+                TotalPages = (int)Math.Ceiling((double)totalCount / pageSize)
+            };
+        }
+
+        public async Task<ForumThreadDetailViewModel> GetThreadBySlug(string slug, int page, int pageSize)
+        {
+            page = Math.Max(1, page);
+            pageSize = Math.Max(1, Math.Min(100, pageSize));
+
+            var thread = await _processor.GetThreadBySlug(slug);
+            if (thread == null)
+                throw new KeyNotFoundException($"Thread with slug '{slug}' not found.");
+
+            var categoryModel = await _processor.GetCategoryById(thread.CategoryId);
+            
+            if (categoryModel != null && categoryModel.IsLocked)
+                throw new InvalidOperationException("This thread's category is locked.");
+
+            var totalCount = await _processor.GetPostCountForThread(thread.Id);
+            var posts = await _processor.GetPostsByThread(thread.Id, page, pageSize);
+
+            var authorIds = posts.Select(p => p.AuthorId).Concat(new[] { thread.AuthorId }).Distinct().ToList();
+            var authorNames = await _processor.GetAuthorNames(authorIds);
+
+            var viewerId = await _userContext.GetLoginIdOrNullAsync() ?? 0;
+
+            var postViewModels = new List<ForumPostViewModel>();
+            foreach (var post in posts)
+            {
+                var vm = _mapper.Map<ForumPostViewModel>(post);
+                vm.AuthorName = authorNames.TryGetValue(post.AuthorId, out var name) && !string.IsNullOrWhiteSpace(name) 
+                    ? name 
+                    : "Anonymous";
+                vm.IsOwn = post.AuthorId == viewerId;
+
+                if (viewerId != 0)
+                {
+                    var userVote = await _voteProcessor.GetUserVotesForForumPosts(viewerId, new List<int> { post.Id });
+                    if (userVote.TryGetValue(post.Id, out var voteType))
+                        vm.CurrentUserVote = VoteTypeToString(voteType);
+                }
+
+                postViewModels.Add(vm);
+            }
+
+            return new ForumThreadDetailViewModel
+            {
+                Id = thread.Id,
+                CategoryId = thread.CategoryId,
+                CategoryName = categoryModel?.Name ?? "Unknown",
+                CategorySlug = categoryModel?.Slug ?? "unknown",
+                AuthorId = thread.AuthorId,
+                AuthorName = authorNames.TryGetValue(thread.AuthorId, out var authorName) && !string.IsNullOrWhiteSpace(authorName) 
+                    ? authorName 
+                    : "Anonymous",
+                Title = thread.Title,
+                Slug = thread.Slug,
+                IsPinned = thread.IsPinned,
+                IsLocked = thread.IsLocked,
+                ViewCount = thread.ViewCount,
+                CreatedAt = thread.CreatedAt,
+                UpdatedAt = thread.UpdatedAt,
+                Posts = postViewModels,
+                TotalPosts = totalCount,
+                CurrentPage = page,
+                PageSize = pageSize,
+                TotalPages = (int)Math.Ceiling((double)totalCount / pageSize)
+            };
+        }
+
+        public async Task<ForumThreadViewModel> CreateThread(CreateThreadRequest request)
+        {
+            var userId = await _userContext.GetLoginIdAsync();
+            if (userId == 0)
+                throw new UnauthorizedAccessException("User not logged in.");
+
+            if (string.IsNullOrWhiteSpace(request.Title))
+                throw new InvalidOperationException("Title must not be empty.");
+            if (request.Title.Length > MaxTitleLength)
+                throw new InvalidOperationException($"Title must not exceed {MaxTitleLength} characters.");
+            if (string.IsNullOrWhiteSpace(request.Content))
+                throw new InvalidOperationException("Content must not be empty.");
+            if (request.Content.Length > MaxContentLength)
+                throw new InvalidOperationException($"Content must not exceed {MaxContentLength} characters.");
+
+            var category = await _processor.GetCategoryById(request.CategoryId);
+            if (category == null)
+                throw new KeyNotFoundException($"Category with id {request.CategoryId} not found.");
+            if (category.IsLocked)
+                throw new InvalidOperationException("Cannot create threads in a locked category.");
+
+            if (!await _contentFilter.CheckRateLimitAsync(userId))
+                throw new InvalidOperationException("Rate limit exceeded. Please wait a moment before submitting again.");
+
+            var filterResult = await _contentFilter.FilterContentAsync(request.Content, userId);
+            if (filterResult.IsBlocked)
+                throw new InvalidOperationException($"Content blocked: {string.Join("; ", filterResult.Warnings)}");
+
+            var slug = GenerateSlug(request.Title);
+
+            var thread = new ForumThreadModel
+            {
+                CategoryId = request.CategoryId,
+                AuthorId = userId,
+                Title = request.Title,
+                Slug = slug,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            var createdThread = await _processor.CreateThread(thread);
+
+            var firstPost = new ForumPostModel
+            {
+                ThreadId = createdThread.Id,
+                AuthorId = userId,
+                Content = request.Content,
+                ContentHtml = filterResult.SanitizedContent ?? string.Empty,
+                IsFirstPost = true,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            var createdPost = await _processor.CreatePost(firstPost);
+
+            var authorNames = await _processor.GetAuthorNames(new List<int> { userId });
+            var vm = _mapper.Map<ForumThreadViewModel>(createdThread);
+            vm.AuthorName = authorNames.TryGetValue(userId, out var name) && !string.IsNullOrWhiteSpace(name) 
+                ? name 
+                : "Anonymous";
+            vm.CategoryName = category.Name;
+            vm.CategorySlug = category.Slug;
+            vm.PostCount = 1;
+
+            return vm;
+        }
+
+        public async Task<ForumPostViewModel> CreatePost(int threadId, CreatePostRequest request)
+        {
+            var userId = await _userContext.GetLoginIdAsync();
+            if (userId == 0)
+                throw new UnauthorizedAccessException("User not logged in.");
+
+            if (string.IsNullOrWhiteSpace(request.Content))
+                throw new InvalidOperationException("Content must not be empty.");
+            if (request.Content.Length > MaxContentLength)
+                throw new InvalidOperationException($"Content must not exceed {MaxContentLength} characters.");
+
+            var thread = await _processor.GetThreadById(threadId);
+            if (thread == null)
+                throw new KeyNotFoundException($"Thread with id {threadId} not found.");
+
+            var category = await _processor.GetCategoryById(thread.CategoryId);
+            if (category != null && (category.IsLocked || thread.IsLocked))
+                throw new InvalidOperationException("Cannot post to a locked thread or category.");
+
+            if (!await _contentFilter.CheckRateLimitAsync(userId))
+                throw new InvalidOperationException("Rate limit exceeded. Please wait a moment before submitting again.");
+
+            var filterResult = await _contentFilter.FilterContentAsync(request.Content, userId);
+            if (filterResult.IsBlocked)
+                throw new InvalidOperationException($"Content blocked: {string.Join("; ", filterResult.Warnings)}");
+
+            var post = new ForumPostModel
+            {
+                ThreadId = threadId,
+                AuthorId = userId,
+                Content = request.Content,
+                ContentHtml = filterResult.SanitizedContent ?? string.Empty,
+                IsFirstPost = false,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            var createdPost = await _processor.CreatePost(post);
+
+            var authorNames = await _processor.GetAuthorNames(new List<int> { userId });
+            var vm = _mapper.Map<ForumPostViewModel>(createdPost);
+            vm.AuthorName = authorNames.TryGetValue(userId, out var name) && !string.IsNullOrWhiteSpace(name) 
+                ? name 
+                : "Anonymous";
+            vm.IsOwn = true;
+
+            return vm;
+        }
+
+        public async Task<ForumPostViewModel> UpdatePost(int postId, UpdatePostRequest request)
+        {
+            var userId = await _userContext.GetLoginIdAsync();
+            if (userId == 0)
+                throw new UnauthorizedAccessException("User not logged in.");
+
+            if (string.IsNullOrWhiteSpace(request.Content))
+                throw new InvalidOperationException("Content must not be empty.");
+            if (request.Content.Length > MaxContentLength)
+                throw new InvalidOperationException($"Content must not exceed {MaxContentLength} characters.");
+
+            var post = await _processor.GetPostById(postId);
+            if (post == null)
+                throw new KeyNotFoundException($"Post with id {postId} not found.");
+
+            if (post.AuthorId != userId)
+                throw new UnauthorizedAccessException("You can only edit your own posts.");
+
+            if ((DateTime.UtcNow - post.CreatedAt).TotalMinutes > EditWindowMinutes)
+                throw new InvalidOperationException($"The edit window for this post has expired ({EditWindowMinutes} minutes).");
+
+            if (!await _contentFilter.CheckRateLimitAsync(userId))
+                throw new InvalidOperationException("Rate limit exceeded. Please wait a moment before submitting again.");
+
+            var filterResult = await _contentFilter.FilterContentAsync(request.Content, userId);
+            if (filterResult.IsBlocked)
+                throw new InvalidOperationException($"Content blocked: {string.Join("; ", filterResult.Warnings)}");
+
+            var updatedPost = await _processor.UpdatePost(postId, request.Content, filterResult.SanitizedContent ?? string.Empty);
+            if (updatedPost == null)
+                throw new KeyNotFoundException($"Post with id {postId} not found.");
+
+            var authorNames = await _processor.GetAuthorNames(new List<int> { userId });
+            var vm = _mapper.Map<ForumPostViewModel>(updatedPost);
+            vm.AuthorName = authorNames.TryGetValue(userId, out var name) && !string.IsNullOrWhiteSpace(name) 
+                ? name 
+                : "Anonymous";
+            vm.IsOwn = true;
+
+            return vm;
+        }
+
+        public async Task<ForumVoteResultViewModel> VoteOnPost(int postId, string voteType)
+        {
+            var userId = await _userContext.GetLoginIdAsync();
+            if (userId == 0)
+                throw new UnauthorizedAccessException("User not logged in.");
+
+            var post = await _processor.GetPostById(postId);
+            if (post == null)
+                throw new KeyNotFoundException($"Post with id {postId} not found.");
+
+            VoteType? parsed = (voteType ?? "").ToLowerInvariant() switch
+            {
+                "upvote" => VoteType.Upvote,
+                "downvote" => VoteType.Downvote,
+                "none" => null,
+                _ => throw new InvalidOperationException("voteType must be 'upvote', 'downvote', or 'none'.")
+            };
+
+            var outcome = await _voteProcessor.SetForumPostVote(postId, userId, parsed);
+            if (outcome == null)
+                throw new KeyNotFoundException($"Post with id {postId} not found.");
+            if (outcome.IsSelfVote)
+                throw new InvalidOperationException("You cannot vote on your own post.");
+            if (outcome.BelowDownvoteThreshold)
+                throw new InvalidOperationException(
+                    $"You need at least {VoteProcessor.MinReputationToDownvote} reputation to downvote.");
+
+            var userVote = await _voteProcessor.GetUserVotesForForumPosts(userId, new List<int> { postId });
+            var currentUserVote = userVote.TryGetValue(postId, out var vt) ? VoteTypeToString(vt) : null;
+
+            return new ForumVoteResultViewModel
+            {
+                Votes = outcome.VoteCount,
+                CurrentUserVote = currentUserVote
+            };
+        }
+
+        public async Task RecordThreadView(int threadId, string? visitorIdentifier)
+        {
+            var cacheKey = $"forum_view:{threadId}:{visitorIdentifier ?? "anonymous"}:{DateTime.UtcNow:yyyyMMdd}";
+            var cached = await _cache.GetStringAsync(cacheKey);
+            
+            if (!string.IsNullOrEmpty(cached))
+                return;
+
+            await _cache.SetStringAsync(cacheKey, "1", new DistributedCacheEntryOptions 
+            { 
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromDays(1) 
+            });
+
+            await _processor.IncrementViewCount(threadId);
+        }
+
+        private static string GenerateSlug(string title)
+        {
+            var slug = title.ToLowerInvariant()
+                .Replace(" ", "-")
+                .Replace("/", "-")
+                .Replace("\\", "-")
+                .Replace("?", "")
+                .Replace("!", "")
+                .Replace(".", "")
+                .Replace(",", "")
+                .Replace(";", "")
+                .Replace(":", "")
+                .Replace("'", "")
+                .Replace("\"", "")
+                .Replace("&", "and")
+                .Replace("@", "at");
+
+            // Ensure unique slug by appending random suffix if needed
+            using var rng = RandomNumberGenerator.Create();
+            var bytes = new byte[4];
+            rng.GetBytes(bytes);
+            var suffix = BitConverter.ToUInt32(bytes, 0).ToString("x8");
+            
+            return $"{slug}-{suffix}";
+        }
+
+        private static string? VoteTypeToString(VoteType? v) => v switch
+        {
+            VoteType.Upvote => "upvote",
+            VoteType.Downvote => "downvote",
+            _ => null
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Implements the Forum API endpoints and supporting service layer for forum operations.

## Changes Made

### API Endpoints

* Added `GET /api/v1/forum/categories` to list forum categories with thread counts.
* Added `GET /api/v1/forum/categories/{slug}/threads` for paginated thread retrieval.
* Added `GET /api/v1/forum/threads/{slug}` to retrieve a thread with paginated posts.
* Added `POST /api/v1/forum/threads` to create new threads and their initial posts.
* Added `POST /api/v1/forum/threads/{id}/posts` to reply to existing threads.
* Added `PUT /api/v1/forum/posts/{id}` to edit forum posts.
* Added `POST /api/v1/forum/posts/{id}/vote` to support post voting.

### Business Logic

* Implemented `ForumService` for forum-related business operations.
* Implemented `ForumProcessor` to handle request processing and orchestration.
* Added validation and error handling across forum workflows.
* Added view-count tracking with rate limiting to prevent artificial inflation.

### Additional Features

* Category thread count aggregation.
* Paginated thread and post retrieval.
* Thread creation with automatic first-post creation.
* Post editing and voting functionality.
* Consistent API response handling.
* Integration with existing architectural patterns and dependency injection setup.

## Acceptance Criteria

* [x] GET /api/v1/forum/categories
* [x] GET /api/v1/forum/categories/{slug}/threads
* [x] GET /api/v1/forum/threads/{slug}
* [x] POST /api/v1/forum/threads
* [x] POST /api/v1/forum/threads/{id}/posts
* [x] PUT /api/v1/forum/posts/{id}
* [x] POST /api/v1/forum/posts/{id}/vote
* [x] View counting with rate limiting
* [x] ForumService implementation
* [x] ForumProcessor implementation

Closes #83
