### PR TITLE
fix: Use LastActionAt instead of Date for report monthly statistics

### DIFF
--- a/Backend/SorobanSecurityPortalApi.Tests/Services/PublicVisibilityTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Services/PublicVisibilityTests.cs
@@ -331,4 +331,69 @@ namespace SorobanSecurityPortalApi.Tests.Services
             result.Should().BeNull();
         }
     }
+
+    // ---- Statistics Changes tests ----
+
+    [Fact]
+    public async Task ReportGetStatisticsChanges_CountsReportsWithRecentLastActionAt()
+    {
+        var ago = DateTime.UtcNow.AddMonths(-1);
+        var list = new List<ReportModel>
+        {
+            new()
+            {
+                Id = 1, Status = ReportModelStatus.Approved, IsHidden = false, IsDeleted = false,
+                Name = "Recent", LastActionAt = DateTime.UtcNow.AddDays(-5),
+                Date = DateTime.UtcNow.AddMonths(-6) // old audit date, should still count
+            },
+            new()
+            {
+                Id = 2, Status = ReportModelStatus.Approved, IsHidden = false, IsDeleted = false,
+                Name = "Old", LastActionAt = DateTime.UtcNow.AddMonths(-3),
+                Date = DateTime.UtcNow
+            },
+        };
+
+        var (processor, _) = BuildReportProcessor(list);
+
+        var result = await processor.GetStatisticsChanges();
+
+        result.Total.Should().Be(2);
+        result.New.Should().Be(1, "only the report with LastActionAt within the last month counts");
+    }
+
+    [Fact]
+    public async Task ReportGetStatisticsChanges_ExcludesHiddenDeletedUnapproved()
+    {
+        var list = new List<ReportModel>
+        {
+            new()
+            {
+                Id = 1, Status = ReportModelStatus.Approved, IsHidden = false, IsDeleted = false,
+                Name = "Visible Approved", LastActionAt = DateTime.UtcNow.AddDays(-1)
+            },
+            new()
+            {
+                Id = 2, Status = ReportModelStatus.Approved, IsHidden = true, IsDeleted = false,
+                Name = "Hidden Approved", LastActionAt = DateTime.UtcNow.AddDays(-1)
+            },
+            new()
+            {
+                Id = 3, Status = ReportModelStatus.Approved, IsHidden = false, IsDeleted = true,
+                Name = "Deleted Approved", LastActionAt = DateTime.UtcNow.AddDays(-1)
+            },
+            new()
+            {
+                Id = 4, Status = ReportModelStatus.New, IsHidden = false, IsDeleted = false,
+                Name = "Unapproved", LastActionAt = DateTime.UtcNow.AddDays(-1)
+            },
+        };
+
+        var (processor, _) = BuildReportProcessor(list);
+
+        var result = await processor.GetStatisticsChanges();
+
+        result.Total.Should().Be(1);
+        result.New.Should().Be(1);
+    }
 }

--- a/Backend/SorobanSecurityPortalApi/Data/Processors/ReportProcessor.cs
+++ b/Backend/SorobanSecurityPortalApi/Data/Processors/ReportProcessor.cs
@@ -361,7 +361,7 @@ namespace SorobanSecurityPortalApi.Data.Processors
             var ago = DateTime.UtcNow.AddMonths(-1);
             var newReports = await db.Report
                 .AsNoTracking()
-                .Where(v => v.Status == ReportModelStatus.Approved && !v.IsHidden && !v.IsDeleted && v.Date >= ago)
+                .Where(v => v.Status == ReportModelStatus.Approved && !v.IsHidden && !v.IsDeleted && v.LastActionAt >= ago)
                 .CountAsync();
             return new ReportStatisticsChangesViewModel
             {


### PR DESCRIPTION
## Summary

Fixes the Home page "Reports" tile always showing 0 (or no badge) in the
"+N this month" section of "By the numbers".

## Root cause

`ReportProcessor.GetStatisticsChanges()` used `Report.Date` — the **audit
date** supplied by the uploader — to determine the monthly change count.
Since most audit dates are older than one month, newly uploaded reports
never contributed to the badge, even when they were just added to the
portal.

## Change

**`Backend/SorobanSecurityPortalApi/Data/Processors/ReportProcessor.cs`**
— Single-line change on line 364: `v.Date >= ago` → `v.LastActionAt >= ago`

`Report.LastActionAt` is the closest existing timestamp to a portal-ingestion
date.  It is set to `DateTime.UtcNow` when a report is:
-  Approved (the moment it becomes visible on the portal)
-  Edited (acceptable edge case — old edited reports briefly appear as new)

No migration was needed.

All existing filters (`Status == Approved`, `!IsHidden`, `!IsDeleted`) are
preserved.

## Files modified

| File | Lines | Description |
|------|-------|-------------|
| `Backend/.../Data/Processors/ReportProcessor.cs` | 364 | Use `LastActionAt` instead of `Date` |
| `Backend/.../Tests/Services/PublicVisibilityTests.cs` | 335–398 | Two new unit tests |

## Tests added

1. **`ReportGetStatisticsChanges_CountsReportsWithRecentLastActionAt`** —
   Verifies that a report with an old audit `Date` but recent `LastActionAt`
   is counted as new, and a report with recent `Date` but old `LastActionAt`
   is not.

2. **`ReportGetStatisticsChanges_ExcludesHiddenDeletedUnapproved`** —
   Verifies that hidden, soft-deleted, and unapproved reports are still
   excluded from both `Total` and `New` counts.

## Other processors (not changed)

`VulnerabilityProcessor`, `ProtocolProcessor`, and `AuditorProcessor` have
the same pattern — they also use `v.Date` for their monthly count.
- `VulnerabilityModel` has `LastActionAt` and could benefit from the same
  fix.
- `ProtocolModel` and `AuditorModel` lack a `LastActionAt` field.

Closes #201

<!-- greptile_comment -->

<h3>Confidence Score: 2/5</h3>

The production fix in ReportProcessor.cs is correct and safe, but the test file has a structural error that will break the build.

The one-line change to ReportProcessor.cs is exactly right. The test file, however, places both new test methods after the closing brace of the PublicVisibilityTests class — C# does not allow methods at namespace scope, so the test project will fail to compile. Until that brace is moved, the branch cannot produce a green build.

Backend/SorobanSecurityPortalApi.Tests/Services/PublicVisibilityTests.cs — the class-closing `}` on line 333 must be moved to after the second new test method.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Backend/SorobanSecurityPortalApi/Data/Processors/ReportProcessor.cs | Single-line fix swaps v.Date for v.LastActionAt in GetStatisticsChanges; the change is correct and LastActionAt is a non-nullable DateTime so no null-safety concern. |
| Backend/SorobanSecurityPortalApi.Tests/Services/PublicVisibilityTests.cs | Two new [Fact] test methods were inserted after the closing brace of PublicVisibilityTests and before the namespace closing brace, placing them outside any class — this is a C# syntax error that prevents the test project from compiling. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as Home Page
    participant API as StatisticsController
    participant RP as ReportProcessor
    participant DB as Database

    UI->>API: GET /statistics
    API->>RP: GetStatisticsChanges()
    RP->>DB: "COUNT WHERE Status=Approved AND !IsHidden AND !IsDeleted AND LastActionAt >= (now - 1 month)"
    Note over DB: Previously used Date (audit date), now uses LastActionAt (approval date)
    DB-->>RP: newReports count
    RP->>DB: "COUNT WHERE Status=Approved AND !IsHidden AND !IsDeleted"
    DB-->>RP: total count
    RP-->>API: "ReportStatisticsChangesViewModel { Total, New }"
    API-->>UI: "{ total: N, new: M }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as Home Page
    participant API as StatisticsController
    participant RP as ReportProcessor
    participant DB as Database

    UI->>API: GET /statistics
    API->>RP: GetStatisticsChanges()
    RP->>DB: "COUNT WHERE Status=Approved AND !IsHidden AND !IsDeleted AND LastActionAt >= (now - 1 month)"
    Note over DB: Previously used Date (audit date), now uses LastActionAt (approval date)
    DB-->>RP: newReports count
    RP->>DB: "COUNT WHERE Status=Approved AND !IsHidden AND !IsDeleted"
    DB-->>RP: total count
    RP-->>API: "ReportStatisticsChangesViewModel { Total, New }"
    API-->>UI: "{ total: N, new: M }"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix: Use LastActionAt instead of Date fo..."](https://github.com/inferara/soroban-security-portal/commit/cd7b9b893680d2fdbbb37f126e491ab4df2e6712) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38629882)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->