### PR TITLE
Fix/edit view data

### DIFF
--- a/Backend/SorobanSecurityPortalApi.Tests/Services/AgentRunServiceTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Services/AgentRunServiceTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Common.Caching;
 using SorobanSecurityPortalApi.Data.Processors;
 using SorobanSecurityPortalApi.Models.DbModels;
 using SorobanSecurityPortalApi.Models.Mapping;
@@ -31,7 +32,8 @@ namespace SorobanSecurityPortalApi.Tests.Services
             Mock<IProtocolProcessor>? protocolProc = null,
             Mock<IAuditorProcessor>? auditorProc = null,
             Mock<IHttpClientFactory>? httpFactory = null,
-            Mock<IExtendedConfig>? extendedConfig = null)
+            Mock<IExtendedConfig>? extendedConfig = null,
+            Mock<ILookupCache>? lookupCache = null)
         {
             var userCtx = new Mock<IUserContextAccessor>();
             userCtx.Setup(u => u.GetLoginIdAsync()).ReturnsAsync(99);
@@ -44,7 +46,8 @@ namespace SorobanSecurityPortalApi.Tests.Services
                 (auditorProc ?? new Mock<IAuditorProcessor>()).Object,
                 (httpFactory ?? new Mock<IHttpClientFactory>()).Object,
                 userCtx.Object,
-                (extendedConfig ?? new Mock<IExtendedConfig>()).Object);
+                (extendedConfig ?? new Mock<IExtendedConfig>()).Object,
+                (lookupCache ?? new Mock<ILookupCache>()).Object);
         }
 
         private static Mock<IHttpClientFactory> HttpFactoryReturning(byte[] body)

--- a/Backend/SorobanSecurityPortalApi/Data/Processors/ReportProcessor.cs
+++ b/Backend/SorobanSecurityPortalApi/Data/Processors/ReportProcessor.cs
@@ -299,6 +299,33 @@ namespace SorobanSecurityPortalApi.Data.Processors
             return await query.ToListAsync();
         }
 
+        public async Task<List<ReportModel>> GetListForSources()
+        {
+            await using var db = await _dbFactory.CreateDbContextAsync();
+            var query = db.Report
+                .Include(r => r.Auditor)
+                .Include(r => r.Protocol)
+                .ThenInclude(p => p!.Company)
+                .AsNoTracking()
+                .Where(r => !r.IsHidden && !r.IsDeleted
+                            && (r.Status == ReportModelStatus.Approved || r.Status == ReportModelStatus.New));
+            return await query
+                .Select(v => new ReportModel
+                {
+                    Id = v.Id,
+                    Name = v.Name,
+                    Date = v.Date,
+                    Status = v.Status,
+                    CreatedBy = v.CreatedBy,
+                    LastActionBy = v.LastActionBy,
+                    LastActionAt = v.LastActionAt,
+                    Auditor = v.Auditor,
+                    Protocol = v.Protocol,
+                })
+                .OrderByDescending(v => v.Id)
+                .ToListAsync();
+        }
+
         public async Task<List<ReportModel>> GetListForExamples()
         {
             await using var db = await _dbFactory.CreateDbContextAsync();
@@ -387,6 +414,7 @@ namespace SorobanSecurityPortalApi.Data.Processors
         Task Reject(ReportModel reportModel, int userId);
         Task Remove(int reportId);
         Task<List<ReportModel>> GetList(bool includeNotApproved = false);
+        Task<List<ReportModel>> GetListForSources();
         Task<List<ReportModel>> GetListForExamples();
         Task<List<ReportModel>> GetListForEmbedding();
         Task<List<ReportModel>> GetListForFix();

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/AgentRunService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/AgentRunService.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using AutoMapper;
 using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Common.Caching;
 using SorobanSecurityPortalApi.Common.DataParsers;
 using SorobanSecurityPortalApi.Common.Extensions;
 using SorobanSecurityPortalApi.Common.Security;
@@ -35,6 +36,7 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IUserContextAccessor _userContextAccessor;
         private readonly IExtendedConfig _extendedConfig;
+        private readonly ILookupCache _lookupCache;
 
         public AgentRunService(
             IMapper mapper,
@@ -45,7 +47,8 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             IAuditorProcessor auditorProcessor,
             IHttpClientFactory httpClientFactory,
             IUserContextAccessor userContextAccessor,
-            IExtendedConfig extendedConfig)
+            IExtendedConfig extendedConfig,
+            ILookupCache lookupCache)
         {
             _mapper = mapper;
             _runProcessor = runProcessor;
@@ -56,6 +59,7 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             _extendedConfig = extendedConfig;
             _httpClientFactory = httpClientFactory;
             _userContextAccessor = userContextAccessor;
+            _lookupCache = lookupCache;
         }
 
         public async Task<Result<AgentRunViewModel, string>> Enqueue(EnqueueAgentRunViewModel request)
@@ -193,6 +197,9 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             var commit = await _runProcessor.CommitApproval(id, newReport, existingReportId, vulns);
             if (commit == null)
                 return new Result<bool, string>.Err("Run is no longer in a succeeded state (already approved?).");
+            // Approve writes reports directly (bypassing ReportService), so invalidate lookup caches here.
+            _lookupCache.Remove(LookupCacheKeys.Reports);
+            _lookupCache.Remove(LookupCacheKeys.Sources);
             return new Result<bool, string>.Ok(true);
         }
 

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/VulnerabilitiesService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/VulnerabilitiesService.cs
@@ -56,7 +56,8 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
         {
             return await _lookupCache.GetOrCreateAsync(LookupCacheKeys.Sources, async () =>
             {
-                var reports = await _reportProcessor.GetList();
+                // Include New (agent-created) reports so editing an agent-originated finding can resolve its source report.
+                var reports = await _reportProcessor.GetList(includeNotApproved: true);
                 var result = new List<IdValueUrl>();
                 foreach (var report in reports) {
                     result.Add(new IdValueUrl

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/VulnerabilitiesService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/VulnerabilitiesService.cs
@@ -56,8 +56,8 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
         {
             return await _lookupCache.GetOrCreateAsync(LookupCacheKeys.Sources, async () =>
             {
-                // Include New (agent-created) reports so editing an agent-originated finding can resolve its source report.
-                var reports = await _reportProcessor.GetList(includeNotApproved: true);
+                // Include New (agent-created) reports as well as Approved ones so editing an agent-originated finding can resolve its source report; hidden/deleted/rejected reports are excluded.
+                var reports = await _reportProcessor.GetListForSources();
                 var result = new List<IdValueUrl>();
                 foreach (var report in reports) {
                     result.Add(new IdValueUrl

--- a/UI/src/features/pages/admin/vulnerabilities/edit-item/edit-vulnerability.tsx
+++ b/UI/src/features/pages/admin/vulnerabilities/edit-item/edit-vulnerability.tsx
@@ -104,6 +104,19 @@ export const EditVulnerability: FC = () => {
       setCompany(null);
     }
   };
+
+  const resolveTagNamesToTagItems = (names: string[], curatedTags: TagItem[]): TagItem[] =>
+    names.map(name => {
+      const matched = curatedTags.find(t => t.name.toLowerCase() === (name ?? '').toLowerCase());
+      return matched ?? {
+        id: -1,
+        name,
+        bgColor: '',
+        textColor: '',
+        date: new Date(),
+        createdBy: -1,
+      };
+    });
   
   // Populate form when vulnerability data is loaded
   useEffect(() => {
@@ -147,12 +160,9 @@ export const EditVulnerability: FC = () => {
           
           // Restore tags
           if (parsedData.tagNames && Array.isArray(parsedData.tagNames)) {
-            const tagNames = parsedData.tagNames;
-            const foundTags = tagsList.filter(t => tagNames.includes(t.name));
-            setTags(foundTags);
+            setTags(resolveTagNamesToTagItems(parsedData.tagNames, tagsList));
           } else {
-            const foundCategories = tagsList.filter((c: TagItem) => vulnerability.tags.includes(c.name));
-            setTags(foundCategories);
+            setTags(resolveTagNamesToTagItems(vulnerability.tags, tagsList));
           }
           
           // Restore protocol and company
@@ -197,8 +207,7 @@ export const EditVulnerability: FC = () => {
             (s: VulnerabilitySeverity) => s.name.toLowerCase() === (vulnerability.severity ?? '').toLowerCase()
           );
           setSeverity(foundSeverity || null);
-          const foundCategories = tagsList.filter((c: TagItem) => vulnerability.tags.includes(c.name));
-          setTags(foundCategories);
+          setTags(resolveTagNamesToTagItems(vulnerability.tags, tagsList));
           const foundCompany = companiesList.find((c: CompanyItem) => c.name === vulnerability.companyName);
           setCompany(foundCompany || null);
           const foundProtocol = protocolsList.find((p: ProtocolItem) => p.name === vulnerability.protocolName);
@@ -218,8 +227,7 @@ export const EditVulnerability: FC = () => {
           (s: VulnerabilitySeverity) => s.name.toLowerCase() === (vulnerability.severity ?? '').toLowerCase()
         );
         setSeverity(foundSeverity || null);
-        const foundCategories = tagsList.filter((c: TagItem) => vulnerability.tags.includes(c.name));
-        setTags(foundCategories);
+        setTags(resolveTagNamesToTagItems(vulnerability.tags, tagsList));
         const foundCompany = companiesList.find((c: CompanyItem) => c.name === vulnerability.companyName);
         setCompany(foundCompany || null);
         const foundProtocol = protocolsList.find((p: ProtocolItem) => p.name === vulnerability.protocolName);
@@ -464,6 +472,7 @@ export const EditVulnerability: FC = () => {
                 options={tagsList}
                 value={tags}
                 onChange={(_, newValue) => setTags(newValue as TagItem[])}
+                isOptionEqualToValue={(option, value) => (option as TagItem).name === (value as TagItem).name}
                 getOptionLabel={(option) => (option as TagItem).name}
                 renderInput={(params) => (
                   <TextField

--- a/UI/src/features/pages/admin/vulnerabilities/edit-item/edit-vulnerability.tsx
+++ b/UI/src/features/pages/admin/vulnerabilities/edit-item/edit-vulnerability.tsx
@@ -134,10 +134,14 @@ export const EditVulnerability: FC = () => {
           
           // Restore severity
           if (parsedData.severityName) {
-            const foundSeverity = severitiesList.find(s => s.name === parsedData.severityName);
+            const foundSeverity = severitiesList.find(
+              s => s.name.toLowerCase() === (parsedData.severityName ?? '').toLowerCase()
+            );
             setSeverity(foundSeverity || null);
           } else {
-            const foundSeverity = severitiesList.find((s: VulnerabilitySeverity) => s.name === vulnerability.severity);
+            const foundSeverity = severitiesList.find(
+              (s: VulnerabilitySeverity) => s.name.toLowerCase() === (vulnerability.severity ?? '').toLowerCase()
+            );
             setSeverity(foundSeverity || null);
           }
           
@@ -189,7 +193,9 @@ export const EditVulnerability: FC = () => {
           setTitle(vulnerability.title);
           setDescription(vulnerability.description);
           setReportUrl(vulnerability.reportUrl || '');
-          const foundSeverity = severitiesList.find((s: VulnerabilitySeverity) => s.name === vulnerability.severity);
+          const foundSeverity = severitiesList.find(
+            (s: VulnerabilitySeverity) => s.name.toLowerCase() === (vulnerability.severity ?? '').toLowerCase()
+          );
           setSeverity(foundSeverity || null);
           const foundCategories = tagsList.filter((c: TagItem) => vulnerability.tags.includes(c.name));
           setTags(foundCategories);
@@ -208,7 +214,9 @@ export const EditVulnerability: FC = () => {
         setTitle(vulnerability.title);
         setDescription(vulnerability.description);
         setReportUrl(vulnerability.reportUrl || '');
-        const foundSeverity = severitiesList.find((s: VulnerabilitySeverity) => s.name === vulnerability.severity);
+        const foundSeverity = severitiesList.find(
+          (s: VulnerabilitySeverity) => s.name.toLowerCase() === (vulnerability.severity ?? '').toLowerCase()
+        );
         setSeverity(foundSeverity || null);
         const foundCategories = tagsList.filter((c: TagItem) => vulnerability.tags.includes(c.name));
         setTags(foundCategories);


### PR DESCRIPTION
closes #194 
## Problem
When editing a finding that originated from an agent run, several fields in the
edit form came up blank (Severity, Tags, Report), forcing users to re-enter the
data manually causing friction and risking incorrect data entry.

## Evidence
<img width="1600" height="864" alt="image" src="https://github.com/user-attachments/assets/8ee90059-4665-4f95-9890-a76d7606e6bf" />


## Root cause
The edit form rebuilds each selection by name-matching against lookup lists, and
agent-created data doesn't match the same way manually-entered data does:

- **Severity** — agent ingestion stores severity lowercase (`"critical"`), but the
  severity dropdown list is capitalized (`"Critical"`). The case-sensitive match
  never resolved, so the field stayed blank.
- **Report** — an agent run links its finding to a report saved with status `new`,
  but the source dropdown was built only from approved reports, so the finding's
  own report was not selectable.
- **Tags** — tags were rebuilt by filtering the curated tag list, so any tag the
  agent emitted that wasn't already curated was silently dropped (and lost on save).

(Protocol, Auditor and Category populated correctly because they come from the
report relation by exact name / enum value.)

## Changes
- **Severity:** compare severity by name case-insensitively (null-safe). Manually
  created findings are unaffected.
- **Tags:** resolve tag names to `TagItem`s by case-insensitive match, with a
  synthetic fallback for non-curated names so they display and persist; add
  `isOptionEqualToValue` to avoid MUI "value not in options" warnings.
- **Report:** include not-yet-approved reports in `ListSources`. Agent approval
  writes reports directly via `CommitApproval` (bypassing `ReportService`), so it
  now invalidates the `Reports`/`Sources` lookup caches in `AgentRunService.Approve`.
  Updated the test constructor for the new `ILookupCache` dependency.

## Testing
- Frontend `tsc --noEmit` and ESLint pass.
- Verified end-to-end locally: edited an agent-style finding (lowercase severity,
  a `new`-status report, a non-curated tag) and confirmed Severity, Report and Tags
  all pre-fill correctly and save without data loss.

## Commits (atomic)
- `fix(vulnerabilities): match severity case-insensitively in edit form`
- `fix(vulnerabilities): keep non-curated tags in edit form`
- `fix(vulnerabilities): allow agent (unapproved) reports as a finding's source`

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three bug fixes are narrowly scoped, the new GetListForSources query explicitly excludes hidden/deleted rows, cache invalidation is placed correctly after the null-check guard, and the frontend save path is unaffected by the synthetic tag sentinel value.

Each fix is tightly targeted: severity matching is case-insensitive but still resolves to a real options-list object; synthetic tag fallbacks carry only the name through to the save payload; the new report-source query adds a status guard without loosening the hidden/deleted filters. No logic paths were left unguarded by this change.

No files require special attention. The test file lacks assertions for the new cache-invalidation calls, but this was already noted in a prior review thread.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| UI/src/features/pages/admin/vulnerabilities/edit-item/edit-vulnerability.tsx | Adds case-insensitive severity matching, synthetic TagItem fallback for non-curated tags, and isOptionEqualToValue for the tags Autocomplete; logic is correct and the save path (tags.map(t => t.name)) is unaffected by the id:-1 sentinel. |
| Backend/SorobanSecurityPortalApi/Data/Processors/ReportProcessor.cs | Adds GetListForSources() with explicit Approved+New status filter and !IsHidden/!IsDeleted guards; correctly scoped. The Include() calls are redundant alongside Select() in EF Core but harmless. |
| Backend/SorobanSecurityPortalApi/Services/ControllersServices/AgentRunService.cs | Injects ILookupCache and invalidates Reports/Sources caches after CommitApproval; correctly placed after the null-check guard so caches are only cleared on successful approval. |
| Backend/SorobanSecurityPortalApi/Services/ControllersServices/VulnerabilitiesService.cs | ListSources() now calls GetListForSources() instead of GetList(), correctly including New-status reports while excluding hidden/deleted ones. |
| Backend/SorobanSecurityPortalApi.Tests/Services/AgentRunServiceTests.cs | Constructor updated with ILookupCache default mock so existing tests compile; no new assertions for cache invalidation behavior are added, leaving that contract untested. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as EditVulnerability UI
    participant VS as VulnerabilityService
    participant RP as ReportProcessor
    participant Cache as LookupCache
    participant AR as AgentRunService

    UI->>VS: ListSources()
    VS->>Cache: GetOrCreateAsync(Sources)
    Cache-->>VS: cache miss
    VS->>RP: GetListForSources()
    Note over RP: Status=Approved OR Status=New, not hidden, not deleted
    RP-->>VS: reports list
    VS-->>Cache: store result
    VS-->>UI: IdValueUrl list including New reports

    UI->>UI: resolveTagNamesToTagItems
    Note over UI: case-insensitive name match, synthetic fallback id=-1

    UI->>VS: editVulnerability with tags as names

    AR->>AR: CommitApproval success
    AR->>Cache: Remove Reports key
    AR->>Cache: Remove Sources key
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as EditVulnerability UI
    participant VS as VulnerabilityService
    participant RP as ReportProcessor
    participant Cache as LookupCache
    participant AR as AgentRunService

    UI->>VS: ListSources()
    VS->>Cache: GetOrCreateAsync(Sources)
    Cache-->>VS: cache miss
    VS->>RP: GetListForSources()
    Note over RP: Status=Approved OR Status=New, not hidden, not deleted
    RP-->>VS: reports list
    VS-->>Cache: store result
    VS-->>UI: IdValueUrl list including New reports

    UI->>UI: resolveTagNamesToTagItems
    Note over UI: case-insensitive name match, synthetic fallback id=-1

    UI->>VS: editVulnerability with tags as names

    AR->>AR: CommitApproval success
    AR->>Cache: Remove Reports key
    AR->>Cache: Remove Sources key
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(vulnerabilities): exclude hidden/del..."](https://github.com/inferara/soroban-security-portal/commit/681148ea1bcd95bfd546e3d3d561f73c28bd4e70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39477516)</sub>

<!-- /greptile_comment -->