### PR TITLE
test: add soft delete tests for Report moderation target and Rating query filtering (#285)

### DIFF
--- a/Backend/SorobanSecurityPortalApi.Tests/Services/ModerationTargetTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Services/ModerationTargetTests.cs
@@ -341,6 +341,45 @@ namespace SorobanSecurityPortalApi.Tests.Services
             target.ContentType.Should().Be(ModeratedContentType.Report);
         }
 
+        [Fact]
+        public async Task Report_Hide_Sets_IsHidden_True_And_SaveChanges()
+        {
+            var report = new ReportModel { Id = 10, Name = "R", CreatedBy = 1, IsHidden = false };
+            var (factory, dbMock) = BuildReportFactory(new List<ReportModel> { report });
+            var target = new ReportModerationTarget(factory.Object);
+
+            await target.Hide(10);
+
+            report.IsHidden.Should().BeTrue();
+            dbMock.Verify(d => d.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Report_SoftDelete_Sets_IsDeleted_True_And_SaveChanges()
+        {
+            var report = new ReportModel { Id = 10, Name = "R", CreatedBy = 1, IsDeleted = false };
+            var (factory, dbMock) = BuildReportFactory(new List<ReportModel> { report });
+            var target = new ReportModerationTarget(factory.Object);
+
+            await target.SoftDelete(10);
+
+            report.IsDeleted.Should().BeTrue();
+            dbMock.Verify(d => d.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Report_Restore_Clears_BothHiddenAndDeleted()
+        {
+            var report = new ReportModel { Id = 10, Name = "R", CreatedBy = 1, IsHidden = true, IsDeleted = true };
+            var (factory, _) = BuildReportFactory(new List<ReportModel> { report });
+            var target = new ReportModerationTarget(factory.Object);
+
+            await target.Restore(10);
+
+            report.IsHidden.Should().BeFalse();
+            report.IsDeleted.Should().BeFalse();
+        }
+
         // --- ModerationTargetRegistry tests ---
 
         [Fact]

--- a/Backend/SorobanSecurityPortalApi.Tests/Services/PublicVisibilityTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Services/PublicVisibilityTests.cs
@@ -4,14 +4,22 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
+using AutoMapper;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using SorobanSecurityPortalApi.Authorization;
 using SorobanSecurityPortalApi.Common;
 using SorobanSecurityPortalApi.Common.Data;
 using SorobanSecurityPortalApi.Data.Processors;
 using SorobanSecurityPortalApi.Models.DbModels;
+using SorobanSecurityPortalApi.Models.Mapping;
+using SorobanSecurityPortalApi.Models.ViewModels;
+using SorobanSecurityPortalApi.Services.ControllersServices;
 using Xunit;
 
 namespace SorobanSecurityPortalApi.Tests.Services
@@ -329,6 +337,98 @@ namespace SorobanSecurityPortalApi.Tests.Services
             var result = await processor.GetPublic(10);
 
             result.Should().BeNull();
+        }
+
+        // ---- Rating tests ----
+
+        private static (RatingService service, Mock<IDistributedCache> cache) BuildRatingService(
+            List<RatingModel> ratings,
+            List<LoginModel>? logins = null,
+            List<UserProfileModel>? profiles = null)
+        {
+            var dbQueryMock = new Mock<IDbQuery>();
+            var loggerMock = new Mock<ILogger<Db>>();
+            var dataSourceProviderMock = new Mock<IDataSourceProvider>();
+
+            var dbMock = new Mock<Db>(
+                dbQueryMock.Object,
+                loggerMock.Object,
+                dataSourceProviderMock.Object
+            ) { CallBase = true };
+
+            dbMock.Object.Rating = CreateDbSetMock(ratings).Object;
+            dbMock.Object.Login = CreateDbSetMock(logins ?? new List<LoginModel>()).Object;
+            dbMock.Object.UserProfiles = CreateDbSetMock(profiles ?? new List<UserProfileModel>()).Object;
+
+            var mappingConfig = new MapperConfiguration(mc => mc.AddProfile(new RatingModelProfile()), NullLoggerFactory.Instance);
+            var mapper = mappingConfig.CreateMapper();
+            var cacheMock = new Mock<IDistributedCache>();
+
+            var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+            var loginProcessorMock = new Mock<ILoginProcessor>();
+            var userContext = new UserContextAccessor(httpContextAccessorMock.Object, loginProcessorMock.Object);
+            var contentFilterMock = new Mock<IContentFilterService>();
+
+            var service = new RatingService(dbMock.Object, cacheMock.Object, userContext, mapper, contentFilterMock.Object);
+            return (service, cacheMock);
+        }
+
+        [Fact]
+        public async Task RatingGetSummary_ExcludesHiddenContent()
+        {
+            var visible = new RatingModel { Id = 1, UserId = 1, EntityType = EntityType.Protocol, EntityId = 50, Score = 5, IsHidden = false, IsDeleted = false };
+            var hidden = new RatingModel { Id = 2, UserId = 2, EntityType = EntityType.Protocol, EntityId = 50, Score = 1, IsHidden = true, IsDeleted = false };
+
+            var (service, _) = BuildRatingService(new List<RatingModel> { visible, hidden });
+
+            var summary = await service.GetSummary(EntityType.Protocol, 50);
+
+            summary.TotalReviews.Should().Be(1);
+            summary.AverageScore.Should().Be(5.0f);
+        }
+
+        [Fact]
+        public async Task RatingGetSummary_ExcludesDeletedContent()
+        {
+            var visible = new RatingModel { Id = 1, UserId = 1, EntityType = EntityType.Protocol, EntityId = 50, Score = 5, IsHidden = false, IsDeleted = false };
+            var deleted = new RatingModel { Id = 2, UserId = 2, EntityType = EntityType.Protocol, EntityId = 50, Score = 1, IsHidden = false, IsDeleted = true };
+
+            var (service, _) = BuildRatingService(new List<RatingModel> { visible, deleted });
+
+            var summary = await service.GetSummary(EntityType.Protocol, 50);
+
+            summary.TotalReviews.Should().Be(1);
+            summary.AverageScore.Should().Be(5.0f);
+        }
+
+        [Fact]
+        public async Task RatingGetSummary_ReturnsZero_WhenAllDeleted()
+        {
+            var deleted = new RatingModel { Id = 1, UserId = 1, EntityType = EntityType.Protocol, EntityId = 50, Score = 5, IsHidden = false, IsDeleted = true };
+            var hidden = new RatingModel { Id = 2, UserId = 2, EntityType = EntityType.Protocol, EntityId = 50, Score = 3, IsHidden = true, IsDeleted = false };
+
+            var (service, _) = BuildRatingService(new List<RatingModel> { deleted, hidden });
+
+            var summary = await service.GetSummary(EntityType.Protocol, 50);
+
+            summary.TotalReviews.Should().Be(0);
+            summary.AverageScore.Should().Be(0f);
+        }
+
+        [Fact]
+        public async Task RatingGetRatings_ExcludesHiddenAndDeletedContent()
+        {
+            var visible = new RatingModel { Id = 1, UserId = 1, EntityType = EntityType.Protocol, EntityId = 50, Score = 5, IsHidden = false, IsDeleted = false, CreatedAt = DateTime.UtcNow };
+            var hidden = new RatingModel { Id = 2, UserId = 2, EntityType = EntityType.Protocol, EntityId = 50, Score = 1, IsHidden = true, IsDeleted = false, CreatedAt = DateTime.UtcNow };
+            var deleted = new RatingModel { Id = 3, UserId = 3, EntityType = EntityType.Protocol, EntityId = 50, Score = 2, IsHidden = false, IsDeleted = true, CreatedAt = DateTime.UtcNow };
+
+            var logins = new List<LoginModel> { new LoginModel { LoginId = 1, Login = "user@test.com", FullName = "Test User" } };
+            var (service, _) = BuildRatingService(new List<RatingModel> { visible, hidden, deleted }, logins);
+
+            var result = await service.GetRatings(EntityType.Protocol, 50, 1);
+
+            result.Should().HaveCount(1);
+            result[0].AuthorId.Should().Be(1);
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds test coverage for soft delete functionality on two previously untested surfaces:

1. **ReportModerationTarget** — Hide, SoftDelete, and Restore (all 3 other entity types already had these)
2. **RatingService query filtering** — GetSummary and GetRatings now verified to exclude hidden/deleted ratings

## Changes
- `ModerationTargetTests.cs`: +3 tests for ReportModerationTarget (Hide, SoftDelete, Restore)
- `PublicVisibilityTests.cs`: +4 tests for RatingService visibility filtering + BuildRatingService helper

## Testing
- All 43 tests in ModerationTargetTests + PublicVisibilityTests pass
- Build: 0 errors, 0 new warnings

## Risk / Rollback
- Test-only change, zero production code modified
- No migration, config, or dependency changes
- Rollback: revert this commit

Closes #285