### PR TITLE
Fix Dev Tools: stale env.js cache + stuck rollout on 1-CPU node

### DIFF
--- a/Deploy/helm/charts/sorobanretweb/templates/soroban-ret-web.yaml
+++ b/Deploy/helm/charts/sorobanretweb/templates/soroban-ret-web.yaml
@@ -9,6 +9,12 @@ metadata:
     build: "{{ .Values.global.app.build }}"
 spec:
   replicas: 1
+  # The cluster is a single 1-CPU node, so two pods (old + surge) can't fit during
+  # a rolling update and the new one gets stuck Pending. Recreate tears the old pod
+  # down before starting the new one. Trade-off: the Dev Tools backend is briefly
+  # unavailable while the replacement warms up.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: "{{ .Values.global.environment.name }}-soroban-ret-web"

--- a/Deploy/helm/values.yaml
+++ b/Deploy/helm/values.yaml
@@ -42,12 +42,15 @@ global:
     # (read-only/empty-root FS, no network, resource caps) and/or behind auth.
     noCompile: "true"
     # Compilation is CPU/RAM heavy; cap it so a build can't starve the node.
+    # Node is a single 1-CPU box. With ~700m already requested by other pods,
+    # leave room for this one with a modest request (it can still burst to the
+    # limit when the core is free). See the Recreate strategy in the deployment.
     resources:
       requests:
-        cpu: "250m"
+        cpu: "150m"
         memory: "512Mi"
       limits:
-        cpu: "2"
+        cpu: "1"
         memory: "2Gi"
   letsEncryptIssuer: ""
   secrets:

--- a/UI/nginx.template.conf
+++ b/UI/nginx.template.conf
@@ -97,7 +97,17 @@ http {
         location / {
             root   /usr/share/nginx/html;
             index  index.html index.htm;
-            try_files $uri $uri/ /index.html =404;
+            try_files $uri $uri/ @spa;
+        }
+
+        # SPA fallback (deep-links like /dev-tools). Served via a named location so
+        # the no-store header applies here too; the try_files internal redirect to
+        # /index.html does NOT re-enter "location = /index.html", so without this the
+        # entrypoint would still be cacheable on exactly the routes users land on.
+        location @spa {
+            root   /usr/share/nginx/html;
+            add_header Cache-Control "no-store" always;
+            try_files /index.html =404;
         }
 
         error_page   500 502 503 504  /50x.html;

--- a/UI/nginx.template.conf
+++ b/UI/nginx.template.conf
@@ -80,6 +80,20 @@ http {
             client_max_body_size 16m;
         }
 
+        # Runtime config and the SPA entrypoint must never be cached: they change
+        # on every deploy (env.js pins the backend URLs, index.html pins the hashed
+        # asset bundle). A stale env.js makes the app call an old/wrong backend URL,
+        # which shows up in the browser as "Failed to fetch".
+        location = /env.js {
+            root   /usr/share/nginx/html;
+            add_header Cache-Control "no-store" always;
+        }
+
+        location = /index.html {
+            root   /usr/share/nginx/html;
+            add_header Cache-Control "no-store" always;
+        }
+
         location / {
             root   /usr/share/nginx/html;
             index  index.html index.htm;


### PR DESCRIPTION
Two small prod fixes, both verified before pushing.

## 1. "Could not reach the Dev Tools backend: Failed to fetch"

The deployed `env.js` is actually correct (checked the live pod), so this was a stale **cached** `env.js` from an earlier deploy: nginx served `env.js`/`index.html` with only ETag/Last-Modified and no `Cache-Control`, so browsers heuristically cached them and could keep using an old config that points at a wrong backend URL.

Fix: serve `env.js` and `index.html` with `Cache-Control: no-store` so runtime config and the SPA entrypoint are always fresh. Hashed assets under `/assets/` stay cacheable.

Verified in real nginx (Docker) against the actual rendered config: `/env.js`, `/`, `/index.html`, the SPA deep-links (`/dev-tools`) and `/vulnerability/:id` all return `no-store`, while `/assets/*.js` stay cacheable. The first attempt missed the SPA fallback path (the routes users actually land on), so the fallback now goes through a named `@spa` location that sets the header.

## 2. soroban-ret-web rollout stuck Pending on the 1-CPU node

The prod node has 1 CPU and ~700m is already requested by other pods. A rolling update briefly runs two soroban-ret-web pods (old 250m + surge 250m) = 1200m, so the new pod gets stuck `Pending` (Insufficient cpu) and the rollout never completes.

Fix: `Recreate` strategy (old pod down before new one starts) + CPU request lowered to 150m (still bursts to the limit when the core is free). Steady state is 700m + 150m = 850m with headroom. CPU limit set to 1 (2 was meaningless on a 1-core node). Trade-off: the Dev Tools backend is briefly unavailable while the replacement warms up during a deploy.

Rendered with `helm template` to confirm the strategy and resources come out right.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| UI/nginx.template.conf | Adds no-store handling for runtime config and the SPA entrypoint. |
| Deploy/helm/charts/sorobanretweb/templates/soroban-ret-web.yaml | Changes the deployment rollout strategy to `Recreate`. |
| Deploy/helm/values.yaml | Updates compile resource defaults for the constrained node. |

<sub>Reviews (3): Last reviewed commit: ["Fix soroban-ret-web rollout on the singl..."](https://github.com/inferara/soroban-security-portal/commit/593e35353e84e20d0e3f9e1a0a25d8406ccda49a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40883268)</sub>

<!-- /greptile_comment -->