### PR TITLE
Add enableCompile input to prod deploy workflow

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -15,6 +15,11 @@ on:
         description: 'Environment name'
         required: false
         default: 'prod'
+      enableCompile:
+        description: 'Enable the Dev Tools /compile endpoint (runs an unsandboxed Rust toolchain in the soroban-ret-web pod)'
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   deploy:
@@ -42,6 +47,7 @@ jobs:
           API_URL: ${{ inputs.apiUrl }}
           HOST_NAME: ${{ inputs.hostName }}
           ENV_NAME: ${{ inputs.envName }}
+          ENABLE_COMPILE: ${{ inputs.enableCompile }}
           DB_NAME: ${{ secrets.DB_NAME }}
           DB_USER_NAME: ${{ secrets.POSTGRES_USER }}
           DB_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
@@ -60,6 +66,16 @@ jobs:
           buildNumber=$(date +'%y%m%d%H%M%S')
           echo "Deploying Soroban Security Portal (build $buildNumber)..."
 
+          # The chart defaults the Dev Tools /compile endpoint OFF. Turn it on only
+          # when this deploy was dispatched with enableCompile=true.
+          if [ "$ENABLE_COMPILE" = "true" ]; then
+            noCompile="false"
+            echo "Dev Tools /compile endpoint: ENABLED"
+          else
+            noCompile="true"
+            echo "Dev Tools /compile endpoint: disabled"
+          fi
+
           helm upgrade sorobansecurityportal \
             oci://registry-1.docker.io/georgii4inferara/sorobansecurityportal \
             --devel \
@@ -70,6 +86,7 @@ jobs:
             --set global.app.build="$buildNumber" \
             --set global.app.domain="$HOST_NAME" \
             --set global.sorobansecurityportalui.apiUrl="$API_URL" \
+            --set-string global.devtools.noCompile="$noCompile" \
             --set global.sorobansecurityportalui.gaId="$GA_ID" \
             --set global.environment.namespace=sorobansecurityportal-ns \
             --set global.environment.name="$ENV_NAME" \


### PR DESCRIPTION
Small follow-up to the Dev Tools PR.

The Helm chart ships with the Dev Tools `/compile` endpoint **off by default**. This adds an `enableCompile` boolean input to the prod deploy workflow so we can flip it on when we dispatch a deploy. When `enableCompile=true`, the workflow passes `global.devtools.noCompile=false` to Helm, which turns compile/decompile on.

Default stays `false`, so a normal deploy is unchanged.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The default deploy path keeps compile disabled.
- The enabled path passes the expected inverse value to Helm.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/cd-prod.yml | Adds the `enableCompile` dispatch input and maps it to the Helm `global.devtools.noCompile` value. |

<sub>Reviews (1): Last reviewed commit: ["Add enableCompile input to prod deploy w..."](https://github.com/inferara/soroban-security-portal/commit/46cc6fc58db37389cbb53cc7047ec677c5890f1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40785142)</sub>

<!-- /greptile_comment -->