### PR TITLE
add acknowledged category

### DIFF
--- a/Backend/SorobanSecurityPortalApi.Tests/Common/VulnerabilityNormalizerTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Common/VulnerabilityNormalizerTests.cs
@@ -34,6 +34,7 @@ namespace SorobanSecurityPortalApi.Tests.Common
         [InlineData(1, VulnerabilityCategory.ValidNotFixed)]
         [InlineData(2, VulnerabilityCategory.ValidPartiallyFixed)]
         [InlineData(3, VulnerabilityCategory.Invalid)]
+        [InlineData(4, VulnerabilityCategory.Acknowledged)]
         [InlineData(100, VulnerabilityCategory.NA)]
         [InlineData(7, VulnerabilityCategory.NA)]   // out of range → NA
         [InlineData(-1, VulnerabilityCategory.NA)]

--- a/Backend/SorobanSecurityPortalApi/Models/DbModels/VulnerabilityModel.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/DbModels/VulnerabilityModel.cs
@@ -53,6 +53,7 @@ namespace SorobanSecurityPortalApi.Models.DbModels
         ValidNotFixed = 1,
         ValidPartiallyFixed = 2,
         Invalid = 3,
+        Acknowledged = 4,
         NA = 100
     }
 }

--- a/UI/src/api/soroban-security-portal/models/vulnerability.ts
+++ b/UI/src/api/soroban-security-portal/models/vulnerability.ts
@@ -77,6 +77,7 @@ export enum VulnerabilityCategory {
   ValidNotFixed = 1,
   ValidPartiallyFixed = 2,
   Invalid = 3,
+  Acknowledged = 4,
   NA = 100
 }
 
@@ -109,6 +110,11 @@ export const VulnerabilityCategories: VulnerabilityCategoryInfo[] = [
     color: CategoryColors.validPartiallyFixed
   },
   {
+    id: VulnerabilityCategory.Acknowledged,
+    label: 'Acknowledged (by design)',
+    color: CategoryColors.acknowledged
+  },
+  {
     id: VulnerabilityCategory.Invalid,
     label: 'Invalid',
     color: CategoryColors.invalid
@@ -120,14 +126,16 @@ export const VulnerabilityCategories: VulnerabilityCategoryInfo[] = [
   }
 ];
 
-export const AvailableVulnerabilityCategories = VulnerabilityCategories.filter(cat => cat.id !== VulnerabilityCategory.Invalid);
+export const AvailableVulnerabilityCategories = VulnerabilityCategories.filter(
+  cat => cat.id !== VulnerabilityCategory.Invalid && cat.id !== VulnerabilityCategory.NA
+);
 
 export function getCategoryLabel(category: VulnerabilityCategory): string {
-  return AvailableVulnerabilityCategories[category]?.label || 'Unknown';
+  return VulnerabilityCategories.find(c => c.id === category)?.label || 'Unknown';
 }
 
 export function getCategoryColor(category: VulnerabilityCategory): string {
-  return AvailableVulnerabilityCategories[category]?.color || CategoryColors.fallback;
+  return VulnerabilityCategories.find(c => c.id === category)?.color || CategoryColors.fallback;
 }
 
 export function getCategoryIdByLabel(label: string): VulnerabilityCategory | null {
@@ -167,6 +175,7 @@ export function getCategoryImage(category: VulnerabilityCategory): string {
     [VulnerabilityCategory.Valid]: '/static/images/vulnerability_categories/valid-fixed.png',
     [VulnerabilityCategory.ValidNotFixed]: '/static/images/vulnerability_categories/valid-not-fixed.png',
     [VulnerabilityCategory.ValidPartiallyFixed]: '/static/images/vulnerability_categories/valid-partially-fixed.png',
+    [VulnerabilityCategory.Acknowledged]: '/static/images/vulnerability_categories/valid-fixed.png',
     [VulnerabilityCategory.Invalid]: '/static/images/vulnerability_categories/invalid.png',
     [VulnerabilityCategory.NA]: '/static/images/vulnerability_categories/invalid.png' // fallback to invalid
   };

--- a/UI/src/features/pages/regular/report-details/report-details.tsx
+++ b/UI/src/features/pages/regular/report-details/report-details.tsx
@@ -365,6 +365,15 @@ export const ReportDetails: FC = () => {
                                         height={40}
                                         title="Valid (Partially Fixed)"
                                       />
+                                    ) : vulnerability.category === VulnerabilityCategory.Acknowledged ? (
+                                      <img
+                                        loading="lazy"
+                                        src="/static/images/vulnerability_categories/valid-fixed.png"
+                                        alt="Acknowledged"
+                                        width={40}
+                                        height={40}
+                                        title="Acknowledged (by design)"
+                                      />
                                     ) : (
                                       <BugReport />
                                     )}

--- a/UI/src/features/pages/regular/vulnerabilities/vulnerabilities.tsx
+++ b/UI/src/features/pages/regular/vulnerabilities/vulnerabilities.tsx
@@ -809,6 +809,9 @@ export const Vulnerabilities: FC = () => {
                     {option.id === VulnerabilityCategory.ValidPartiallyFixed && (
                       <img loading="lazy" src="static/images/vulnerability_categories/valid-partially-fixed.png" alt="Valid Partially Fixed" width={24} height={24} />
                     )}
+                    {option.id === VulnerabilityCategory.Acknowledged && (
+                      <img loading="lazy" src="static/images/vulnerability_categories/valid-fixed.png" alt="Acknowledged" width={24} height={24} />
+                    )}
                     {option.label}
                   </Box>
                 );
@@ -1034,6 +1037,9 @@ export const Vulnerabilities: FC = () => {
                       )}
                       {vuln.category === VulnerabilityCategory.ValidPartiallyFixed && (
                         <img loading="lazy" src="static/images/vulnerability_categories/valid-partially-fixed.png" alt="Valid Partially Fixed" width={24} height={24} />
+                      )}
+                      {vuln.category === VulnerabilityCategory.Acknowledged && (
+                        <img loading="lazy" src="static/images/vulnerability_categories/valid-fixed.png" alt="Acknowledged" width={24} height={24} />
                       )}
                     </Stack>
                     <Stack direction="row" spacing={1} sx={{ alignItems: 'center', mb: 1 }}>

--- a/UI/src/theme/constants.ts
+++ b/UI/src/theme/constants.ts
@@ -101,6 +101,7 @@ export const CategoryColors = {
   validNotFixed: '#9c27b0',
   validPartiallyFixed: '#ba68c8',
   invalid: '#adadadff',
+  acknowledged: '#5c6bc0',
   na: '#ce93d8',
   fallback: '#757575',
 } as const;


### PR DESCRIPTION
closes #189 Please review @AKercha1

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are additive and the pre-existing getCategoryLabel/getCategoryColor indexing bug is fixed as a bonus.

The category addition is complete end-to-end and the normalizer test confirms the backend handles the new value correctly. Two minor gaps remain: the Acknowledged entry is absent from the category info tooltip visible to users, and a redundant NA filter was left in vulnerabilities.tsx now that AvailableVulnerabilityCategories already excludes it. Neither affects data correctness.

UI/src/features/pages/regular/vulnerabilities/vulnerabilities.tsx — tooltip content and redundant filter; UI/src/api/soroban-security-portal/models/vulnerability.ts — shared placeholder image for Acknowledged.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Backend/SorobanSecurityPortalApi/Models/DbModels/VulnerabilityModel.cs | Adds Acknowledged = 4 to the VulnerabilityCategory enum; no migration needed as integers are stored directly. |
| Backend/SorobanSecurityPortalApi.Tests/Common/VulnerabilityNormalizerTests.cs | Adds [InlineData(4, VulnerabilityCategory.Acknowledged)] to the category-normalizer test; the normalizer already uses Enum.IsDefined so the new value is automatically handled correctly. |
| UI/src/api/soroban-security-portal/models/vulnerability.ts | Adds Acknowledged = 4 to the TS enum, registers its VulnerabilityCategoryInfo, fixes the broken array-index lookup in getCategoryLabel/getCategoryColor to use .find(), and updates AvailableVulnerabilityCategories to also exclude NA. The Acknowledged icon reuses the valid-fixed.png image. |
| UI/src/features/pages/regular/report-details/report-details.tsx | Adds an Acknowledged branch to the category icon chain in the vulnerability list; no logic issues. |
| UI/src/features/pages/regular/vulnerabilities/vulnerabilities.tsx | Adds Acknowledged icon rendering in the filter dropdown and vulnerability card list; the category info tooltip is not updated to include Acknowledged (by design), and the NA exclusion filter on line 60 is now redundant. |
| UI/src/theme/constants.ts | Adds acknowledged: '#5c6bc0' (indigo) to CategoryColors; color is distinct from existing palette entries. |

</details>



<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    DB["DB: category integer"]
    Normalizer["VulnerabilityNormalizer.Category(int)\nEnum.IsDefined check"]
    Enum["VulnerabilityCategory enum\n0=Valid, 1=ValidNotFixed\n2=ValidPartiallyFixed, 3=Invalid\n4=Acknowledged, 100=NA"]
    Available["AvailableVulnerabilityCategories\nexcludes Invalid & NA"]
    Dropdown["Category filter dropdown\n(vulnerabilities.tsx)"]
    Card["Vulnerability card icon\n(vulnerabilities.tsx)"]
    Detail["Report detail icon\n(report-details.tsx)"]
    Label["getCategoryLabel / getCategoryColor\nFixed: .find() not array index"]

    DB --> Normalizer --> Enum
    Enum --> Available --> Dropdown
    Enum --> Label
    Enum --> Card
    Enum --> Detail
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    DB["DB: category integer"]
    Normalizer["VulnerabilityNormalizer.Category(int)\nEnum.IsDefined check"]
    Enum["VulnerabilityCategory enum\n0=Valid, 1=ValidNotFixed\n2=ValidPartiallyFixed, 3=Invalid\n4=Acknowledged, 100=NA"]
    Available["AvailableVulnerabilityCategories\nexcludes Invalid & NA"]
    Dropdown["Category filter dropdown\n(vulnerabilities.tsx)"]
    Card["Vulnerability card icon\n(vulnerabilities.tsx)"]
    Detail["Report detail icon\n(report-details.tsx)"]
    Label["getCategoryLabel / getCategoryColor\nFixed: .find() not array index"]

    DB --> Normalizer --> Enum
    Enum --> Available --> Dropdown
    Enum --> Label
    Enum --> Card
    Enum --> Detail
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `UI/src/features/pages/regular/vulnerabilities/vulnerabilities.tsx`, line 825-858 ([link](https://github.com/inferara/soroban-security-portal/blob/f03e12fc8127510c5b1fd676fb1c63b5d2491e76/UI/src/features/pages/regular/vulnerabilities/vulnerabilities.tsx#L825-L858)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Tooltip missing "Acknowledged" entry**

   The category info tooltip lists "Valid (Fixed)", "Valid Not Fixed", and "Valid Partially Fixed" but has no entry for the newly added "Acknowledged (by design)" category. A user hovering the `ⓘ` icon will see an incomplete legend that silently omits the new option shown in the dropdown below.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!


2. `UI/src/features/pages/regular/vulnerabilities/vulnerabilities.tsx`, line 60 ([link](https://github.com/inferara/soroban-security-portal/blob/f03e12fc8127510c5b1fd676fb1c63b5d2491e76/UI/src/features/pages/regular/vulnerabilities/vulnerabilities.tsx#L60)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Redundant `NA` filter now that `AvailableVulnerabilityCategories` already excludes `NA`**

   This PR updated `AvailableVulnerabilityCategories` to filter out both `Invalid` and `NA`, so the extra `.filter(c => c.id !== VulnerabilityCategory.NA)` here is a no-op. Removing it keeps the intent clear.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["add acknowledged category"](https://github.com/inferara/soroban-security-portal/commit/f03e12fc8127510c5b1fd676fb1c63b5d2491e76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37811315)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->