### PR TITLE
Fix/reports are not selectable when editing a vulnerability

### DIFF
--- a/Backend/SorobanSecurityPortalApi.Tests/Controllers/VulnerabilitiesControllerSourcesTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Controllers/VulnerabilitiesControllerSourcesTests.cs
@@ -1,0 +1,99 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Controllers;
+using SorobanSecurityPortalApi.Models.ViewModels;
+using SorobanSecurityPortalApi.Services.ControllersServices;
+
+namespace SorobanSecurityPortalApi.Tests.Controllers
+{
+    public class VulnerabilitiesControllerSourcesTests
+    {
+        [Fact]
+        public async Task ListSources_WhenIncludeNotApprovedIsFalse_ReturnsSourcesWithoutAuth()
+        {
+            var sources = new List<IdValueUrl> { new() { Id = 1, Name = "Approved" } };
+            var service = new Mock<IVulnerabilityService>();
+            service.Setup(s => s.ListSources(false)).ReturnsAsync(sources);
+
+            var controller = CreateController(service.Object);
+
+            var result = await controller.ListSources(includeNotApproved: false);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Same(sources, ok.Value);
+            service.Verify(s => s.ListSources(false), Times.Once);
+        }
+
+        [Fact]
+        public async Task ListSources_WhenIncludeNotApprovedIsTrue_AndUserIsAnonymous_ReturnsUnauthorized()
+        {
+            var service = new Mock<IVulnerabilityService>();
+            var controller = CreateController(service.Object);
+
+            var result = await controller.ListSources(includeNotApproved: true);
+
+            Assert.IsType<UnauthorizedResult>(result);
+            service.Verify(s => s.ListSources(It.IsAny<bool>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ListSources_WhenIncludeNotApprovedIsTrue_AndUserIsContributor_ReturnsForbid()
+        {
+            var service = new Mock<IVulnerabilityService>();
+            var controller = CreateController(service.Object, CreateUserWithRole(Role.Contributor));
+
+            var result = await controller.ListSources(includeNotApproved: true);
+
+            Assert.IsType<ForbidResult>(result);
+            service.Verify(s => s.ListSources(It.IsAny<bool>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ListSources_WhenIncludeNotApprovedIsTrue_AndUserIsModerator_ReturnsSources()
+        {
+            var sources = new List<IdValueUrl> { new() { Id = 2, Name = "Pending" } };
+            var service = new Mock<IVulnerabilityService>();
+            service.Setup(s => s.ListSources(true)).ReturnsAsync(sources);
+
+            var controller = CreateController(service.Object, CreateUserWithRole(Role.Moderator));
+
+            var result = await controller.ListSources(includeNotApproved: true);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Same(sources, ok.Value);
+            service.Verify(s => s.ListSources(true), Times.Once);
+        }
+
+        private static VulnerabilitiesController CreateController(
+            IVulnerabilityService service,
+            ClaimsPrincipal? user = null)
+        {
+            return new VulnerabilitiesController(service)
+            {
+                ControllerContext = new ControllerContext
+                {
+                    HttpContext = new DefaultHttpContext
+                    {
+                        User = user ?? new ClaimsPrincipal(new ClaimsIdentity())
+                    }
+                }
+            };
+        }
+
+        private static ClaimsPrincipal CreateUserWithRole(Role role)
+        {
+            var identity = new ClaimsIdentity(
+                new[]
+                {
+                    new Claim(ClaimTypes.Name, "testuser"),
+                    new Claim(ClaimTypes.Role, role.ToString())
+                },
+                "TestAuthType");
+
+            return new ClaimsPrincipal(identity);
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Controllers/VulnerabilitiesController.cs
+++ b/Backend/SorobanSecurityPortalApi/Controllers/VulnerabilitiesController.cs
@@ -27,9 +27,9 @@ namespace SorobanSecurityPortalApi.Controllers
         }
 
         [HttpGet("sources")]
-        public async Task<IActionResult> ListSources()
+        public async Task<IActionResult> ListSources([FromQuery] bool includeNotApproved = false)
         {
-            var result = await _vulnerabilityService.ListSources();
+            var result = await _vulnerabilityService.ListSources(includeNotApproved);
             return Ok(result);
         }
 

--- a/Backend/SorobanSecurityPortalApi/Controllers/VulnerabilitiesController.cs
+++ b/Backend/SorobanSecurityPortalApi/Controllers/VulnerabilitiesController.cs
@@ -29,8 +29,18 @@ namespace SorobanSecurityPortalApi.Controllers
         [HttpGet("sources")]
         public async Task<IActionResult> ListSources([FromQuery] bool includeNotApproved = false)
         {
+            if (includeNotApproved && !UserHasAnyRole(Role.Admin, Role.Moderator))
+            {
+                return User?.Identity?.IsAuthenticated == true ? Forbid() : Unauthorized();
+            }
+
             var result = await _vulnerabilityService.ListSources(includeNotApproved);
             return Ok(result);
+        }
+
+        private bool UserHasAnyRole(params Role[] roles)
+        {
+            return roles.Any(role => User.IsInRole(role.ToString()));
         }
 
         [HttpPost]

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/VulnerabilitiesService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/VulnerabilitiesService.cs
@@ -52,13 +52,38 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             return result;
         }
 
-        public async Task<List<IdValueUrl>> ListSources()
+        public async Task<List<IdValueUrl>> ListSources(bool includeNotApproved = false)
         {
+            if (includeNotApproved)
+            {
+                var reports = await _reportProcessor.GetList(true);
+                var result = new List<IdValueUrl>();
+                foreach (var report in reports)
+                {
+                    result.Add(new IdValueUrl
+                    {
+                        Id = report.Id,
+                        Name = report.Name,
+                        Url = "",
+                        ProtocolId = report.Protocol?.Id,
+                        AuditorId = report.Auditor?.Id
+                    });
+                }
+                result.Add(new IdValueUrl
+                {
+                    Id = 0,
+                    Name = "External",
+                    Url = ""
+                });
+                return result;
+            }
+
             return await _lookupCache.GetOrCreateAsync(LookupCacheKeys.Sources, async () =>
             {
                 var reports = await _reportProcessor.GetList();
                 var result = new List<IdValueUrl>();
-                foreach (var report in reports) {
+                foreach (var report in reports)
+                {
                     result.Add(new IdValueUrl
                     {
                         Id = report.Id,
@@ -267,7 +292,7 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
     public interface IVulnerabilityService
     {
         Task<List<IdValue>> ListSeverities();
-        Task<List<IdValueUrl>> ListSources();
+        Task<List<IdValueUrl>> ListSources(bool includeNotApproved = false);
         Task<List<VulnerabilityViewModel>> Search(VulnerabilitySearchViewModel? vulnerabilitySearch);
         Task<int> SearchTotal(VulnerabilitySearchViewModel? vulnerabilitySearch);
         Task<(List<VulnerabilityViewModel> Items, int Total)> SearchWithTotal(VulnerabilitySearchViewModel? vulnerabilitySearch);

--- a/UI/src/api/soroban-security-portal/__tests__/vulnerability-sources-api.test.ts
+++ b/UI/src/api/soroban-security-portal/__tests__/vulnerability-sources-api.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRequest = vi.fn();
+vi.mock('../../rest-api', () => {
+  const MockRestApi = function () { return { request: mockRequest }; };
+  return { default: MockRestApi };
+});
+vi.mock('../../../environments/environment', () => ({
+  environment: { apiUrl: 'http://localhost', clientId: 'test-client' },
+}));
+Object.defineProperty(globalThis, 'localStorage', {
+  value: { getItem: vi.fn().mockReturnValue(null) },
+  writable: true,
+});
+
+import { getSourceCall } from '../soroban-security-portal-api';
+
+beforeEach(() => {
+  mockRequest.mockReset();
+});
+
+describe('getSourceCall', () => {
+  it('GETs the public sources endpoint by default', async () => {
+    mockRequest.mockResolvedValue({ data: [], status: 200 });
+    await getSourceCall();
+    const [endpoint, method] = mockRequest.mock.calls[0];
+    expect(method).toBe('GET');
+    expect(endpoint).toBe('api/v1/vulnerabilities/sources');
+  });
+
+  it('adds includeNotApproved when requested', async () => {
+    mockRequest.mockResolvedValue({ data: [], status: 200 });
+    await getSourceCall(true);
+    const [endpoint, method] = mockRequest.mock.calls[0];
+    expect(method).toBe('GET');
+    expect(endpoint).toBe('api/v1/vulnerabilities/sources?includeNotApproved=true');
+  });
+});

--- a/UI/src/api/soroban-security-portal/soroban-security-portal-api.ts
+++ b/UI/src/api/soroban-security-portal/soroban-security-portal-api.ts
@@ -289,9 +289,10 @@ export const getSeveritiesCall = async (): Promise<VulnerabilitySeverity[]> => {
     const response = await client.request('api/v1/vulnerabilities/severities', 'GET');
     return response.data as VulnerabilitySeverity[];
 };
-export const getSourceCall = async (): Promise<VulnerabilitySource[]> => {
+export const getSourceCall = async (includeNotApproved = false): Promise<VulnerabilitySource[]> => {
     const client = await getRestClient();
-    const response = await client.request('api/v1/vulnerabilities/sources', 'GET');
+    const query = includeNotApproved ? '?includeNotApproved=true' : '';
+    const response = await client.request(`api/v1/vulnerabilities/sources${query}`, 'GET');
     return response.data as VulnerabilitySource[];
 };
 export const getVulnerabilitiesCall = async (vulnerabilitySearch?: VulnerabilitySearch): Promise<Vulnerability[]> => {

--- a/UI/src/features/pages/admin/vulnerabilities/edit-item/__tests__/edit-vulnerability.helpers.test.ts
+++ b/UI/src/features/pages/admin/vulnerabilities/edit-item/__tests__/edit-vulnerability.helpers.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { findSourceOption } from '../edit-vulnerability.helpers';
+
+const sources = [
+  { id: 0, name: 'External', url: '', protocolId: 0, auditorId: 0 },
+  { id: 7, name: 'Shared Name', url: '', protocolId: 10, auditorId: 20 },
+  { id: 9, name: 'Shared Name', url: '', protocolId: 11, auditorId: 21 },
+];
+
+describe('findSourceOption', () => {
+  it('prefers the report id when multiple reports share a name', () => {
+    const result = findSourceOption(sources, 9, 'Shared Name');
+
+    expect(result?.id).toBe(9);
+  });
+
+  it('falls back to the report name when no id is provided', () => {
+    const result = findSourceOption(sources, undefined, 'Shared Name');
+
+    expect(result?.id).toBe(7);
+  });
+
+  it('supports zero-valued ids such as the External option', () => {
+    const result = findSourceOption(sources, 0, 'External');
+
+    expect(result?.id).toBe(0);
+  });
+
+  it('returns null when the source is explicitly unset', () => {
+    const result = findSourceOption(sources, null, undefined);
+
+    expect(result).toBeNull();
+  });
+});

--- a/UI/src/features/pages/admin/vulnerabilities/edit-item/edit-vulnerability.helpers.ts
+++ b/UI/src/features/pages/admin/vulnerabilities/edit-item/edit-vulnerability.helpers.ts
@@ -1,0 +1,20 @@
+import { VulnerabilitySource } from '../../../../../api/soroban-security-portal/models/vulnerability';
+
+export const findSourceOption = (
+  sourceList: VulnerabilitySource[],
+  sourceId?: number | null,
+  sourceName?: string | null,
+): VulnerabilitySource | null => {
+  if (sourceId !== undefined && sourceId !== null) {
+    const sourceById = sourceList.find(source => source.id === sourceId);
+    if (sourceById) {
+      return sourceById;
+    }
+  }
+
+  if (!sourceName) {
+    return null;
+  }
+
+  return sourceList.find(source => source.name === sourceName) ?? null;
+};

--- a/UI/src/features/pages/admin/vulnerabilities/edit-item/edit-vulnerability.tsx
+++ b/UI/src/features/pages/admin/vulnerabilities/edit-item/edit-vulnerability.tsx
@@ -42,6 +42,7 @@ import { ConfirmDialog } from '../../admin-main-window/confirm-dialog';
 import { CompanyItem } from '../../../../../api/soroban-security-portal/models/company';
 import { MarkdownEditor } from '../../../../../components/MarkdownEditor';
 import { isAdminOrModerator } from '../../../../authentication/authPermissions';
+import { findSourceOption } from './edit-vulnerability.helpers';
 
 export const EditVulnerability: FC = () => {
   const [title, setTitle] = useState('');
@@ -104,6 +105,23 @@ export const EditVulnerability: FC = () => {
       setCompany(null);
     }
   };
+
+  const handleSetSource = (newSource: VulnerabilitySource | null) => {
+    setSource(newSource);
+
+    const nextProtocol = protocolsList.find(p => p.id === newSource?.protocolId) || null;
+    const nextAuditor = auditorsList.find(a => a.id === newSource?.auditorId) || null;
+
+    setProtocol(nextProtocol);
+    setAuditor(nextAuditor);
+
+    if (nextProtocol) {
+      const nextCompany = companiesList.find(c => c.id === nextProtocol.companyId) || null;
+      setCompany(nextCompany);
+    } else {
+      setCompany(null);
+    }
+  };
   
   // Populate form when vulnerability data is loaded
   useEffect(() => {
@@ -119,9 +137,9 @@ export const EditVulnerability: FC = () => {
             category?: number | null;
             severityName?: string;
             tagNames?: string[];
-            protocolId?: number;
-            auditorId?: number;
-            sourceId?: number;
+            protocolId?: number | null;
+            auditorId?: number | null;
+            sourceId?: number | null;
           } = JSON.parse(savedData);
           setTitle(parsedData.title || vulnerability.title);
           setDescription(parsedData.description || vulnerability.description);
@@ -152,7 +170,7 @@ export const EditVulnerability: FC = () => {
           }
           
           // Restore protocol and company
-          if (parsedData.protocolId) {
+          if (parsedData.protocolId !== undefined && parsedData.protocolId !== null) {
             const foundProtocol = protocolsList.find(p => p.id === parsedData.protocolId);
             if (foundProtocol) {
               setProtocol(foundProtocol);
@@ -167,7 +185,7 @@ export const EditVulnerability: FC = () => {
           }
           
           // Restore auditor
-          if (parsedData.auditorId) {
+          if (parsedData.auditorId !== undefined && parsedData.auditorId !== null) {
             const foundAuditor = auditorsList.find(a => a.id === parsedData.auditorId);
             setAuditor(foundAuditor || null);
           } else {
@@ -176,13 +194,12 @@ export const EditVulnerability: FC = () => {
           }
           
           // Restore source
-          if (parsedData.sourceId) {
-            const foundSource = sourceList.find(s => s.id === parsedData.sourceId);
-            setSource(foundSource || null);
-          } else {
-            const foundSource = sourceList.find((s: VulnerabilitySource) => s.name === vulnerability.reportName);
-            setSource(foundSource || null);
-          }
+          const fallbackSourceId =
+            parsedData.sourceId === undefined ? vulnerability.reportId : parsedData.sourceId;
+          const fallbackSourceName =
+            parsedData.sourceId === undefined ? vulnerability.reportName : undefined;
+          const foundSource = findSourceOption(sourceList, fallbackSourceId, fallbackSourceName);
+          setSource(foundSource);
         } catch (error) {
           console.error('Error loading saved form data:', error);
           // Fall back to original vulnerability data
@@ -199,8 +216,8 @@ export const EditVulnerability: FC = () => {
           setProtocol(foundProtocol || null);
           const foundAuditor = auditorsList.find((a: AuditorItem) => a.name === vulnerability.auditorName);
           setAuditor(foundAuditor || null);
-          const foundSource = sourceList.find((s: VulnerabilitySource) => s.name === vulnerability.reportName);
-          setSource(foundSource || null);
+          const foundSource = findSourceOption(sourceList, vulnerability.reportId, vulnerability.reportName);
+          setSource(foundSource);
           setCategory(vulnerability.category);
         }
       } else {
@@ -218,8 +235,8 @@ export const EditVulnerability: FC = () => {
         setProtocol(foundProtocol || null);
         const foundAuditor = auditorsList.find((a: AuditorItem) => a.name === vulnerability.auditorName);
         setAuditor(foundAuditor || null);
-        const foundSource = sourceList.find((s: VulnerabilitySource) => s.name === vulnerability.reportName);
-        setSource(foundSource || null);
+        const foundSource = findSourceOption(sourceList, vulnerability.reportId, vulnerability.reportName);
+        setSource(foundSource);
         setCategory(vulnerability.category);
       }
       setIsFormLoaded(true);
@@ -537,7 +554,8 @@ export const EditVulnerability: FC = () => {
               <Autocomplete
                 options={sourceList}
                 value={source}
-                onChange={(_, newValue) => setSource(newValue)}
+                onChange={(_, newValue) => handleSetSource(newValue)}
+                isOptionEqualToValue={(option, value) => option.id === value.id}
                 getOptionLabel={(option) => (option as VulnerabilitySource).name}
                 renderInput={(params) => (
                   <TextField

--- a/UI/src/features/pages/admin/vulnerabilities/edit-item/hooks/edit-vulnerability.hook.ts
+++ b/UI/src/features/pages/admin/vulnerabilities/edit-item/hooks/edit-vulnerability.hook.ts
@@ -109,7 +109,7 @@ export const useEditVulnerability = (props: UseEditVulnerabilityProps) => {
     };
 
     const getSource = async (): Promise<void> => {
-        const response = await getSourceCall();
+        const response = await getSourceCall(true);
         setSourceList(response);
     };
 

--- a/UI/src/features/pages/regular/vulnerabilities-add/hooks/vulnerabilities-add.hook.ts
+++ b/UI/src/features/pages/regular/vulnerabilities-add/hooks/vulnerabilities-add.hook.ts
@@ -57,7 +57,7 @@ export const useVulnerabilityAdd = () => {
   };
 
   const getSource = async (): Promise<void> => {
-    const response = await getSourceCall(true);
+    const response = await getSourceCall();
     setSourceList(response);
   };
 

--- a/UI/src/features/pages/regular/vulnerabilities-add/hooks/vulnerabilities-add.hook.ts
+++ b/UI/src/features/pages/regular/vulnerabilities-add/hooks/vulnerabilities-add.hook.ts
@@ -57,7 +57,7 @@ export const useVulnerabilityAdd = () => {
   };
 
   const getSource = async (): Promise<void> => {
-    const response = await getSourceCall();
+    const response = await getSourceCall(true);
     setSourceList(response);
   };
 


### PR DESCRIPTION
- Close #195 
- 
**Summary**
Fixes the admin vulnerability edit form so reports created via agent runs remain selectable when editing an existing vulnerability.

**What Changed**
- restore the selected report using `reportId` first, with name fallback only when needed
- add a dedicated helper for source lookup to handle duplicate report names and `External` (`id: 0`) safely
- make the report `Autocomplete` compare options by `id` so the selected value stays stable across reloads
- keep related protocol, auditor, and company fields in sync when the report selection changes
- add targeted unit coverage for the source lookup behavior

**Why**
The edit flow was relying too heavily on report names when rehydrating the selected report. That made agent-generated reports fragile in the selector, especially when names were duplicated or when the selected option needed to be matched by ID.

<!-- greptile_comment -->

<h3>Confidence Score: 2/5</h3>

Not safe to merge: the edit-vulnerability component will not build because a helper function was deleted while all four of its call sites remain.

The function `resolveTagNamesToTagItems` was removed from `edit-vulnerability.tsx` and replaced with `handleSetSource`, but every one of its four call sites (lines 168, 170, 214, 234) was left untouched. TypeScript will refuse to compile this file, so the admin edit page is completely broken in this branch.

UI/src/features/pages/admin/vulnerabilities/edit-item/edit-vulnerability.tsx — needs the `resolveTagNamesToTagItems` function restored (or the four call sites updated to an equivalent inline expression).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| UI/src/features/pages/admin/vulnerabilities/edit-item/edit-vulnerability.tsx | Introduces `handleSetSource` by replacing `resolveTagNamesToTagItems`, but leaves all four call sites for the deleted function intact — this breaks the TypeScript build and causes a runtime ReferenceError on the edit page. |
| Backend/SorobanSecurityPortalApi/Controllers/VulnerabilitiesController.cs | Adds inline role check for `includeNotApproved=true` (Admin/Moderator only), correctly returning 401 for anonymous callers and 403 for authenticated non-privileged users. |
| Backend/SorobanSecurityPortalApi/Services/ControllersServices/VulnerabilitiesService.cs | Adds an unapproved-report path that bypasses the lookup cache and returns all reports from `_reportProcessor.GetList(true)`, structurally correct and intentional for the admin edit flow. |
| UI/src/features/pages/admin/vulnerabilities/edit-item/edit-vulnerability.helpers.ts | New `findSourceOption` helper correctly prefers ID lookup over name matching and handles `id=0` (External) safely. |
| UI/src/features/pages/admin/vulnerabilities/edit-item/hooks/edit-vulnerability.hook.ts | Passes `includeNotApproved=true` to `getSourceCall`, now correctly requesting all reports (including agent-created ones) for the admin edit form. |
| UI/src/api/soroban-security-portal/soroban-security-portal-api.ts | Adds optional `includeNotApproved` parameter to `getSourceCall`, building the query string conditionally — clean and backward-compatible. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Admin as Admin UI (EditVulnerability)
    participant Hook as useEditVulnerability hook
    participant API as getSourceCall(includeNotApproved=true)
    participant BE as VulnerabilitiesController
    participant Svc as VulnerabilitiesService
    participant DB as ReportProcessor

    Admin->>Hook: mount
    Hook->>API: getSourceCall(true)
    API->>BE: "GET /api/v1/vulnerabilities/sources?includeNotApproved=true"
    BE->>BE: UserHasAnyRole(Admin, Moderator)?
    alt Not authenticated
        BE-->>API: 401 Unauthorized
    else Contributor
        BE-->>API: 403 Forbidden
    else Admin / Moderator
        BE->>Svc: ListSources(true)
        Svc->>DB: "GetList(includeNotApproved=true)"
        DB-->>Svc: All reports (incl. unapproved)
        Svc-->>BE: "List + External(id=0)"
        BE-->>API: 200 OK
        API-->>Hook: VulnerabilitySource[]
        Hook-->>Admin: sourceList populated
        Admin->>Admin: findSourceOption(sourceList, reportId, reportName)
        Admin->>Admin: setSource / handleSetSource sync protocol+auditor+company
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Admin as Admin UI (EditVulnerability)
    participant Hook as useEditVulnerability hook
    participant API as getSourceCall(includeNotApproved=true)
    participant BE as VulnerabilitiesController
    participant Svc as VulnerabilitiesService
    participant DB as ReportProcessor

    Admin->>Hook: mount
    Hook->>API: getSourceCall(true)
    API->>BE: "GET /api/v1/vulnerabilities/sources?includeNotApproved=true"
    BE->>BE: UserHasAnyRole(Admin, Moderator)?
    alt Not authenticated
        BE-->>API: 401 Unauthorized
    else Contributor
        BE-->>API: 403 Forbidden
    else Admin / Moderator
        BE->>Svc: ListSources(true)
        Svc->>DB: "GetList(includeNotApproved=true)"
        DB-->>Svc: All reports (incl. unapproved)
        Svc-->>BE: "List + External(id=0)"
        BE-->>API: 200 OK
        API-->>Hook: VulnerabilitySource[]
        Hook-->>Admin: sourceList populated
        Admin->>Admin: findSourceOption(sourceList, reportId, reportName)
        Admin->>Admin: setSource / handleSetSource sync protocol+auditor+company
    end
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `UI/src/features/pages/admin/vulnerabilities/edit-item/edit-vulnerability.tsx`, line 168-170 ([link](https://github.com/inferara/soroban-security-portal/blob/7c2cf22376d303afa4823bcaf8137e9cf27e7067/UI/src/features/pages/admin/vulnerabilities/edit-item/edit-vulnerability.tsx#L168-L170)) 

   <a href="#"><img alt="P0" src="https://greptile-static-assets.s3.amazonaws.com/badges/p0.svg?v=9" align="top"></a> **`resolveTagNamesToTagItems` removed but still called**

   The function definition was deleted in this PR (replaced with `handleSetSource`) but all four call sites were left intact: lines 168, 170, 214, and 234. TypeScript will fail to compile this component, and any attempt to open the edit-vulnerability page at runtime will throw a `ReferenceError`. The function body must be re-added (or the calls replaced with inline equivalents) before this change can ship.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/reports-are..."](https://github.com/inferara/soroban-security-portal/commit/7c2cf22376d303afa4823bcaf8137e9cf27e7067) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40433806)</sub>

<!-- /greptile_comment -->