### PR TITLE
fix(helm): use Recreate strategy for the agent-ingestion-worker

### DIFF
--- a/Deploy/helm/charts/agentingestionworker/templates/agent-ingestion-worker-deployment.yaml
+++ b/Deploy/helm/charts/agentingestionworker/templates/agent-ingestion-worker-deployment.yaml
@@ -12,6 +12,12 @@ spec:
   # Single replica — matches the no-row-lock claim design (claim-next is atomic;
   # only one worker processes the queue at a time).
   replicas: 1
+  # Recreate (not RollingUpdate): the worker is single-replica and CPU-heavy.
+  # On a small node a rolling update would try to surge a second worker before
+  # tearing down the old one, and the new pod can't be scheduled (Insufficient
+  # cpu) → the rollout deadlocks. Tear the old pod down first, then start the new.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: "{{ .Values.global.environment.name }}-agent-ingestion-worker"


### PR DESCRIPTION
The agent-ingestion-worker is single-replica and CPU-heavy. With the default RollingUpdate strategy a deploy surges a second worker pod before removing the old one. On a small node (prod has a single 1-CPU node) the new pod can't be scheduled — `Insufficient cpu` — so the rollout deadlocks with the new pod stuck Pending and the old one never torn down.

This switches the worker Deployment to the Recreate strategy: the old pod is torn down first, then the new one starts. Safe here because the worker is single-replica by design (atomic claim-next, only one worker drains the queue), so there's no benefit to overlapping pods.

Found while bringing `/admin/agent-runs` up on prod: the worker had never run there (its image wasn't built by CI and the z.ai key wasn't passed — both fixed on main already), and once those were in place the rollout still hung on this scheduling deadlock. I patched the live prod deployment to Recreate to unblock it; this change makes that durable so the next deploy doesn't re-deadlock.