### PR TITLE
Don't drop admin edits when extending the session

### DIFF
--- a/UI/src/features/authentication/__tests__/authPermissions.test.ts
+++ b/UI/src/features/authentication/__tests__/authPermissions.test.ts
@@ -12,6 +12,7 @@ import {
   canAddReport,
   isAuthorized,
   hasAccessToken,
+  isInitialAuthLoading,
 } from '../authPermissions';
 import { Role } from '../../../api/soroban-security-portal/models/role';
 
@@ -380,6 +381,36 @@ describe('authPermissions', () => {
         } as AuthContextProps['user'],
       });
       expect(hasAccessToken(auth)).toBe(false);
+    });
+  });
+
+  describe('isInitialAuthLoading', () => {
+    it('returns false when idle and not authenticated', () => {
+      const auth = createMockAuth({ isLoading: false, isAuthenticated: false });
+      expect(isInitialAuthLoading(auth)).toBe(false);
+    });
+
+    it('returns true during the initial sign-in (loading, no user yet)', () => {
+      const auth = createMockAuth({ isLoading: true, isAuthenticated: false });
+      expect(isInitialAuthLoading(auth)).toBe(true);
+    });
+
+    it('returns false during a background silent renew of an authenticated user', () => {
+      // react-oidc-context flips isLoading=true while signinSilent() runs, but the
+      // existing (non-expired) user stays authenticated. The protected UI must NOT be
+      // torn down here — otherwise "Stay Logged In" remounts the page and discards
+      // any unsaved in-progress edits.
+      const auth = createMockAuth({
+        isLoading: true,
+        isAuthenticated: true,
+        activeNavigator: 'signinSilent',
+      });
+      expect(isInitialAuthLoading(auth)).toBe(false);
+    });
+
+    it('returns false when authenticated and idle', () => {
+      const auth = createMockAuth({ isLoading: false, isAuthenticated: true });
+      expect(isInitialAuthLoading(auth)).toBe(false);
     });
   });
 });

--- a/UI/src/features/authentication/authPermissions.ts
+++ b/UI/src/features/authentication/authPermissions.ts
@@ -98,3 +98,22 @@ export const isAuthorized = (auth: AuthContextProps): boolean => {
 export const hasAccessToken = (auth: AuthContextProps): boolean => {
   return !!auth.user?.access_token;
 };
+
+// ============================================================================
+// Auth Lifecycle Checks
+// ============================================================================
+
+/**
+ * Whether the app is in its *initial* authentication phase and should block the
+ * UI with a full-screen loading state.
+ *
+ * react-oidc-context flips `isLoading` to true for the duration of ANY wrapped
+ * navigator call, including `signinSilent()`. A background silent token renewal
+ * (e.g. when the user clicks "Stay Logged In") must NOT blank out an already
+ * authenticated screen: doing so unmounts the current page and throws away any
+ * unsaved in-progress edits. We only show the blocking loader when there is no
+ * authenticated user yet (the genuine cold-start / sign-in case).
+ */
+export const isInitialAuthLoading = (auth: AuthContextProps): boolean => {
+  return auth.isLoading && !auth.isAuthenticated;
+};

--- a/UI/src/main.tsx
+++ b/UI/src/main.tsx
@@ -18,7 +18,7 @@ import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
 import ReactGA from 'react-ga4';
 import { AUTH_FAILURE_EVENT } from './api/rest-api';
 import { SessionExpirationWarning } from './components/SessionExpirationWarning';
-import { isAdminOrModerator } from './features/authentication/authPermissions';
+import { isAdminOrModerator, isInitialAuthLoading } from './features/authentication/authPermissions';
 
 if (environment.gaId) {
   ReactGA.initialize(environment.gaId);
@@ -159,8 +159,11 @@ export function AppWrapper() {
     );
   }
   else if (window.location.pathname.startsWith(`${environment.basePath}/admin`)) {
-    // Show loading state while auth is initializing
-    if (auth.isLoading) {
+    // Show loading state while auth is *initializing*. We intentionally do NOT block on a
+    // background silent renew of an already-authenticated admin (isLoading flips true while
+    // signinSilent runs): blanking the screen there unmounts the admin page and discards any
+    // unsaved in-progress edits (e.g. an agent-run review). See isInitialAuthLoading.
+    if (isInitialAuthLoading(auth)) {
       return (
         <MuiThemeProvider theme={theme}>
           <Authentication errorText="" isLoading={true} />


### PR DESCRIPTION
## What happened

While reviewing an agent run in the admin area and correcting findings, the "Session Expiring Soon" dialog popped up. Clicking **Stay Logged In** flashed a loading screen and dropped every unsaved edit on the page.

## Why

The dialog's "Stay Logged In" button calls `auth.signinSilent()`. In react-oidc-context that's a wrapped "navigator" method, so it sets `auth.isLoading = true` for the whole duration of the renewal.

The `/admin` branch in `main.tsx` rendered a full-screen "Signing you in..." spinner whenever `auth.isLoading` was true — which unmounted the entire `AdminMainWindow`. The agent-run review state (title, protocol, auditor, findings, etc.) all lives in component-local `useState`, so the unmount threw it away. When the renewal finished, the page remounted and re-seeded everything from the server, so the corrections were gone.

The interesting part: the *automatic* background renew (`automaticSilentRenew: true`) goes straight through oidc-client-ts and never touches `isLoading`, so it's invisible. Only the **manual** `signinSilent()` (the button, and the duplicate `addAccessTokenExpiring` handler in `main.tsx`) goes through the wrapper and trips this. So renewal was actually succeeding — you stayed logged in — but the spinner alone was enough to nuke the form.

## Fix

Only show the blocking loader during the genuine initial sign-in (when there's no authenticated user yet), not during a background renew of someone who's already logged in. Added a small `isInitialAuthLoading(auth) = auth.isLoading && !auth.isAuthenticated` helper and switched the admin gate to use it. Now the admin page stays mounted across silent renewals and edits survive.
