### PR TITLE
Dynamic soroban-ret engine versions for Dev Tools

### DIFF
--- a/.github/workflows/devtools-engines.yml
+++ b/.github/workflows/devtools-engines.yml
@@ -36,4 +36,9 @@ jobs:
           chmod 600 $HOME/.kube/config
 
       - name: Build and upload missing engines
+        env:
+          # The prod Helm release uses environment.name "prod", so the pod is
+          # labeled app=prod-soroban-ret-web (the script's default matches the
+          # chart's default name, which dev uses).
+          APP_LABEL: prod-soroban-ret-web
         run: bash DevTools/scripts/upload-engines.sh

--- a/.github/workflows/devtools-engines.yml
+++ b/.github/workflows/devtools-engines.yml
@@ -1,0 +1,35 @@
+name: Sync Dev Tools engine versions
+
+# Keeps the soroban-ret version dropdown on /dev-tools in sync with crates.io:
+# builds any newly published soroban-ret-cli version as a static musl binary
+# on the runner and uploads it into the soroban-ret-web pod's /engines PVC.
+# No portal rebuild or redeploy involved.
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync-engines:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.3
+
+      - name: Install musl build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends musl-tools jq
+          rustup target add x86_64-unknown-linux-musl
+
+      - name: Write kubeconfig from secret
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBECONFIG }}" > $HOME/.kube/config
+
+      - name: Build and upload missing engines
+        run: bash DevTools/scripts/upload-engines.sh

--- a/.github/workflows/devtools-engines.yml
+++ b/.github/workflows/devtools-engines.yml
@@ -10,9 +10,12 @@ on:
     - cron: '17 3 * * *'
   workflow_dispatch:
 
+concurrency: devtools-engines
+
 jobs:
   sync-engines:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
 
@@ -30,6 +33,7 @@ jobs:
         run: |
           mkdir -p $HOME/.kube
           echo "${{ secrets.KUBECONFIG }}" > $HOME/.kube/config
+          chmod 600 $HOME/.kube/config
 
       - name: Build and upload missing engines
         run: bash DevTools/scripts/upload-engines.sh

--- a/.gitignore
+++ b/.gitignore
@@ -141,7 +141,7 @@ dist
 !.eslintrc.cjs
 
 # Rust build artifacts
-target/
+DevTools/soroban-ret-web/target/
 
 # Local kubeconfig used for ad-hoc cluster access — never commit (contains credentials)
 kubeconfig.temp

--- a/.gitignore
+++ b/.gitignore
@@ -140,5 +140,8 @@ dist
 !.dockerignore
 !.eslintrc.cjs
 
+# Rust build artifacts
+target/
+
 # Local kubeconfig used for ad-hoc cluster access — never commit (contains credentials)
 kubeconfig.temp

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -9,7 +9,9 @@ RUN apt-get update && \
 	
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
-    npm install -g npm@latest
+    # npm 12+ dropped Node 20 support, so "latest" breaks this image; stay on
+    # the newest npm that still runs on Node 20.
+    npm install -g npm@11
 
 ENV PLAYWRIGHT_NODEJS_PATH=/usr/bin/node
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build

--- a/Backend/docker-compose.yml
+++ b/Backend/docker-compose.yml
@@ -87,7 +87,10 @@ services:
       # Compile runs arbitrary user Rust on the server — off by default. Only
       # enable once it's sandboxed and/or behind auth.
       - DEVTOOLS_NO_COMPILE=true
+      - DEVTOOLS_ENGINES_DIR=/engines
       - RUST_LOG=info
+    volumes:
+      - soroban-ret-engines-volume:/engines
     ports:
       - "8787:8787"
     healthcheck:
@@ -102,6 +105,7 @@ services:
 volumes:
   soroban-security-portal-db-vector-volume:
   soroban-security-portal-default-db-vector-volume:
+  soroban-ret-engines-volume:
 networks:
   soroban-security-portal-network:
     driver: bridge

--- a/Deploy/helm/charts/sorobanretweb/templates/soroban-ret-engines-pvc.yaml
+++ b/Deploy/helm/charts/sorobanretweb/templates/soroban-ret-engines-pvc.yaml
@@ -3,6 +3,8 @@ kind: PersistentVolumeClaim
 metadata:
   namespace: {{ .Values.global.environment.namespace }}
   name: "{{ .Values.global.environment.name }}-soroban-ret-engines"
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     app: "{{ .Values.global.app.name }}"
     env: "{{ .Values.global.environment.namespace }}"

--- a/Deploy/helm/charts/sorobanretweb/templates/soroban-ret-engines-pvc.yaml
+++ b/Deploy/helm/charts/sorobanretweb/templates/soroban-ret-engines-pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: {{ .Values.global.environment.namespace }}
+  name: "{{ .Values.global.environment.name }}-soroban-ret-engines"
+  labels:
+    app: "{{ .Values.global.app.name }}"
+    env: "{{ .Values.global.environment.namespace }}"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: "{{ .Values.global.devtools.engines.storageClassName }}"
+  resources:
+    requests:
+      storage: "{{ .Values.global.devtools.engines.storage }}"

--- a/Deploy/helm/charts/sorobanretweb/templates/soroban-ret-web.yaml
+++ b/Deploy/helm/charts/sorobanretweb/templates/soroban-ret-web.yaml
@@ -43,6 +43,8 @@ spec:
               value: "{{ .Values.global.devtools.sorobanSdkVersion }}"
             - name: DEVTOOLS_NO_COMPILE
               value: "{{ .Values.global.devtools.noCompile }}"
+            - name: DEVTOOLS_ENGINES_DIR
+              value: "/engines"
             - name: RUST_LOG
               value: "info"
           readinessProbe:
@@ -63,3 +65,10 @@ spec:
           resources:
 {{ toYaml .Values.global.devtools.resources | indent 12 }}
           imagePullPolicy: "{{ .Values.global.containerRegistry.imagePullPolicy }}"
+          volumeMounts:
+            - name: engines
+              mountPath: /engines
+      volumes:
+        - name: engines
+          persistentVolumeClaim:
+            claimName: "{{ .Values.global.environment.name }}-soroban-ret-engines"

--- a/Deploy/helm/values.yaml
+++ b/Deploy/helm/values.yaml
@@ -41,6 +41,11 @@ global:
     # enable (--set global.devtools.noCompile=false) once it's sandboxed
     # (read-only/empty-root FS, no network, resource caps) and/or behind auth.
     noCompile: "true"
+    # Engine binaries uploaded by the devtools-engines workflow (kubectl cp
+    # onto this PVC); the service rescans the directory on every request.
+    engines:
+      storageClassName: "local-path"
+      storage: "1Gi"
     # Compilation is CPU/RAM heavy; cap it so a build can't starve the node.
     # Node is a single 1-CPU box. With ~700m already requested by other pods,
     # leave room for this one with a modest request (it can still burst to the

--- a/Deploy/helm/values.yaml
+++ b/Deploy/helm/values.yaml
@@ -41,8 +41,8 @@ global:
     # enable (--set global.devtools.noCompile=false) once it's sandboxed
     # (read-only/empty-root FS, no network, resource caps) and/or behind auth.
     noCompile: "true"
-    # Engine binaries uploaded by the devtools-engines workflow (kubectl cp
-    # onto this PVC); the service rescans the directory on every request.
+    # Engine binaries uploaded by the devtools-engines workflow (streamed
+    # onto this PVC via kubectl exec); the service rescans the directory on every request.
     engines:
       storageClassName: "local-path"
       storage: "1Gi"

--- a/DevTools/README.md
+++ b/DevTools/README.md
@@ -114,6 +114,32 @@ contract info). Decompilation fidelity depends on the soroban-ret version;
 freshly compiled trivial snippets may not round-trip exactly, while the Samples
 and real on-chain contracts recover best.
 
+Versions can also be provided as binaries in a scanned directory
+(`--engines-dir` / `DEVTOOLS_ENGINES_DIR`, unset by default). Files named
+`soroban-ret-<version>` (strict `x.y.z`, executable) are registered as CLI
+engines; the directory is rescanned on every lookup, so a newly added binary
+appears in the dropdown immediately — no restart. Dotfiles/`.tmp` staging
+files and foreign names are ignored; an explicit `DEVTOOLS_RET_BINARIES`
+entry wins over a same-version dir file, and the builtin version always wins
+over both.
+
+In Kubernetes this directory is a 1Gi PVC mounted at `/engines`. The
+`devtools-engines` GitHub workflow (daily + manual dispatch) checks crates.io
+for new `soroban-ret-cli` releases, builds each missing version as a static
+musl binary on the runner, smoke-tests it and uploads it via `kubectl exec`
+streaming (a dotfile staging name, then an atomic `mv`) — so new crate
+releases show up on `/dev-tools` without any portal rebuild or redeploy. The
+same logic can be run by hand against any cluster (e.g. dev) via:
+
+```bash
+NAMESPACE=sorobansecurityportal-ns bash DevTools/scripts/upload-engines.sh
+```
+
+(On non-Linux hosts the build runs inside a `rust:alpine` container
+automatically.) The builtin library version itself is derived from
+`Cargo.lock` at build time (`build.rs`), so bumping the `soroban-ret`
+dependency in `Cargo.toml` is the single source of truth for it.
+
 ## Running locally
 
 ### 1. Backend
@@ -141,6 +167,7 @@ Useful flags / env vars (all overridable):
 | `--stellar-bin` / `DEVTOOLS_STELLAR_BIN` | (use `stellar` on PATH, else `cargo`) |
 | `--no-compile` / `DEVTOOLS_NO_COMPILE` | `false` |
 | `DEVTOOLS_RET_BINARIES` | (empty) — `version=path;…` external CLI engines |
+| `--engines-dir` / `DEVTOOLS_ENGINES_DIR` | (unset) — directory scanned for `soroban-ret-<version>` engine binaries |
 | `DEVTOOLS_MAX_CONCURRENCY` | host parallelism — cap on concurrent disassembly jobs |
 | `DEVTOOLS_CORS_ALLOW_ORIGINS` | `*` (any) — comma-separated allowlist to restrict CORS |
 

--- a/DevTools/README.md
+++ b/DevTools/README.md
@@ -119,7 +119,8 @@ Versions can also be provided as binaries in a scanned directory
 `soroban-ret-<version>` (strict `x.y.z`, executable) are registered as CLI
 engines; the directory is rescanned on every lookup, so a newly added binary
 appears in the dropdown immediately — no restart. Dotfiles/`.tmp` staging
-files and foreign names are ignored; an explicit `DEVTOOLS_RET_BINARIES`
+files, symlinks, and foreign names are ignored (only regular executable files
+are registered); an explicit `DEVTOOLS_RET_BINARIES`
 entry wins over a same-version dir file, and the builtin version always wins
 over both.
 

--- a/DevTools/docker-compose.yml
+++ b/DevTools/docker-compose.yml
@@ -28,7 +28,10 @@ services:
       # Restrict CORS when exposing cross-origin: DEVTOOLS_CORS_ALLOW_ORIGINS=https://host
       # Register extra soroban-ret CLI versions for the dropdown, e.g.
       #   DEVTOOLS_RET_BINARIES=0.0.1=/opt/engines/0.0.1/soroban-ret
+      - DEVTOOLS_ENGINES_DIR=/engines
       - RUST_LOG=info
+    volumes:
+      - soroban-ret-engines-volume:/engines
     ports:
       - "8787:8787"
     healthcheck:
@@ -37,3 +40,6 @@ services:
       timeout: 5s
       retries: 3
       start_period: 20s
+
+volumes:
+  soroban-ret-engines-volume:

--- a/DevTools/scripts/upload-engines.sh
+++ b/DevTools/scripts/upload-engines.sh
@@ -20,6 +20,8 @@ TARGET="x86_64-unknown-linux-musl"
 ENGINES_DIR="/engines"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FIXTURE_DIR="$SCRIPT_DIR/../soroban-ret-web/fixtures"
+WORK_ROOT="$(mktemp -d)"
+trap 'rm -rf "$WORK_ROOT"' EXIT
 
 use_docker() {
   case "${USE_DOCKER:-auto}" in
@@ -39,22 +41,24 @@ build_engine() {
     # docker cp. The smoke test runs inside the container because the
     # produced Linux binary can't run on a non-Linux host.
     local cname="ret-engine-build-$v-$$"
-    docker run --name "$cname" -i rust:alpine sh -ec "
+    if ! docker run --name "$cname" -i rust:alpine sh -ec "
       cat > /tmp/fixture.wasm
       apk add -q musl-dev
       cargo install soroban-ret-cli --version $v --root /tmp/eng
       /tmp/eng/bin/soroban-ret /tmp/fixture.wasm > /dev/null" \
-      < "$FIXTURE_DIR/test_add_u64.wasm"
+      < "$FIXTURE_DIR/test_add_u64.wasm"; then
+      docker rm -f "$cname" > /dev/null 2>&1 || true
+      return 1
+    fi
     docker cp "$cname:/tmp/eng/bin/soroban-ret" "$dest"
     docker rm "$cname" > /dev/null
     chmod 0755 "$dest" 2>/dev/null || true
   else
-    local root
-    root="$(mktemp -d)"
+    local root="$WORK_ROOT/build-$v"
+    mkdir -p "$root"
     cargo install soroban-ret-cli --version "$v" --target "$TARGET" --root "$root"
     "$root/bin/soroban-ret" "$FIXTURE_DIR/test_add_u64.wasm" > /dev/null
     install -m 0755 "$root/bin/soroban-ret" "$dest"
-    rm -rf "$root"
   fi
 }
 
@@ -69,25 +73,34 @@ echo "Target pod: $NAMESPACE/$pod"
 versions="$(curl -fsSL https://crates.io/api/v1/crates/soroban-ret-cli \
   | jq -r '.versions[] | select(.yanked | not) | .num')"
 echo "crates.io soroban-ret-cli versions:" $versions
-existing="$(kubectl -n "$NAMESPACE" exec "$pod" -- ls "$ENGINES_DIR" 2>/dev/null || true)"
+existing="$(kubectl -n "$NAMESPACE" exec "$pod" -- sh -c "ls $ENGINES_DIR 2>/dev/null || true")"
 
 added=0 skipped=0
 for v in $versions; do
+  if ! [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "skip $v (unexpected version format)" >&2
+    skipped=$((skipped + 1))
+    continue
+  fi
   if printf '%s\n' "$existing" | grep -qx "soroban-ret-$v"; then
     echo "skip $v (already uploaded)"
     skipped=$((skipped + 1))
     continue
   fi
-  work="$(mktemp -d)"
+  work="$WORK_ROOT/$v"
+  mkdir -p "$work"
   echo "building soroban-ret-cli $v ($TARGET)..."
   build_engine "$v" "$work/soroban-ret-$v"
   echo "uploading soroban-ret-$v..."
   # Two-phase upload: the scanner ignores dotfiles, so a partially copied
   # binary can never be picked up; mv within the same filesystem is atomic.
-  kubectl -n "$NAMESPACE" cp "$work/soroban-ret-$v" "$pod:$ENGINES_DIR/.soroban-ret-$v.tmp"
+  # Streaming via `exec -i cat` instead of `kubectl cp` keeps every remote
+  # path inside a quoted sh -c string, immune to Git-Bash/MSYS path
+  # conversion, and needs no tar in the container.
+  kubectl -n "$NAMESPACE" exec -i "$pod" -- sh -ec \
+    "cat > $ENGINES_DIR/.soroban-ret-$v.tmp" < "$work/soroban-ret-$v"
   kubectl -n "$NAMESPACE" exec "$pod" -- sh -ec \
     "chmod 0755 $ENGINES_DIR/.soroban-ret-$v.tmp && mv $ENGINES_DIR/.soroban-ret-$v.tmp $ENGINES_DIR/soroban-ret-$v"
-  rm -rf "$work"
   added=$((added + 1))
 done
 echo "Done: $added uploaded, $skipped already present."

--- a/DevTools/scripts/upload-engines.sh
+++ b/DevTools/scripts/upload-engines.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Build missing soroban-ret CLI engine versions and upload them into the
+# soroban-ret-web pod's /engines volume, where the service picks them up
+# without a restart (see docs/superpowers/specs/2026-07-17-devtools-dynamic-engines-design.md).
+#
+# Requirements: kubectl (context pointing at the target cluster), curl, jq,
+# and either a Linux host with cargo + the x86_64-unknown-linux-musl target
+# (rustup target add x86_64-unknown-linux-musl; apt install musl-tools), or
+# Docker (used automatically on non-Linux hosts).
+#
+# Env overrides:
+#   NAMESPACE   k8s namespace            (default sorobansecurityportal-ns)
+#   APP_LABEL   pod label selector value (default sorobansecurityportal-soroban-ret-web)
+#   USE_DOCKER  1 = always build in Docker, 0 = never (default: auto by OS)
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-sorobansecurityportal-ns}"
+APP_LABEL="${APP_LABEL:-sorobansecurityportal-soroban-ret-web}"
+TARGET="x86_64-unknown-linux-musl"
+ENGINES_DIR="/engines"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="$SCRIPT_DIR/../soroban-ret-web/fixtures"
+
+use_docker() {
+  case "${USE_DOCKER:-auto}" in
+    1) return 0 ;;
+    0) return 1 ;;
+    *) [ "$(uname -s)" != "Linux" ] ;;
+  esac
+}
+
+# build_engine <version> <dest-file>: cargo-install the CLI as a static Linux
+# binary and smoke-test it on a fixture contract before returning.
+build_engine() {
+  local v="$1" dest="$2"
+  if use_docker; then
+    # rust:alpine targets musl natively. No bind mounts (Git Bash on Windows
+    # mangles them): the fixture goes in via stdin, the binary comes out via
+    # docker cp. The smoke test runs inside the container because the
+    # produced Linux binary can't run on a non-Linux host.
+    local cname="ret-engine-build-$v-$$"
+    docker run --name "$cname" -i rust:alpine sh -ec "
+      cat > /tmp/fixture.wasm
+      apk add -q musl-dev
+      cargo install soroban-ret-cli --version $v --root /tmp/eng
+      /tmp/eng/bin/soroban-ret /tmp/fixture.wasm > /dev/null" \
+      < "$FIXTURE_DIR/test_add_u64.wasm"
+    docker cp "$cname:/tmp/eng/bin/soroban-ret" "$dest"
+    docker rm "$cname" > /dev/null
+    chmod 0755 "$dest" 2>/dev/null || true
+  else
+    local root
+    root="$(mktemp -d)"
+    cargo install soroban-ret-cli --version "$v" --target "$TARGET" --root "$root"
+    "$root/bin/soroban-ret" "$FIXTURE_DIR/test_add_u64.wasm" > /dev/null
+    install -m 0755 "$root/bin/soroban-ret" "$dest"
+    rm -rf "$root"
+  fi
+}
+
+pod="$(kubectl -n "$NAMESPACE" get pod -l "app=$APP_LABEL" \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+if [ -z "$pod" ]; then
+  echo "ERROR: no pod with label app=$APP_LABEL in namespace $NAMESPACE" >&2
+  exit 1
+fi
+echo "Target pod: $NAMESPACE/$pod"
+
+versions="$(curl -fsSL https://crates.io/api/v1/crates/soroban-ret-cli \
+  | jq -r '.versions[] | select(.yanked | not) | .num')"
+echo "crates.io soroban-ret-cli versions:" $versions
+existing="$(kubectl -n "$NAMESPACE" exec "$pod" -- ls "$ENGINES_DIR" 2>/dev/null || true)"
+
+added=0 skipped=0
+for v in $versions; do
+  if printf '%s\n' "$existing" | grep -qx "soroban-ret-$v"; then
+    echo "skip $v (already uploaded)"
+    skipped=$((skipped + 1))
+    continue
+  fi
+  work="$(mktemp -d)"
+  echo "building soroban-ret-cli $v ($TARGET)..."
+  build_engine "$v" "$work/soroban-ret-$v"
+  echo "uploading soroban-ret-$v..."
+  # Two-phase upload: the scanner ignores dotfiles, so a partially copied
+  # binary can never be picked up; mv within the same filesystem is atomic.
+  kubectl -n "$NAMESPACE" cp "$work/soroban-ret-$v" "$pod:$ENGINES_DIR/.soroban-ret-$v.tmp"
+  kubectl -n "$NAMESPACE" exec "$pod" -- sh -ec \
+    "chmod 0755 $ENGINES_DIR/.soroban-ret-$v.tmp && mv $ENGINES_DIR/.soroban-ret-$v.tmp $ENGINES_DIR/soroban-ret-$v"
+  rm -rf "$work"
+  added=$((added + 1))
+done
+echo "Done: $added uploaded, $skipped already present."

--- a/DevTools/scripts/upload-engines.sh
+++ b/DevTools/scripts/upload-engines.sh
@@ -41,11 +41,11 @@ build_engine() {
     # docker cp. The smoke test runs inside the container because the
     # produced Linux binary can't run on a non-Linux host.
     local cname="ret-engine-build-$v-$$"
-    if ! docker run --name "$cname" -i rust:alpine sh -ec "
+    if ! docker run --platform linux/amd64 --name "$cname" -i rust:alpine sh -ec "
       cat > /tmp/fixture.wasm
       apk add -q musl-dev
-      cargo install soroban-ret-cli --version $v --root /tmp/eng
-      /tmp/eng/bin/soroban-ret /tmp/fixture.wasm > /dev/null" \
+      cargo install soroban-ret-cli --version $v --root /tmp/eng --target x86_64-unknown-linux-musl
+      /tmp/eng/bin/soroban-ret /tmp/fixture.wasm > /tmp/smoke.out 2>&1; [ -s /tmp/smoke.out ]" \
       < "$FIXTURE_DIR/test_add_u64.wasm"; then
       docker rm -f "$cname" > /dev/null 2>&1 || true
       return 1
@@ -57,7 +57,7 @@ build_engine() {
     local root="$WORK_ROOT/build-$v"
     mkdir -p "$root"
     cargo install soroban-ret-cli --version "$v" --target "$TARGET" --root "$root"
-    "$root/bin/soroban-ret" "$FIXTURE_DIR/test_add_u64.wasm" > /dev/null
+    "$root/bin/soroban-ret" "$FIXTURE_DIR/test_add_u64.wasm" > "$root/smoke.out" 2>&1; [ -s "$root/smoke.out" ]
     install -m 0755 "$root/bin/soroban-ret" "$dest"
   fi
 }

--- a/DevTools/scripts/upload-engines.sh
+++ b/DevTools/scripts/upload-engines.sh
@@ -70,12 +70,12 @@ if [ -z "$pod" ]; then
 fi
 echo "Target pod: $NAMESPACE/$pod"
 
-versions="$(curl -fsSL https://crates.io/api/v1/crates/soroban-ret-cli \
+versions="$(curl -fsSL -A "soroban-security-portal/upload-engines (https://github.com/Inferara/soroban-security-portal)" https://crates.io/api/v1/crates/soroban-ret-cli \
   | jq -r '.versions[] | select(.yanked | not) | .num')"
 echo "crates.io soroban-ret-cli versions:" $versions
 existing="$(kubectl -n "$NAMESPACE" exec "$pod" -- sh -c "ls $ENGINES_DIR 2>/dev/null || true")"
 
-added=0 skipped=0
+added=0 skipped=0 failed=0
 for v in $versions; do
   if ! [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "skip $v (unexpected version format)" >&2
@@ -90,17 +90,26 @@ for v in $versions; do
   work="$WORK_ROOT/$v"
   mkdir -p "$work"
   echo "building soroban-ret-cli $v ($TARGET)..."
-  build_engine "$v" "$work/soroban-ret-$v"
+  if ! build_engine "$v" "$work/soroban-ret-$v"; then
+    echo "ERROR: build failed for soroban-ret-cli $v; skipping" >&2
+    failed=$((failed + 1))
+    continue
+  fi
   echo "uploading soroban-ret-$v..."
   # Two-phase upload: the scanner ignores dotfiles, so a partially copied
   # binary can never be picked up; mv within the same filesystem is atomic.
   # Streaming via `exec -i cat` instead of `kubectl cp` keeps every remote
   # path inside a quoted sh -c string, immune to Git-Bash/MSYS path
   # conversion, and needs no tar in the container.
-  kubectl -n "$NAMESPACE" exec -i "$pod" -- sh -ec \
-    "cat > $ENGINES_DIR/.soroban-ret-$v.tmp" < "$work/soroban-ret-$v"
-  kubectl -n "$NAMESPACE" exec "$pod" -- sh -ec \
-    "chmod 0755 $ENGINES_DIR/.soroban-ret-$v.tmp && mv $ENGINES_DIR/.soroban-ret-$v.tmp $ENGINES_DIR/soroban-ret-$v"
+  if ! { kubectl -n "$NAMESPACE" exec -i "$pod" -- sh -ec \
+           "cat > $ENGINES_DIR/.soroban-ret-$v.tmp" < "$work/soroban-ret-$v" \
+         && kubectl -n "$NAMESPACE" exec "$pod" -- sh -ec \
+           "chmod 0755 $ENGINES_DIR/.soroban-ret-$v.tmp && mv $ENGINES_DIR/.soroban-ret-$v.tmp $ENGINES_DIR/soroban-ret-$v"; }; then
+    echo "ERROR: upload failed for soroban-ret-$v" >&2
+    failed=$((failed + 1))
+    continue
+  fi
   added=$((added + 1))
 done
-echo "Done: $added uploaded, $skipped already present."
+echo "Done: $added uploaded, $skipped already present, $failed failed."
+[ "$failed" -eq 0 ] || exit 1

--- a/DevTools/soroban-ret-web/Cargo.lock
+++ b/DevTools/soroban-ret-web/Cargo.lock
@@ -1710,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ret"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba5252b69df318b6c908830da8567921661cb080efa830081643762350c272c"
+checksum = "1af26b02b578d69f87ff20ebbad70517c8c896fd47503d068f77c591d621b55b"
 dependencies = [
  "cov-mark",
  "log",

--- a/DevTools/soroban-ret-web/Dockerfile
+++ b/DevTools/soroban-ret-web/Dockerfile
@@ -3,7 +3,7 @@
 # ---- Build stage: compile the service binary ----
 FROM rust:1.96-bookworm AS build
 WORKDIR /app
-COPY Cargo.toml Cargo.lock ./
+COPY Cargo.toml Cargo.lock build.rs ./
 COPY src ./src
 COPY fixtures ./fixtures
 RUN cargo build --release --bin soroban-ret-web

--- a/DevTools/soroban-ret-web/build.rs
+++ b/DevTools/soroban-ret-web/build.rs
@@ -1,0 +1,25 @@
+//! Exports RET_VERSION: the exact `soroban-ret` library version from
+//! Cargo.lock. Keeps the version reported by /versions in lockstep with the
+//! dependency — bumping Cargo.toml can no longer desynchronize the constant.
+
+fn main() {
+    println!("cargo:rerun-if-changed=Cargo.lock");
+    let lock = std::fs::read_to_string("Cargo.lock").expect("failed to read Cargo.lock");
+    let mut in_ret_package = false;
+    let mut version = None;
+    for line in lock.lines() {
+        let line = line.trim();
+        if line == "[[package]]" {
+            in_ret_package = false;
+        } else if line == "name = \"soroban-ret\"" {
+            in_ret_package = true;
+        } else if in_ret_package {
+            if let Some(v) = line.strip_prefix("version = ") {
+                version = Some(v.trim_matches('"').to_string());
+                break;
+            }
+        }
+    }
+    let version = version.expect("soroban-ret package not found in Cargo.lock");
+    println!("cargo:rustc-env=RET_VERSION={}", version);
+}

--- a/DevTools/soroban-ret-web/src/engine.rs
+++ b/DevTools/soroban-ret-web/src/engine.rs
@@ -13,6 +13,10 @@
 //! selected version is honored end-to-end (a CLI engine is shelled out to for
 //! the decompiled Rust; WAT / hex / section views are produced locally and are
 //! version-independent).
+//!
+//! A third source is an optional directory (`DEVTOOLS_ENGINES_DIR`) scanned for
+//! `soroban-ret-<version>` binaries on every lookup, so binaries uploaded into
+//! a Kubernetes PVC appear in the dropdown without a restart.
 
 use crate::error::WebError;
 use std::collections::BTreeMap;
@@ -45,12 +49,16 @@ impl Engine {
 pub struct Registry {
     pub builtin_version: String,
     clis: BTreeMap<String, PathBuf>,
+    engines_dir: Option<PathBuf>,
 }
 
 impl Registry {
-    /// Build the registry: the builtin library version plus any CLI binaries
-    /// configured via `DEVTOOLS_RET_BINARIES` that actually exist on disk.
-    pub fn from_env(builtin_version: &str) -> Self {
+    /// Build the registry: the builtin library version, any CLI binaries
+    /// configured via `DEVTOOLS_RET_BINARIES` that exist on disk, and an
+    /// optional directory scanned for uploaded `soroban-ret-<version>`
+    /// binaries (rescanned on every lookup, so uploads appear without a
+    /// restart).
+    pub fn from_env(builtin_version: &str, engines_dir: Option<PathBuf>) -> Self {
         let mut clis = BTreeMap::new();
         if let Ok(spec) = std::env::var("DEVTOOLS_RET_BINARIES") {
             for entry in spec.split(';') {
@@ -81,15 +89,62 @@ impl Registry {
                 }
             }
         }
+        Self::new(builtin_version, clis, engines_dir)
+    }
+
+    fn new(
+        builtin_version: &str,
+        clis: BTreeMap<String, PathBuf>,
+        engines_dir: Option<PathBuf>,
+    ) -> Self {
         Self {
             builtin_version: builtin_version.to_string(),
             clis,
+            engines_dir,
         }
+    }
+
+    /// Engines currently present in the scan directory. Called on every
+    /// lookup — a readdir of a tiny directory is microseconds, and rescanning
+    /// means a freshly uploaded binary shows up with no restart, no locks and
+    /// no background tasks.
+    fn scan_engines_dir(&self) -> BTreeMap<String, PathBuf> {
+        let mut found = BTreeMap::new();
+        let Some(dir) = &self.engines_dir else {
+            return found;
+        };
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return found;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            let Some(ver) = engine_file_version(name) else { continue };
+            if ver == self.builtin_version {
+                continue;
+            }
+            let Ok(md) = entry.metadata() else { continue };
+            if !md.is_file() || !is_executable(&md) {
+                continue;
+            }
+            found.insert(ver.to_string(), entry.path());
+        }
+        found
+    }
+
+    /// All external CLI engines: scanned directory entries, with explicit
+    /// `DEVTOOLS_RET_BINARIES` config overriding same-version dir files.
+    fn cli_engines(&self) -> BTreeMap<String, PathBuf> {
+        let mut map = self.scan_engines_dir();
+        for (ver, path) in &self.clis {
+            map.insert(ver.clone(), path.clone());
+        }
+        map
     }
 
     /// Available versions, newest first, with the builtin version always present.
     pub fn available(&self) -> Vec<String> {
-        let mut versions: Vec<String> = self.clis.keys().cloned().collect();
+        let mut versions: Vec<String> = self.cli_engines().into_keys().collect();
         if !versions.iter().any(|v| v == &self.builtin_version) {
             versions.push(self.builtin_version.clone());
         }
@@ -102,10 +157,10 @@ impl Registry {
         match version {
             None => Ok(Engine::Builtin),
             Some(v) if v.is_empty() || v == self.builtin_version => Ok(Engine::Builtin),
-            Some(v) => match self.clis.get(v) {
+            Some(v) => match self.cli_engines().remove(v) {
                 Some(path) => Ok(Engine::Cli {
                     version: v.to_string(),
-                    path: path.clone(),
+                    path,
                 }),
                 None => Err(WebError::InvalidInput(format!(
                     "Unknown soroban-ret version '{}'. Available: {}",
@@ -115,6 +170,30 @@ impl Registry {
             },
         }
     }
+}
+
+/// `soroban-ret-<major>.<minor>.<patch>` -> the version, else None. Strict on
+/// purpose: the scanner must never pick up `.tmp` upload staging files or
+/// anything else that lands in the directory.
+fn engine_file_version(name: &str) -> Option<&str> {
+    let ver = name.strip_prefix("soroban-ret-")?;
+    let parts: Vec<&str> = ver.split('.').collect();
+    let ok = parts.len() == 3
+        && parts
+            .iter()
+            .all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()));
+    ok.then_some(ver)
+}
+
+#[cfg(unix)]
+fn is_executable(md: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    md.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(not(unix))]
+fn is_executable(_md: &std::fs::Metadata) -> bool {
+    true // Windows local dev: no exec bit; the name convention is the filter.
 }
 
 /// Compare dotted versions numerically (so "0.0.10" > "0.0.2").
@@ -129,6 +208,146 @@ fn natural_version_cmp(a: &str, b: &str) -> std::cmp::Ordering {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static DIR_SEQ: AtomicU32 = AtomicU32::new(0);
+
+    /// Fresh per-test scratch dir (no tempfile dependency).
+    fn temp_engines_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "ret-web-engines-test-{}-{}",
+            std::process::id(),
+            DIR_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn add_engine_file(dir: &Path, name: &str) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, b"#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        path
+    }
+
+    fn registry(builtin: &str, clis: &[(&str, &str)], dir: Option<PathBuf>) -> Registry {
+        let clis = clis
+            .iter()
+            .map(|(v, p)| ((*v).to_string(), PathBuf::from(p)))
+            .collect();
+        Registry::new(builtin, clis, dir)
+    }
+
+    #[test]
+    fn scan_registers_convention_named_files() {
+        let dir = temp_engines_dir();
+        add_engine_file(&dir, "soroban-ret-0.0.1");
+        add_engine_file(&dir, "soroban-ret-0.0.2");
+        let reg = registry("0.0.3", &[], Some(dir));
+        assert_eq!(reg.available(), vec!["0.0.3", "0.0.2", "0.0.1"]);
+    }
+
+    #[test]
+    fn scan_ignores_tmp_dotfiles_and_foreign_names() {
+        let dir = temp_engines_dir();
+        add_engine_file(&dir, ".soroban-ret-0.0.9.tmp"); // in-flight upload
+        add_engine_file(&dir, "soroban-ret-abc");        // not a semver
+        add_engine_file(&dir, "soroban-ret-0.1");        // two components
+        add_engine_file(&dir, "soroban-ret-0.0.2.exe");  // trailing garbage
+        add_engine_file(&dir, "readme.txt");
+        let reg = registry("0.0.3", &[], Some(dir));
+        assert_eq!(reg.available(), vec!["0.0.3"]);
+    }
+
+    #[test]
+    fn dir_version_equal_to_builtin_is_ignored() {
+        let dir = temp_engines_dir();
+        add_engine_file(&dir, "soroban-ret-0.0.3");
+        let reg = registry("0.0.3", &[], Some(dir));
+        assert_eq!(reg.available(), vec!["0.0.3"]);
+        // Resolving it must yield the (richer) builtin engine, not the CLI.
+        assert!(matches!(reg.resolve(Some("0.0.3")).unwrap(), Engine::Builtin));
+    }
+
+    #[test]
+    fn env_entry_wins_over_dir_entry() {
+        let dir = temp_engines_dir();
+        add_engine_file(&dir, "soroban-ret-0.0.1");
+        let reg = registry("0.0.3", &[("0.0.1", "/explicit/soroban-ret")], Some(dir));
+        match reg.resolve(Some("0.0.1")).unwrap() {
+            Engine::Cli { path, .. } => assert_eq!(path, PathBuf::from("/explicit/soroban-ret")),
+            Engine::Builtin => panic!("expected CLI engine"),
+        }
+    }
+
+    #[test]
+    fn resolve_dir_engine_returns_cli_with_scanned_path() {
+        let dir = temp_engines_dir();
+        let bin = add_engine_file(&dir, "soroban-ret-0.0.1");
+        let reg = registry("0.0.3", &[], Some(dir));
+        match reg.resolve(Some("0.0.1")).unwrap() {
+            Engine::Cli { version, path } => {
+                assert_eq!(version, "0.0.1");
+                assert_eq!(path, bin);
+            }
+            Engine::Builtin => panic!("expected CLI engine"),
+        }
+    }
+
+    #[test]
+    fn resolve_unknown_version_errors() {
+        let reg = registry("0.0.3", &[], None);
+        assert!(reg.resolve(Some("9.9.9")).is_err());
+    }
+
+    #[test]
+    fn missing_dir_yields_builtin_only() {
+        let reg = registry(
+            "0.0.3",
+            &[],
+            Some(std::env::temp_dir().join("ret-web-engines-does-not-exist")),
+        );
+        assert_eq!(reg.available(), vec!["0.0.3"]);
+    }
+
+    #[test]
+    fn versions_sort_naturally_newest_first() {
+        let dir = temp_engines_dir();
+        add_engine_file(&dir, "soroban-ret-0.0.10");
+        add_engine_file(&dir, "soroban-ret-0.0.2");
+        let reg = registry("0.0.3", &[], Some(dir));
+        assert_eq!(reg.available(), vec!["0.0.10", "0.0.3", "0.0.2"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_executable_files_are_ignored() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = temp_engines_dir();
+        let path = add_engine_file(&dir, "soroban-ret-0.0.1");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        let reg = registry("0.0.3", &[], Some(dir));
+        assert_eq!(reg.available(), vec!["0.0.3"]);
+    }
+
+    #[test]
+    fn engine_file_version_accepts_only_strict_semver() {
+        assert_eq!(engine_file_version("soroban-ret-0.0.4"), Some("0.0.4"));
+        assert_eq!(engine_file_version("soroban-ret-10.2.33"), Some("10.2.33"));
+        assert_eq!(engine_file_version("soroban-ret-0.0"), None);
+        assert_eq!(engine_file_version("soroban-ret-0.0.4.tmp"), None);
+        assert_eq!(engine_file_version("soroban-ret-"), None);
+        assert_eq!(engine_file_version("soroban-ret-0.0.a"), None);
+        assert_eq!(engine_file_version("other-0.0.4"), None);
+    }
+
     /// The version reported as "builtin" must always equal the soroban-ret
     /// entry in Cargo.lock — guards against the stale-constant bug where the
     /// dependency was bumped to 0.0.3 but the constant said 0.0.2.

--- a/DevTools/soroban-ret-web/src/engine.rs
+++ b/DevTools/soroban-ret-web/src/engine.rs
@@ -123,6 +123,13 @@ impl Registry {
             if ver == self.builtin_version {
                 continue;
             }
+            // Regular files only — refuse symlinks explicitly so the
+            // documented contract doesn't hinge on DirEntry::metadata's
+            // no-follow semantics.
+            let Ok(ft) = entry.file_type() else { continue };
+            if ft.is_symlink() {
+                continue;
+            }
             let Ok(md) = entry.metadata() else { continue };
             if !md.is_file() || !is_executable(&md) {
                 continue;
@@ -333,6 +340,16 @@ mod tests {
         let dir = temp_engines_dir();
         let path = add_engine_file(&dir, "soroban-ret-0.0.1");
         fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        let reg = registry("0.0.3", &[], Some(dir));
+        assert_eq!(reg.available(), vec!["0.0.3"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinks_are_ignored_even_when_target_is_valid() {
+        let dir = temp_engines_dir();
+        let target = add_engine_file(&dir, "real-binary");
+        std::os::unix::fs::symlink(&target, dir.join("soroban-ret-0.0.1")).unwrap();
         let reg = registry("0.0.3", &[], Some(dir));
         assert_eq!(reg.available(), vec!["0.0.3"]);
     }

--- a/DevTools/soroban-ret-web/src/engine.rs
+++ b/DevTools/soroban-ret-web/src/engine.rs
@@ -126,3 +126,31 @@ fn natural_version_cmp(a: &str, b: &str) -> std::cmp::Ordering {
     };
     parse(a).cmp(&parse(b))
 }
+
+#[cfg(test)]
+mod tests {
+    /// The version reported as "builtin" must always equal the soroban-ret
+    /// entry in Cargo.lock — guards against the stale-constant bug where the
+    /// dependency was bumped to 0.0.3 but the constant said 0.0.2.
+    #[test]
+    fn builtin_version_matches_cargo_lock() {
+        let lock = include_str!("../Cargo.lock");
+        let mut in_ret_package = false;
+        let mut lock_version = None;
+        for line in lock.lines() {
+            let line = line.trim();
+            if line == "[[package]]" {
+                in_ret_package = false;
+            } else if line == "name = \"soroban-ret\"" {
+                in_ret_package = true;
+            } else if in_ret_package {
+                if let Some(v) = line.strip_prefix("version = ") {
+                    lock_version = Some(v.trim_matches('"').to_string());
+                    break;
+                }
+            }
+        }
+        let lock_version = lock_version.expect("soroban-ret not found in Cargo.lock");
+        assert_eq!(env!("RET_VERSION"), lock_version);
+    }
+}

--- a/DevTools/soroban-ret-web/src/main.rs
+++ b/DevTools/soroban-ret-web/src/main.rs
@@ -86,6 +86,11 @@ struct Cli {
     /// Disable the compile endpoint entirely (skips skeleton scaffold + warm)
     #[arg(long, env = "DEVTOOLS_NO_COMPILE", default_value = "false")]
     no_compile: bool,
+
+    /// Directory scanned for uploaded `soroban-ret-<version>` engine binaries
+    /// (rescanned on every request; unset = disabled)
+    #[arg(long, env = "DEVTOOLS_ENGINES_DIR")]
+    engines_dir: Option<PathBuf>,
 }
 
 struct AppState {
@@ -163,7 +168,10 @@ async fn main() {
         CompileEnv::init(dir, cli.soroban_sdk_version.clone(), cli.stellar_bin.clone()).await
     };
 
-    let registry = Registry::from_env(RET_VERSION);
+    if let Some(dir) = &cli.engines_dir {
+        log::info!("Scanning for engine binaries in {}", dir.display());
+    }
+    let registry = Registry::from_env(RET_VERSION, cli.engines_dir.clone());
     log::info!("soroban-ret versions available: {}", registry.available().join(", "));
 
     let state = Arc::new(AppState {

--- a/DevTools/soroban-ret-web/src/main.rs
+++ b/DevTools/soroban-ret-web/src/main.rs
@@ -38,8 +38,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use tower_http::cors::{AllowOrigin, Any, CorsLayer};
 
-/// soroban-ret library version this service is built against.
-const RET_VERSION: &str = "0.0.2";
+/// soroban-ret library version this service is built against — derived from
+/// Cargo.lock by build.rs, so it can never go stale on a dependency bump.
+const RET_VERSION: &str = env!("RET_VERSION");
 
 #[derive(Parser)]
 #[command(name = "soroban-ret-web")]

--- a/docs/superpowers/plans/2026-07-17-devtools-dynamic-engines.md
+++ b/docs/superpowers/plans/2026-07-17-devtools-dynamic-engines.md
@@ -1,0 +1,1017 @@
+# Dev Tools Dynamic Engine Versions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every published `soroban-ret-cli` version selectable on `/dev-tools` without rebuilding or redeploying the backend: CI builds static engine binaries and `kubectl cp`s them onto a PVC that `soroban-ret-web` rescans on every request.
+
+**Architecture:** Three independent pieces glued by a file-naming convention (`soroban-ret-<semver>` in `/engines`): (1) `soroban-ret-web` gains a `DEVTOOLS_ENGINES_DIR` scanned lazily on each `available()`/`resolve()` call; (2) a scheduled GitHub workflow builds missing versions with `cargo install --target x86_64-unknown-linux-musl` on the runner and uploads them atomically via `kubectl cp` + `mv`; (3) the Helm chart adds the PVC/mount/env. A `build.rs` derives the builtin library version from `Cargo.lock`, fixing the stale `RET_VERSION = "0.0.2"` constant.
+
+**Tech Stack:** Rust (axum service, edition 2024, rust ≥1.95), Bash, GitHub Actions, Helm/K3S, Docker.
+
+**Spec:** `docs/superpowers/specs/2026-07-17-devtools-dynamic-engines-design.md`
+
+## Global Constraints
+
+- Engine file naming convention: `soroban-ret-<semver>` where semver matches `^\d+\.\d+\.\d+$`; anything else in the dir is ignored (dotfiles, `.tmp`, non-executables).
+- Precedence: builtin library > `DEVTOOLS_RET_BINARIES` env entries > engines-dir files. A dir/env version equal to the builtin is ignored.
+- `DEVTOOLS_ENGINES_DIR` unset ⇒ feature fully disabled (local dev unchanged).
+- Build target for uploaded engines: `x86_64-unknown-linux-musl` (static, runs on the K3S node and on GitHub runners).
+- Upload must be atomic: copy to `.soroban-ret-<v>.tmp`, then `mv` to the final name.
+- No new public endpoints; upload happens only via kubectl (existing `secrets.KUBECONFIG` trust).
+- PVC: `local-path` storage class (same as postgres), 1Gi, mounted at `/engines`.
+- All Rust work happens in `DevTools/soroban-ret-web`. Run tests with `cargo test` in that directory. If the machine has no Rust ≥1.95 toolchain, run instead: `docker run --rm -v "${PWD}:/app" -w /app rust:1.96-bookworm cargo test` (from `DevTools/soroban-ret-web`; PowerShell: replace `${PWD}` with `${PWD}.Path`).
+- Commit messages: plain human style, no AI/Claude mentions (user's global rule).
+
+---
+
+### Task 1: Derive the builtin version from Cargo.lock (`build.rs`)
+
+Fixes the live bug: `main.rs:42` hardcodes `RET_VERSION = "0.0.2"` while `Cargo.toml` depends on soroban-ret 0.0.3, so `/versions` misreports `current`.
+
+**Files:**
+- Create: `DevTools/soroban-ret-web/build.rs`
+- Modify: `DevTools/soroban-ret-web/src/main.rs:41-42` (the `RET_VERSION` const)
+- Test: inline test module added in `DevTools/soroban-ret-web/src/engine.rs` (Task 2 extends this module; if executing this task first, create the `#[cfg(test)] mod tests` block at the end of `engine.rs`)
+
+**Interfaces:**
+- Produces: compile-time env `RET_VERSION` (via `env!("RET_VERSION")`), equal to the `soroban-ret` version pinned in `Cargo.lock`. `main.rs` keeps exporting `const RET_VERSION: &str` with the same name, so no other call sites change.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `DevTools/soroban-ret-web/src/engine.rs` (create the module if absent):
+
+```rust
+#[cfg(test)]
+mod tests {
+    /// The version reported as "builtin" must always equal the soroban-ret
+    /// entry in Cargo.lock — guards against the stale-constant bug where the
+    /// dependency was bumped to 0.0.3 but the constant said 0.0.2.
+    #[test]
+    fn builtin_version_matches_cargo_lock() {
+        let lock = include_str!("../Cargo.lock");
+        let mut in_ret_package = false;
+        let mut lock_version = None;
+        for line in lock.lines() {
+            let line = line.trim();
+            if line == "[[package]]" {
+                in_ret_package = false;
+            } else if line == "name = \"soroban-ret\"" {
+                in_ret_package = true;
+            } else if in_ret_package {
+                if let Some(v) = line.strip_prefix("version = ") {
+                    lock_version = Some(v.trim_matches('"').to_string());
+                    break;
+                }
+            }
+        }
+        let lock_version = lock_version.expect("soroban-ret not found in Cargo.lock");
+        assert_eq!(env!("RET_VERSION"), lock_version);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `DevTools/soroban-ret-web`): `cargo test builtin_version_matches_cargo_lock`
+Expected: **compile error** — `error: environment variable `RET_VERSION` not defined` (that is the failing state: the build-time env doesn't exist yet).
+
+- [ ] **Step 3: Create `DevTools/soroban-ret-web/build.rs`**
+
+```rust
+//! Exports RET_VERSION: the exact `soroban-ret` library version from
+//! Cargo.lock. Keeps the version reported by /versions in lockstep with the
+//! dependency — bumping Cargo.toml can no longer desynchronize the constant.
+
+fn main() {
+    println!("cargo:rerun-if-changed=Cargo.lock");
+    let lock = std::fs::read_to_string("Cargo.lock").expect("failed to read Cargo.lock");
+    let mut in_ret_package = false;
+    let mut version = None;
+    for line in lock.lines() {
+        let line = line.trim();
+        if line == "[[package]]" {
+            in_ret_package = false;
+        } else if line == "name = \"soroban-ret\"" {
+            in_ret_package = true;
+        } else if in_ret_package {
+            if let Some(v) = line.strip_prefix("version = ") {
+                version = Some(v.trim_matches('"').to_string());
+                break;
+            }
+        }
+    }
+    let version = version.expect("soroban-ret package not found in Cargo.lock");
+    println!("cargo:rustc-env=RET_VERSION={}", version);
+}
+```
+
+Note: `[[package]]` blocks in Cargo.lock list keys alphabetically, so `name` always precedes `version`; the exact-match on `name = "soroban-ret"` cannot confuse `soroban-ret-web` (different string).
+
+- [ ] **Step 4: Point the constant at the build-time env**
+
+In `DevTools/soroban-ret-web/src/main.rs`, replace:
+
+```rust
+/// soroban-ret library version this service is built against.
+const RET_VERSION: &str = "0.0.2";
+```
+
+with:
+
+```rust
+/// soroban-ret library version this service is built against — derived from
+/// Cargo.lock by build.rs, so it can never go stale on a dependency bump.
+const RET_VERSION: &str = env!("RET_VERSION");
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test builtin_version_matches_cargo_lock`
+Expected: PASS (and the value is now `0.0.3`).
+
+- [ ] **Step 6: Run the whole suite**
+
+Run: `cargo test`
+Expected: all existing tests (compile.rs, rpc.rs) still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add DevTools/soroban-ret-web/build.rs DevTools/soroban-ret-web/src/main.rs DevTools/soroban-ret-web/src/engine.rs
+git commit -m "Derive the builtin soroban-ret version from Cargo.lock
+
+The RET_VERSION constant said 0.0.2 while Cargo.toml already depended on
+0.0.3, so /versions misreported the current engine. build.rs now reads the
+version from Cargo.lock at compile time."
+```
+
+---
+
+### Task 2: Engines-directory scan in `Registry`
+
+**Files:**
+- Modify: `DevTools/soroban-ret-web/src/engine.rs` (Registry struct + new scan logic + tests)
+- Modify: `DevTools/soroban-ret-web/src/main.rs` (new `--engines-dir` flag, wire into Registry, log line)
+
+**Interfaces:**
+- Consumes: `env!("RET_VERSION")` from Task 1 (unchanged name `RET_VERSION` const in main.rs).
+- Produces:
+  - `Registry::from_env(builtin_version: &str, engines_dir: Option<PathBuf>) -> Registry` (signature gains the second parameter; the only caller is `main.rs`).
+  - Private `Registry::new(builtin_version: &str, clis: BTreeMap<String, PathBuf>, engines_dir: Option<PathBuf>) -> Registry` used by tests.
+  - `available()` / `resolve()` keep their existing signatures — handlers don't change.
+  - `engine_file_version(name: &str) -> Option<&str>` module-private helper.
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend the `#[cfg(test)] mod tests` block in `engine.rs` (added in Task 1) — new imports and tests:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static DIR_SEQ: AtomicU32 = AtomicU32::new(0);
+
+    /// Fresh per-test scratch dir (no tempfile dependency).
+    fn temp_engines_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "ret-web-engines-test-{}-{}",
+            std::process::id(),
+            DIR_SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn add_engine_file(dir: &Path, name: &str) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, b"#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        path
+    }
+
+    fn registry(builtin: &str, clis: &[(&str, &str)], dir: Option<PathBuf>) -> Registry {
+        let clis = clis
+            .iter()
+            .map(|(v, p)| ((*v).to_string(), PathBuf::from(p)))
+            .collect();
+        Registry::new(builtin, clis, dir)
+    }
+
+    #[test]
+    fn scan_registers_convention_named_files() {
+        let dir = temp_engines_dir();
+        add_engine_file(&dir, "soroban-ret-0.0.1");
+        add_engine_file(&dir, "soroban-ret-0.0.2");
+        let reg = registry("0.0.3", &[], Some(dir));
+        assert_eq!(reg.available(), vec!["0.0.3", "0.0.2", "0.0.1"]);
+    }
+
+    #[test]
+    fn scan_ignores_tmp_dotfiles_and_foreign_names() {
+        let dir = temp_engines_dir();
+        add_engine_file(&dir, ".soroban-ret-0.0.9.tmp"); // in-flight upload
+        add_engine_file(&dir, "soroban-ret-abc");        // not a semver
+        add_engine_file(&dir, "soroban-ret-0.1");        // two components
+        add_engine_file(&dir, "soroban-ret-0.0.2.exe");  // trailing garbage
+        add_engine_file(&dir, "readme.txt");
+        let reg = registry("0.0.3", &[], Some(dir));
+        assert_eq!(reg.available(), vec!["0.0.3"]);
+    }
+
+    #[test]
+    fn dir_version_equal_to_builtin_is_ignored() {
+        let dir = temp_engines_dir();
+        add_engine_file(&dir, "soroban-ret-0.0.3");
+        let reg = registry("0.0.3", &[], Some(dir));
+        assert_eq!(reg.available(), vec!["0.0.3"]);
+        // Resolving it must yield the (richer) builtin engine, not the CLI.
+        assert!(matches!(reg.resolve(Some("0.0.3")).unwrap(), Engine::Builtin));
+    }
+
+    #[test]
+    fn env_entry_wins_over_dir_entry() {
+        let dir = temp_engines_dir();
+        add_engine_file(&dir, "soroban-ret-0.0.1");
+        let reg = registry("0.0.3", &[("0.0.1", "/explicit/soroban-ret")], Some(dir));
+        match reg.resolve(Some("0.0.1")).unwrap() {
+            Engine::Cli { path, .. } => assert_eq!(path, PathBuf::from("/explicit/soroban-ret")),
+            Engine::Builtin => panic!("expected CLI engine"),
+        }
+    }
+
+    #[test]
+    fn resolve_dir_engine_returns_cli_with_scanned_path() {
+        let dir = temp_engines_dir();
+        let bin = add_engine_file(&dir, "soroban-ret-0.0.1");
+        let reg = registry("0.0.3", &[], Some(dir));
+        match reg.resolve(Some("0.0.1")).unwrap() {
+            Engine::Cli { version, path } => {
+                assert_eq!(version, "0.0.1");
+                assert_eq!(path, bin);
+            }
+            Engine::Builtin => panic!("expected CLI engine"),
+        }
+    }
+
+    #[test]
+    fn resolve_unknown_version_errors() {
+        let reg = registry("0.0.3", &[], None);
+        assert!(reg.resolve(Some("9.9.9")).is_err());
+    }
+
+    #[test]
+    fn missing_dir_yields_builtin_only() {
+        let reg = registry(
+            "0.0.3",
+            &[],
+            Some(std::env::temp_dir().join("ret-web-engines-does-not-exist")),
+        );
+        assert_eq!(reg.available(), vec!["0.0.3"]);
+    }
+
+    #[test]
+    fn versions_sort_naturally_newest_first() {
+        let dir = temp_engines_dir();
+        add_engine_file(&dir, "soroban-ret-0.0.10");
+        add_engine_file(&dir, "soroban-ret-0.0.2");
+        let reg = registry("0.0.3", &[], Some(dir));
+        assert_eq!(reg.available(), vec!["0.0.10", "0.0.3", "0.0.2"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_executable_files_are_ignored() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = temp_engines_dir();
+        let path = add_engine_file(&dir, "soroban-ret-0.0.1");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+        let reg = registry("0.0.3", &[], Some(dir));
+        assert_eq!(reg.available(), vec!["0.0.3"]);
+    }
+
+    #[test]
+    fn engine_file_version_accepts_only_strict_semver() {
+        assert_eq!(engine_file_version("soroban-ret-0.0.4"), Some("0.0.4"));
+        assert_eq!(engine_file_version("soroban-ret-10.2.33"), Some("10.2.33"));
+        assert_eq!(engine_file_version("soroban-ret-0.0"), None);
+        assert_eq!(engine_file_version("soroban-ret-0.0.4.tmp"), None);
+        assert_eq!(engine_file_version("soroban-ret-"), None);
+        assert_eq!(engine_file_version("soroban-ret-0.0.a"), None);
+        assert_eq!(engine_file_version("other-0.0.4"), None);
+    }
+
+    // ... builtin_version_matches_cargo_lock from Task 1 stays here ...
+}
+```
+
+(Keep the Task 1 test inside this same module; just merge the `use` items.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test` (in `DevTools/soroban-ret-web`)
+Expected: compile errors — `Registry::new` and `engine_file_version` don't exist yet.
+
+- [ ] **Step 3: Implement the scan in `engine.rs`**
+
+Replace the `Registry` struct and impl (keep `Engine`, `natural_version_cmp`, and the module doc — extend the doc with the engines-dir source):
+
+```rust
+pub struct Registry {
+    pub builtin_version: String,
+    clis: BTreeMap<String, PathBuf>,
+    engines_dir: Option<PathBuf>,
+}
+
+impl Registry {
+    /// Build the registry: the builtin library version, any CLI binaries
+    /// configured via `DEVTOOLS_RET_BINARIES` that exist on disk, and an
+    /// optional directory scanned for uploaded `soroban-ret-<version>`
+    /// binaries (rescanned on every lookup, so uploads appear without a
+    /// restart).
+    pub fn from_env(builtin_version: &str, engines_dir: Option<PathBuf>) -> Self {
+        let mut clis = BTreeMap::new();
+        if let Ok(spec) = std::env::var("DEVTOOLS_RET_BINARIES") {
+            for entry in spec.split(';') {
+                let entry = entry.trim();
+                if entry.is_empty() {
+                    continue;
+                }
+                // Split on the first '=' only: Windows paths contain ':' and the
+                // version is always the short left-hand side.
+                if let Some((ver, path)) = entry.split_once('=') {
+                    let ver = ver.trim().to_string();
+                    let path = PathBuf::from(path.trim());
+                    if ver == builtin_version {
+                        log::warn!(
+                            "DEVTOOLS_RET_BINARIES entry for {} shadows the builtin library; ignoring",
+                            ver
+                        );
+                        continue;
+                    }
+                    if path.is_file() {
+                        log::info!("Registered soroban-ret {} -> {}", ver, path.display());
+                        clis.insert(ver, path);
+                    } else {
+                        log::warn!("soroban-ret binary for {} not found at {}", ver, path.display());
+                    }
+                } else {
+                    log::warn!("Ignoring malformed DEVTOOLS_RET_BINARIES entry: {}", entry);
+                }
+            }
+        }
+        Self::new(builtin_version, clis, engines_dir)
+    }
+
+    fn new(
+        builtin_version: &str,
+        clis: BTreeMap<String, PathBuf>,
+        engines_dir: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            builtin_version: builtin_version.to_string(),
+            clis,
+            engines_dir,
+        }
+    }
+
+    /// Engines currently present in the scan directory. Called on every
+    /// lookup — a readdir of a tiny directory is microseconds, and rescanning
+    /// means a freshly uploaded binary shows up with no restart, no locks and
+    /// no background tasks.
+    fn scan_engines_dir(&self) -> BTreeMap<String, PathBuf> {
+        let mut found = BTreeMap::new();
+        let Some(dir) = &self.engines_dir else {
+            return found;
+        };
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return found;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            let Some(ver) = engine_file_version(name) else { continue };
+            if ver == self.builtin_version {
+                continue;
+            }
+            let Ok(md) = entry.metadata() else { continue };
+            if !md.is_file() || !is_executable(&md) {
+                continue;
+            }
+            found.insert(ver.to_string(), entry.path());
+        }
+        found
+    }
+
+    /// All external CLI engines: scanned directory entries, with explicit
+    /// `DEVTOOLS_RET_BINARIES` config overriding same-version dir files.
+    fn cli_engines(&self) -> BTreeMap<String, PathBuf> {
+        let mut map = self.scan_engines_dir();
+        for (ver, path) in &self.clis {
+            map.insert(ver.clone(), path.clone());
+        }
+        map
+    }
+
+    /// Available versions, newest first, with the builtin version always present.
+    pub fn available(&self) -> Vec<String> {
+        let mut versions: Vec<String> = self.cli_engines().into_keys().collect();
+        if !versions.iter().any(|v| v == &self.builtin_version) {
+            versions.push(self.builtin_version.clone());
+        }
+        versions.sort_by(|a, b| natural_version_cmp(b, a));
+        versions
+    }
+
+    /// Resolve a requested version (None = builtin) to a concrete engine.
+    pub fn resolve(&self, version: Option<&str>) -> Result<Engine, WebError> {
+        match version {
+            None => Ok(Engine::Builtin),
+            Some(v) if v.is_empty() || v == self.builtin_version => Ok(Engine::Builtin),
+            Some(v) => match self.cli_engines().remove(v) {
+                Some(path) => Ok(Engine::Cli {
+                    version: v.to_string(),
+                    path,
+                }),
+                None => Err(WebError::InvalidInput(format!(
+                    "Unknown soroban-ret version '{}'. Available: {}",
+                    v,
+                    self.available().join(", ")
+                ))),
+            },
+        }
+    }
+}
+
+/// `soroban-ret-<major>.<minor>.<patch>` -> the version, else None. Strict on
+/// purpose: the scanner must never pick up `.tmp` upload staging files or
+/// anything else that lands in the directory.
+fn engine_file_version(name: &str) -> Option<&str> {
+    let ver = name.strip_prefix("soroban-ret-")?;
+    let parts: Vec<&str> = ver.split('.').collect();
+    let ok = parts.len() == 3
+        && parts
+            .iter()
+            .all(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()));
+    ok.then_some(ver)
+}
+
+#[cfg(unix)]
+fn is_executable(md: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    md.permissions().mode() & 0o111 != 0
+}
+
+#[cfg(not(unix))]
+fn is_executable(_md: &std::fs::Metadata) -> bool {
+    true // Windows local dev: no exec bit; the name convention is the filter.
+}
+```
+
+- [ ] **Step 4: Wire the flag in `main.rs`**
+
+Add to the `Cli` struct (after `no_compile`):
+
+```rust
+    /// Directory scanned for uploaded `soroban-ret-<version>` engine binaries
+    /// (rescanned on every request; unset = disabled)
+    #[arg(long, env = "DEVTOOLS_ENGINES_DIR")]
+    engines_dir: Option<PathBuf>,
+```
+
+Replace the registry construction (`main.rs:165`):
+
+```rust
+    if let Some(dir) = &cli.engines_dir {
+        log::info!("Scanning for engine binaries in {}", dir.display());
+    }
+    let registry = Registry::from_env(RET_VERSION, cli.engines_dir.clone());
+    log::info!("soroban-ret versions available: {}", registry.available().join(", "));
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test`
+Expected: all tests pass (the `non_executable_files_are_ignored` test is unix-only and will be skipped on Windows — that's fine; CI/dev-cluster verification covers it).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add DevTools/soroban-ret-web/src/engine.rs DevTools/soroban-ret-web/src/main.rs
+git commit -m "Scan DEVTOOLS_ENGINES_DIR for uploaded soroban-ret engine binaries
+
+The registry now has a third version source besides the builtin library and
+DEVTOOLS_RET_BINARIES: a directory of soroban-ret-<version> binaries,
+rescanned on every lookup so new uploads appear in the dropdown without a
+restart. Strict name/executable filtering keeps staging files out."
+```
+
+---
+
+### Task 3: Helm PVC + mounts, docker-compose volumes
+
+**Files:**
+- Create: `Deploy/helm/charts/sorobanretweb/templates/soroban-ret-engines-pvc.yaml`
+- Modify: `Deploy/helm/charts/sorobanretweb/templates/soroban-ret-web.yaml` (env + volumeMounts + volumes)
+- Modify: `Deploy/helm/values.yaml:35-43` (devtools block)
+- Modify: `Backend/docker-compose.yml:75-104` (soroban-ret-web service + volumes)
+- Modify: `DevTools/docker-compose.yml` (same service standalone)
+
+**Interfaces:**
+- Consumes: `DEVTOOLS_ENGINES_DIR` env understood by the service (Task 2).
+- Produces: `/engines` PVC named `{{ .Values.global.environment.name }}-soroban-ret-engines` — the path and pod label (`app={{ .Values.global.environment.name }}-soroban-ret-web`) that Task 4's upload script relies on.
+
+- [ ] **Step 1: Add values**
+
+In `Deploy/helm/values.yaml`, inside `global.devtools` (after `noCompile: "true"`):
+
+```yaml
+    # Engine binaries uploaded by the devtools-engines workflow (kubectl cp
+    # onto this PVC); the service rescans the directory on every request.
+    engines:
+      storageClassName: "local-path"
+      storage: "1Gi"
+```
+
+- [ ] **Step 2: Create the PVC template**
+
+`Deploy/helm/charts/sorobanretweb/templates/soroban-ret-engines-pvc.yaml`:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: {{ .Values.global.environment.namespace }}
+  name: "{{ .Values.global.environment.name }}-soroban-ret-engines"
+  labels:
+    app: "{{ .Values.global.app.name }}"
+    env: "{{ .Values.global.environment.namespace }}"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: "{{ .Values.global.devtools.engines.storageClassName }}"
+  resources:
+    requests:
+      storage: "{{ .Values.global.devtools.engines.storage }}"
+```
+
+- [ ] **Step 3: Mount it in the Deployment**
+
+In `Deploy/helm/charts/sorobanretweb/templates/soroban-ret-web.yaml`:
+
+Add to the container `env` list (after `DEVTOOLS_NO_COMPILE`):
+
+```yaml
+            - name: DEVTOOLS_ENGINES_DIR
+              value: "/engines"
+```
+
+Add to the container (after `imagePullPolicy`), and to the pod spec (same indent as `containers`):
+
+```yaml
+          volumeMounts:
+            - name: engines
+              mountPath: /engines
+```
+
+```yaml
+      volumes:
+        - name: engines
+          persistentVolumeClaim:
+            claimName: "{{ .Values.global.environment.name }}-soroban-ret-engines"
+```
+
+- [ ] **Step 4: Verify the chart renders**
+
+Run: `helm template sorobansecurityportal Deploy/helm | Select-String -Pattern "soroban-ret-engines|DEVTOOLS_ENGINES_DIR|mountPath: /engines" -Context 0,1`
+Expected: the PVC object, the env var, and the volumeMount all render; no template errors.
+
+- [ ] **Step 5: Mirror in docker-compose**
+
+`Backend/docker-compose.yml` — in the `soroban-ret-web` service add env and volume, and register the named volume:
+
+```yaml
+      - DEVTOOLS_ENGINES_DIR=/engines
+```
+
+```yaml
+    volumes:
+      - soroban-ret-engines-volume:/engines
+```
+
+and under the top-level `volumes:` key:
+
+```yaml
+  soroban-ret-engines-volume:
+```
+
+`DevTools/docker-compose.yml` — same three additions to its `soroban-ret-web` service (it has no top-level `volumes:` key yet; add one at the end of the file):
+
+```yaml
+volumes:
+  soroban-ret-engines-volume:
+```
+
+- [ ] **Step 6: Validate compose files**
+
+Run: `docker compose -f Backend/docker-compose.yml config --quiet; docker compose -f DevTools/docker-compose.yml config --quiet`
+Expected: exit code 0, no output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Deploy/helm/values.yaml Deploy/helm/charts/sorobanretweb/templates/ Backend/docker-compose.yml DevTools/docker-compose.yml
+git commit -m "Mount an engines PVC/volume into soroban-ret-web
+
+1Gi local-path PVC at /engines with DEVTOOLS_ENGINES_DIR pointing at it, in
+both the Helm chart and the compose files. Uploaded engine binaries survive
+pod restarts and appear in the version dropdown without a redeploy."
+```
+
+---
+
+### Task 4: Upload script `DevTools/scripts/upload-engines.sh`
+
+**Files:**
+- Create: `DevTools/scripts/upload-engines.sh`
+
+**Interfaces:**
+- Consumes: crates.io API (`soroban-ret-cli` versions), kubectl context, pod label `app=$APP_LABEL`, `/engines` dir in the pod (Task 3), fixture `DevTools/soroban-ret-web/fixtures/test_add_u64.wasm` for the smoke test.
+- Produces: `/engines/soroban-ret-<version>` executables in the pod (the exact names Task 2's scanner registers). Used verbatim by Task 5's workflow and runnable by hand against dev.
+
+- [ ] **Step 1: Write the script**
+
+```bash
+#!/usr/bin/env bash
+# Build missing soroban-ret CLI engine versions and upload them into the
+# soroban-ret-web pod's /engines volume, where the service picks them up
+# without a restart (see docs/superpowers/specs/2026-07-17-devtools-dynamic-engines-design.md).
+#
+# Requirements: kubectl (context pointing at the target cluster), curl, jq,
+# and either a Linux host with cargo + the x86_64-unknown-linux-musl target
+# (rustup target add x86_64-unknown-linux-musl; apt install musl-tools), or
+# Docker (used automatically on non-Linux hosts).
+#
+# Env overrides:
+#   NAMESPACE   k8s namespace            (default sorobansecurityportal-ns)
+#   APP_LABEL   pod label selector value (default sorobansecurityportal-soroban-ret-web)
+#   USE_DOCKER  1 = always build in Docker, 0 = never (default: auto by OS)
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-sorobansecurityportal-ns}"
+APP_LABEL="${APP_LABEL:-sorobansecurityportal-soroban-ret-web}"
+TARGET="x86_64-unknown-linux-musl"
+ENGINES_DIR="/engines"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="$SCRIPT_DIR/../soroban-ret-web/fixtures"
+
+use_docker() {
+  case "${USE_DOCKER:-auto}" in
+    1) return 0 ;;
+    0) return 1 ;;
+    *) [ "$(uname -s)" != "Linux" ] ;;
+  esac
+}
+
+# build_engine <version> <dest-file>: cargo-install the CLI as a static Linux
+# binary and smoke-test it on a fixture contract before returning.
+build_engine() {
+  local v="$1" dest="$2"
+  if use_docker; then
+    # rust:alpine targets musl natively. No bind mounts (Git Bash on Windows
+    # mangles them): the fixture goes in via stdin, the binary comes out via
+    # docker cp. The smoke test runs inside the container because the
+    # produced Linux binary can't run on a non-Linux host.
+    local cname="ret-engine-build-$v-$$"
+    docker run --name "$cname" -i rust:alpine sh -ec "
+      cat > /tmp/fixture.wasm
+      apk add -q musl-dev
+      cargo install soroban-ret-cli --version $v --root /tmp/eng
+      /tmp/eng/bin/soroban-ret /tmp/fixture.wasm > /dev/null" \
+      < "$FIXTURE_DIR/test_add_u64.wasm"
+    docker cp "$cname:/tmp/eng/bin/soroban-ret" "$dest"
+    docker rm "$cname" > /dev/null
+    chmod 0755 "$dest" 2>/dev/null || true
+  else
+    local root
+    root="$(mktemp -d)"
+    cargo install soroban-ret-cli --version "$v" --target "$TARGET" --root "$root"
+    "$root/bin/soroban-ret" "$FIXTURE_DIR/test_add_u64.wasm" > /dev/null
+    install -m 0755 "$root/bin/soroban-ret" "$dest"
+    rm -rf "$root"
+  fi
+}
+
+pod="$(kubectl -n "$NAMESPACE" get pod -l "app=$APP_LABEL" \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+if [ -z "$pod" ]; then
+  echo "ERROR: no pod with label app=$APP_LABEL in namespace $NAMESPACE" >&2
+  exit 1
+fi
+echo "Target pod: $NAMESPACE/$pod"
+
+versions="$(curl -fsSL https://crates.io/api/v1/crates/soroban-ret-cli \
+  | jq -r '.versions[] | select(.yanked | not) | .num')"
+echo "crates.io soroban-ret-cli versions:" $versions
+existing="$(kubectl -n "$NAMESPACE" exec "$pod" -- ls "$ENGINES_DIR" 2>/dev/null || true)"
+
+added=0 skipped=0
+for v in $versions; do
+  if printf '%s\n' "$existing" | grep -qx "soroban-ret-$v"; then
+    echo "skip $v (already uploaded)"
+    skipped=$((skipped + 1))
+    continue
+  fi
+  work="$(mktemp -d)"
+  echo "building soroban-ret-cli $v ($TARGET)..."
+  build_engine "$v" "$work/soroban-ret-$v"
+  echo "uploading soroban-ret-$v..."
+  # Two-phase upload: the scanner ignores dotfiles, so a partially copied
+  # binary can never be picked up; mv within the same filesystem is atomic.
+  kubectl -n "$NAMESPACE" cp "$work/soroban-ret-$v" "$pod:$ENGINES_DIR/.soroban-ret-$v.tmp"
+  kubectl -n "$NAMESPACE" exec "$pod" -- sh -ec \
+    "chmod 0755 $ENGINES_DIR/.soroban-ret-$v.tmp && mv $ENGINES_DIR/.soroban-ret-$v.tmp $ENGINES_DIR/soroban-ret-$v"
+  rm -rf "$work"
+  added=$((added + 1))
+done
+echo "Done: $added uploaded, $skipped already present."
+```
+
+- [ ] **Step 2: Syntax-check and mark executable**
+
+Run: `bash -n DevTools/scripts/upload-engines.sh`
+Expected: no output, exit 0.
+
+Run: `git add DevTools/scripts/upload-engines.sh; git update-index --chmod=+x DevTools/scripts/upload-engines.sh`
+(Windows has no exec bit — set it in the git index so the workflow runner gets an executable file.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "Add upload-engines script: build soroban-ret CLIs and kubectl-cp them to the pod
+
+Queries crates.io for non-yanked soroban-ret-cli versions, builds each
+missing one as a static musl binary (in Docker on non-Linux hosts),
+smoke-tests it on a fixture contract and uploads it atomically into the
+/engines volume via a dotfile-staged mv."
+```
+
+---
+
+### Task 5: Scheduled workflow `.github/workflows/devtools-engines.yml`
+
+**Files:**
+- Create: `.github/workflows/devtools-engines.yml`
+
+**Interfaces:**
+- Consumes: `DevTools/scripts/upload-engines.sh` (Task 4), `secrets.KUBECONFIG` (already used by `cd-prod.yml`).
+- Produces: daily sync of prod's `/engines` with crates.io.
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+name: Sync Dev Tools engine versions
+
+# Keeps the soroban-ret version dropdown on /dev-tools in sync with crates.io:
+# builds any newly published soroban-ret-cli version as a static musl binary
+# on the runner and uploads it into the soroban-ret-web pod's /engines PVC.
+# No portal rebuild or redeploy involved.
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync-engines:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.3
+
+      - name: Install musl build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends musl-tools jq
+          rustup target add x86_64-unknown-linux-musl
+
+      - name: Write kubeconfig from secret
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBECONFIG }}" > $HOME/.kube/config
+
+      - name: Build and upload missing engines
+        run: bash DevTools/scripts/upload-engines.sh
+```
+
+- [ ] **Step 2: Lint the workflow**
+
+Run: `Get-Content .github/workflows/devtools-engines.yml | docker run --rm -i mikefarah/yq eval '.' -` (or any YAML parse). Expected: parses cleanly.
+(If `actionlint` is available: `actionlint .github/workflows/devtools-engines.yml` — expected: no findings.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/devtools-engines.yml
+git commit -m "Add a daily workflow syncing Dev Tools engine versions from crates.io"
+```
+
+---
+
+### Task 6: Documentation
+
+**Files:**
+- Modify: `DevTools/README.md` ("Version selection" section + deployment notes)
+
+**Interfaces:** none (docs only).
+
+- [ ] **Step 1: Extend the "Version selection" section**
+
+In `DevTools/README.md`, after the existing `DEVTOOLS_RET_BINARIES` paragraph (ends "…real on-chain contracts recover best."), add:
+
+```markdown
+Versions can also be provided as binaries in a scanned directory
+(`--engines-dir` / `DEVTOOLS_ENGINES_DIR`, unset by default). Files named
+`soroban-ret-<version>` (strict `x.y.z`, executable) are registered as CLI
+engines; the directory is rescanned on every lookup, so a newly added binary
+appears in the dropdown immediately — no restart. Dotfiles/`.tmp` staging
+files and foreign names are ignored; an explicit `DEVTOOLS_RET_BINARIES`
+entry wins over a same-version dir file, and the builtin version always wins
+over both.
+
+In Kubernetes this directory is a 1Gi PVC mounted at `/engines`. The
+`devtools-engines` GitHub workflow (daily + manual dispatch) checks crates.io
+for new `soroban-ret-cli` releases, builds each missing version as a static
+musl binary on the runner, smoke-tests it and uploads it atomically with
+`kubectl cp` — so new crate releases show up on `/dev-tools` without any
+portal rebuild or redeploy. The same logic can be run by hand against any
+cluster (e.g. dev) via:
+
+​```bash
+NAMESPACE=sorobansecurityportal-ns bash DevTools/scripts/upload-engines.sh
+​```
+
+(On non-Linux hosts the build runs inside a `rust:alpine` container
+automatically.) The builtin library version itself is derived from
+`Cargo.lock` at build time (`build.rs`), so bumping the `soroban-ret`
+dependency in `Cargo.toml` is the single source of truth for it.
+```
+
+(Remove the zero-width characters before the inner code fence when pasting — they are only there to survive this plan's own fencing.)
+
+Also update the flag table (after the `DEVTOOLS_RET_BINARIES` row):
+
+```markdown
+| `--engines-dir` / `DEVTOOLS_ENGINES_DIR` | (unset) — directory scanned for `soroban-ret-<version>` engine binaries |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add DevTools/README.md
+git commit -m "Document dynamic engine versions in the Dev Tools README"
+```
+
+---
+
+### Task 7: Local end-to-end check (docker compose)
+
+Proves the whole loop — build binary → drop into volume → appears in dropdown without restart — without touching a cluster.
+
+**Files:** none created (verification only).
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4.
+
+- [ ] **Step 1: Build and start the slim service with the engines volume**
+
+```bash
+docker build --target runtime-slim -t soroban-ret-web:enginestest DevTools/soroban-ret-web
+docker volume create ret-engines-test
+docker run -d --name ret-engines-test -p 18787:8787 \
+  -e DEVTOOLS_ENGINES_DIR=/engines -v ret-engines-test:/engines \
+  soroban-ret-web:enginestest
+```
+
+- [ ] **Step 2: Baseline `/versions`**
+
+Run: `curl -s http://localhost:18787/api/dev-tools/versions`
+Expected: `{"current":"0.0.3","available":["0.0.3"],"compile_enabled":false}` — proves Task 1 (current is 0.0.3, not 0.0.2).
+
+- [ ] **Step 3: Build one engine into the volume (no restart)**
+
+```bash
+MSYS_NO_PATHCONV=1 docker run --rm -v ret-engines-test:/out \
+  rust:alpine sh -ec "
+    apk add -q musl-dev
+    cargo install soroban-ret-cli --version 0.0.2 --root /tmp/eng
+    install -m 0755 /tmp/eng/bin/soroban-ret /out/soroban-ret-0.0.2"
+```
+
+- [ ] **Step 4: Verify dynamic registration and disassembly**
+
+Run: `curl -s http://localhost:18787/api/dev-tools/versions`
+Expected: `available` now `["0.0.3","0.0.2"]` — with no container restart.
+
+Run (uses a committed fixture through the new engine):
+
+```bash
+curl -s -X POST http://localhost:18787/api/dev-tools/disassemble/fixture \
+  -H "Content-Type: application/json" \
+  -d '{"name":"test_add_u64","version":"0.0.2"}' | jq '{engine, engine_version, ok: (.source | length > 0)}'
+```
+
+Expected: `engine: "cli"`, `engine_version: "0.0.2"`, `ok: true`.
+(If the fixture list uses different names, first run `curl -s http://localhost:18787/api/dev-tools/fixtures | jq '.fixtures[].name'` and pick one.)
+
+- [ ] **Step 5: Clean up**
+
+```bash
+docker rm -f ret-engines-test
+docker volume rm ret-engines-test
+```
+
+- [ ] **Step 6: Commit any fixes found**
+
+If steps 2–4 surfaced bugs, fix them (with tests where applicable) and commit before proceeding.
+
+---
+
+### Task 8: Deploy to dev and verify in the cluster
+
+**Files:** none (deployment/verification).
+
+**Interfaces:**
+- Consumes: the dev K3S cluster (local kubeconfig, namespace `sorobansecurityportal-ns`), Docker Hub `andreykerchin/*`, the upload script.
+
+- [ ] **Step 1: Build and push the image**
+
+```bash
+docker build -t andreykerchin/soroban-ret-web:engines1 DevTools/soroban-ret-web --build-arg PREWARM=false
+docker push andreykerchin/soroban-ret-web:engines1
+```
+
+- [ ] **Step 2: Upgrade the chart (new PVC/mount) on dev**
+
+`--reuse-values` does NOT pick up new chart defaults, so pass the new keys explicitly:
+
+```bash
+helm upgrade sorobansecurityportal Deploy/helm -n sorobansecurityportal-ns --reuse-values \
+  --set global.devtools.engines.storageClassName=local-path \
+  --set global.devtools.engines.storage=1Gi \
+  --set-string global.app.build=engines1
+```
+
+- [ ] **Step 3: Point the retweb deployment at the new image**
+
+The shared `service.tag` drives all portal images; overriding just this deployment avoids rebuilding api/ui/worker:
+
+```bash
+kubectl -n sorobansecurityportal-ns set image deployment/sorobansecurityportal-soroban-ret-web \
+  sorobansecurityportal-soroban-ret-web=andreykerchin/soroban-ret-web:engines1
+kubectl -n sorobansecurityportal-ns rollout status deployment/sorobansecurityportal-soroban-ret-web
+```
+
+- [ ] **Step 4: Run the upload script against dev**
+
+```bash
+bash DevTools/scripts/upload-engines.sh
+```
+
+Expected: builds 0.0.1 and 0.0.2 (0.0.3 is the builtin — uploaded too, but shadowed and harmless; if desired later, the script could skip the builtin, YAGNI for now), uploads them, "Done: N uploaded".
+
+- [ ] **Step 5: Verify live**
+
+```bash
+curl -s https://sorobanshield.ru/devtools/api/dev-tools/versions
+```
+
+Expected: `{"current":"0.0.3","available":["0.0.3","0.0.2","0.0.1"],...}`.
+
+Then open `https://sorobanshield.ru/dev-tools` (Playwright), select version 0.0.2 in the dropdown, disassemble a Sample, and confirm the output panel reports engine `cli 0.0.2`. Re-run the script a second time — expected: all versions "skip (already uploaded)".
+
+- [ ] **Step 6: Restart-persistence check**
+
+```bash
+kubectl -n sorobansecurityportal-ns rollout restart deployment/sorobansecurityportal-soroban-ret-web
+kubectl -n sorobansecurityportal-ns rollout status deployment/sorobansecurityportal-soroban-ret-web
+curl -s https://sorobanshield.ru/devtools/api/dev-tools/versions
+```
+
+Expected: versions list unchanged (PVC survived the restart).
+
+---
+
+## Post-plan
+
+After all tasks pass: push the branch, open a PR (screenshots of the dropdown per the user's PR style), and after merge dispatch the `Sync Dev Tools engine versions` workflow once against prod. Prod also needs the same `--set global.devtools.engines.*` note if deployed with `--reuse-values` (cd-prod.yml passes explicit values, so a normal prod deploy is fine).

--- a/docs/superpowers/specs/2026-07-17-devtools-dynamic-engines-design.md
+++ b/docs/superpowers/specs/2026-07-17-devtools-dynamic-engines-design.md
@@ -31,8 +31,11 @@ This is a direct consequence of the manual process.
 ## Decision
 
 Build engine binaries **in GitHub Actions CI** (fast, free CPU), upload them
-**into the cluster** with `kubectl cp` onto a PVC, and have `soroban-ret-web`
-**scan that directory** to register versions dynamically. No GitHub releases,
+**into the cluster** via `kubectl exec` streaming onto a PVC, and have
+`soroban-ret-web` **scan that directory** to register versions dynamically.
+(Originally specified as `kubectl cp`; implementation switched to
+`kubectl exec -i … "cat > …"` streaming — same kubectl trust model, but no
+tar dependency in the container and immune to Git-Bash path mangling.) No GitHub releases,
 no new public endpoints, no image rebuilds when a new crate version appears.
 
 Rejected alternatives:
@@ -94,9 +97,9 @@ Steps:
      on the runner (musl → static binary, runs on any Linux including the K3S
      node and the runner itself);
    - smoke-test on the runner: disassemble a fixture WASM, non-empty output;
-   - upload atomically: `kubectl cp` to `/engines/.soroban-ret-<X>.tmp`, then
-     `kubectl exec mv` to the final name (the scanner never sees a partial
-     file).
+   - upload atomically: stream via `kubectl exec -i … "cat > /engines/.soroban-ret-<X>.tmp"`,
+     then `kubectl exec mv` to the final name (the scanner never sees a
+     partial file).
 4. Log a summary of what was added / skipped.
 
 The upload logic lives in `DevTools/scripts/upload-engines.sh` so it can also be

--- a/docs/superpowers/specs/2026-07-17-devtools-dynamic-engines-design.md
+++ b/docs/superpowers/specs/2026-07-17-devtools-dynamic-engines-design.md
@@ -1,0 +1,148 @@
+# Dev Tools: dynamic soroban-ret engine versions
+
+**Date:** 2026-07-17
+**Status:** Approved
+**Related:** `DevTools/` (issue #206, PR #207), [Inferara/soroban-ret](https://github.com/Inferara/soroban-ret)
+
+## Problem
+
+The `/dev-tools` page offers a soroban-ret version dropdown, but in practice only
+one version is available: the `soroban-ret` **library** compiled into
+`soroban-ret-web` (currently 0.0.3). Additional versions can only be registered
+as external CLI binaries via the `DEVTOOLS_RET_BINARIES` env var, which requires
+baking binaries into the image and editing deploy config — in effect, every new
+crate release means rebuilding and redeploying the backend.
+
+Upstream facts (verified 2026-07-17):
+
+- `soroban-ret` on crates.io is **library-only** (no binaries).
+- `soroban-ret-cli` on crates.io publishes a `soroban-ret` binary for every
+  version (0.0.1–0.0.3), so `cargo install soroban-ret-cli --version X` works.
+- GitHub releases of `Inferara/soroban-ret` carry **no** prebuilt assets, and we
+  have read-only access to that repo (no way to add a release workflow there).
+- The production node is a single 1-CPU machine — compiling engines in-cluster
+  is not acceptable (a `cargo build` would starve the live portal).
+
+Additionally, a real bug exists today: `main.rs` hardcodes
+`RET_VERSION = "0.0.2"` while `Cargo.toml` depends on soroban-ret 0.0.3 — the
+last dependency bump forgot the constant, so `/versions` misreports `current`.
+This is a direct consequence of the manual process.
+
+## Decision
+
+Build engine binaries **in GitHub Actions CI** (fast, free CPU), upload them
+**into the cluster** with `kubectl cp` onto a PVC, and have `soroban-ret-web`
+**scan that directory** to register versions dynamically. No GitHub releases,
+no new public endpoints, no image rebuilds when a new crate version appears.
+
+Rejected alternatives:
+
+- **Release CI in soroban-ret** — no write access to that repo.
+- **`cargo install` at container startup** — minutes-to-tens-of-minutes per
+  version on the 1-CPU node; toolchain only exists in the full (~2.8GB) image.
+- **Scheduled image rebuild** — still a rebuild/redeploy per release.
+- **In-cluster CronJob building on a PVC** — build load lands on the weak
+  production node.
+- **Authenticated upload endpoint on soroban-ret-web** — new public attack
+  surface accepting executables; `kubectl cp` reuses existing trust instead.
+- **GitHub release assets as transfer point** — workable, but requires runtime
+  egress from the pod (flaky on our node) and hosts artifacts publicly for no
+  benefit; `kubectl cp` is strictly simpler.
+
+## Design
+
+### 1. soroban-ret-web: engines directory scan
+
+- New flag/env: `--engines-dir` / `DEVTOOLS_ENGINES_DIR`. Default: unset
+  (feature disabled — local dev behavior unchanged).
+- `Registry` gains a third version source, alongside the builtin library and
+  `DEVTOOLS_RET_BINARIES` (both keep working unchanged): files in the engines
+  directory named exactly `soroban-ret-<semver>` (e.g. `soroban-ret-0.0.4`).
+- The directory is **rescanned on every `available()` / `resolve()` call**.
+  A readdir of a tiny directory costs microseconds; in exchange there are no
+  background tasks, no locks, no restarts — a newly uploaded file shows up in
+  the dropdown on the next `GET /versions`.
+- Scan filters:
+  - name must match `^soroban-ret-(\d+\.\d+\.\d+)$` (dotfiles, `.tmp` files and
+    anything else are ignored);
+  - the file must be a regular file (with the executable bit set, on Unix);
+  - a version equal to the builtin library version is ignored (the builtin
+    in-process engine produces richer output);
+  - on collision with a `DEVTOOLS_RET_BINARIES` entry, the env entry wins
+    (explicit operator config beats convention).
+- Resolved directory entries produce the existing `Engine::Cli` — the shell-out
+  path, 60s timeout, and error surfacing are all reused as-is.
+
+### 2. Fix: derive the builtin version at build time
+
+Delete the hardcoded `RET_VERSION` constant. A `build.rs` parses `Cargo.lock`,
+finds the `soroban-ret` package version, and exports it as a compile-time env
+(`cargo:rustc-env=RET_VERSION=...`) consumed via `env!("RET_VERSION")`.
+Bumping the dependency can then never desynchronize the reported version again.
+
+### 3. CI: `.github/workflows/devtools-engines.yml`
+
+Triggers: `schedule` (daily) + `workflow_dispatch`.
+
+Steps:
+
+1. Query crates.io for all non-yanked `soroban-ret-cli` versions.
+2. `kubectl exec` into the soroban-ret-web pod: `ls /engines` → currently
+   uploaded versions.
+3. For each missing version:
+   - `cargo install soroban-ret-cli --version X --target x86_64-unknown-linux-musl`
+     on the runner (musl → static binary, runs on any Linux including the K3S
+     node and the runner itself);
+   - smoke-test on the runner: disassemble a fixture WASM, non-empty output;
+   - upload atomically: `kubectl cp` to `/engines/.soroban-ret-<X>.tmp`, then
+     `kubectl exec mv` to the final name (the scanner never sees a partial
+     file).
+4. Log a summary of what was added / skipped.
+
+The upload logic lives in `DevTools/scripts/upload-engines.sh` so it can also be
+run by hand. The workflow targets production via the existing
+`secrets.KUBECONFIG`; the dev cluster (deployed locally by the maintainer) is
+served by running the same script manually with the local kubeconfig.
+
+### 4. Helm
+
+In the `sorobanretweb` subchart:
+
+- a `PersistentVolumeClaim` `soroban-ret-engines`, 1Gi,
+  `storageClassName: local-path` (same class postgres uses);
+- mounted at `/engines` in the pod;
+- env `DEVTOOLS_ENGINES_DIR=/engines`.
+
+The Deployment already uses the `Recreate` strategy (single 1-CPU node), so an
+RWO PVC introduces no rollout deadlock.
+
+`Backend/docker-compose.yml` gets an equivalent named volume + env so the
+compose path behaves the same.
+
+### 5. UI
+
+No changes. The dropdown already renders `available[]` from `/versions` and the
+selected version is already honored by every endpoint.
+
+### 6. Failure modes
+
+| Case | Behavior |
+|---|---|
+| Corrupt/foreign file in `/engines` | Filtered out by the scan (name/executable checks), or fails per-request exactly like a bad `DEVTOOLS_RET_BINARIES` path today; the UI already surfaces engine errors. |
+| PVC lost | Dropdown degrades to the builtin version; a manual workflow dispatch repopulates. |
+| crates.io unreachable in CI | Workflow run fails visibly; nothing changes in the cluster; next run catches up. |
+| Version yanked after upload | The binary stays available (already vetted); the workflow simply never re-uploads yanked versions. |
+| Security | No new public surface: writing to the PVC requires kubectl access, the same trust already granted to the deploy workflow. The scanner only executes files matching the strict naming convention on an operator-controlled volume. |
+
+## Testing
+
+- **Rust unit tests** for the directory scan: regex filtering, ignoring
+  dotfiles/tmp/non-executables, builtin shadowing, env-entry precedence,
+  natural version sort order.
+- **build.rs**: unit test asserting the exported version equals the
+  `soroban-ret` entry in `Cargo.lock`.
+- **Smoke test in CI** for every built binary before upload (fixture
+  disassembly on the runner).
+- **E2e on dev**: build 0.0.1/0.0.2, upload via the script, verify the dropdown
+  lists them without a pod restart and that disassembly through each version
+  works end-to-end.


### PR DESCRIPTION
## What

Every published `soroban-ret-cli` version now becomes selectable in the Dev Tools version dropdown automatically — no backend rebuild or redeploy when a new crate version comes out.

How it works:

- `soroban-ret-web` gets a new `DEVTOOLS_ENGINES_DIR` (mounted at `/engines` from a 1Gi PVC). The registry rescans that directory on every lookup, so a freshly uploaded binary shows up in the dropdown immediately — no restart. Strict filtering: only regular executable files named `soroban-ret-<x.y.z>`; dotfiles/`.tmp` staging files, symlinks and foreign names are ignored; the builtin library version always wins, and explicit `DEVTOOLS_RET_BINARIES` entries beat same-version dir files.
- A new `Sync Dev Tools engine versions` workflow (daily + manual) checks crates.io for non-yanked `soroban-ret-cli` versions, builds each missing one as a static x86_64 musl binary on the runner, smoke-tests it against a fixture contract, and uploads it atomically into the pod: streamed via `kubectl exec -i` to a dotfile staging name, then an atomic `mv`. The scanner can never see a partial file.
- The same script (`DevTools/scripts/upload-engines.sh`) runs by hand against any cluster; on non-Linux hosts it builds inside `rust:alpine` (pinned `--platform linux/amd64`).

## Bugs fixed along the way

- `main.rs` hardcoded `RET_VERSION = "0.0.2"` while Cargo.toml already depended on 0.0.3, so `/versions` misreported the current engine. The constant now comes from `Cargo.lock` at compile time via `build.rs`, with a guard test — this can't go stale again. (`Cargo.lock` itself was also still pinning 0.0.2 and got updated.)
- The Dockerfile didn't copy `build.rs` into the build stage — caught by the e2e run below.

## Verification

Local end-to-end with the slim image and a named volume:

1. Baseline: `GET /versions` → `{"current":"0.0.3","available":["0.0.3"],"compile_enabled":false}` (correct 0.0.3, was misreported before the build.rs fix)
2. Built `soroban-ret-cli` 0.0.2 in `rust:alpine`, dropped the binary into the volume — `available` became `["0.0.3","0.0.2"]` with zero restarts (container uptime verified)
3. `POST /disassemble/fixture` with `version: "0.0.2"` → `{"engine":"cli","engine_version":"0.0.2"}` with real decompiled source; 0.0.3 still routes to the in-process library engine
4. 13 unit tests on the registry scan (naming, precedence, builtin shadowing, sort order) + the Cargo.lock guard test, all green

Helm chart renders the PVC/mount/env cleanly; both docker-compose files validate.

## Deploy notes

- The PVC carries `helm.sh/resource-policy: keep`, so uninstall/reinstall doesn't lose uploaded engines.
- `cd-prod.yml` passes explicit values, so the new `global.devtools.engines.*` keys apply on a normal prod deploy. For a manual `--reuse-values` upgrade you'd need to pass them explicitly.
- After merging and deploying, dispatch `Sync Dev Tools engine versions` once — it will populate 0.0.1 and 0.0.2 (and 0.0.3, which stays shadowed by the builtin until the builtin moves ahead).

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core scanning, filtering, and atomic upload logic is well-tested and the RET_VERSION fix is straightforward.

All three moving parts (directory scanner, CI workflow, Helm PVC) are independently correct and thoroughly tested. The two observations are minor: a stopped Docker container that leaks on a rare docker cp failure (no correctness impact, cleans up on ephemeral runners) and an unpinned rust:alpine tag that could silently shift the toolchain. Neither affects the service's runtime behavior.

No files require special attention; upload-engines.sh has the minor Docker cleanup gap but it does not affect the uploaded binary or the service.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/devtools-engines.yml | New daily+manual workflow that checks crates.io and uploads missing engine binaries via kubectl exec. Correct concurrency guard, 60-min timeout, and least-privilege permissions. |
| DevTools/scripts/upload-engines.sh | Build-and-upload script with per-version error isolation, atomic two-phase upload, and version-format validation. Minor: Docker container can leak if docker cp fails after a successful build. |
| DevTools/soroban-ret-web/build.rs | New build script that extracts the soroban-ret version from Cargo.lock at compile time, fixing the stale RET_VERSION constant bug. Parser is correct and guarded by a test. |
| DevTools/soroban-ret-web/src/engine.rs | Adds scan_engines_dir() and cli_engines() for directory-based engine discovery. Strict naming filter, explicit symlink rejection, exec-bit check, and 13 unit tests cover all cases thoroughly. |
| Deploy/helm/charts/sorobanretweb/templates/soroban-ret-engines-pvc.yaml | New PVC template with helm.sh/resource-policy: keep to survive reinstalls. ReadWriteOnce access mode ties the pod to a single node, consistent with the documented single-node cluster. |
| DevTools/soroban-ret-web/Dockerfile | Adds build.rs to the COPY instruction in the build stage, fixing a prior omission that would have broken the image build once build.rs was introduced. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as GitHub Actions (devtools-engines.yml)
    participant Crates as crates.io API
    participant Runner as Build Runner
    participant Pod as soroban-ret-web pod (/engines PVC)
    participant Client as Browser / UI

    Note over CI: Daily cron or manual dispatch
    CI->>Crates: GET /api/v1/crates/soroban-ret-cli
    Crates-->>CI: Non-yanked version list
    CI->>Pod: kubectl exec: ls /engines
    Pod-->>CI: Already-uploaded filenames

    loop For each missing version
        CI->>Runner: cargo install soroban-ret-cli --version X (musl)
        Runner-->>CI: soroban-ret binary + smoke test
        CI->>Pod: "kubectl exec -i: cat > /engines/.soroban-ret-X.tmp"
        CI->>Pod: kubectl exec: chmod + mv .tmp to soroban-ret-X (atomic)
    end

    Note over Client: User opens /dev-tools
    Client->>Pod: GET /versions
    Pod->>Pod: scan_engines_dir() — readdir /engines
    Pod-->>Client: available versions list

    Client->>Pod: POST /disassemble with version
    Pod->>Pod: resolve() to Engine::Cli path
    Pod-->>Client: decompiled Rust source
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as GitHub Actions (devtools-engines.yml)
    participant Crates as crates.io API
    participant Runner as Build Runner
    participant Pod as soroban-ret-web pod (/engines PVC)
    participant Client as Browser / UI

    Note over CI: Daily cron or manual dispatch
    CI->>Crates: GET /api/v1/crates/soroban-ret-cli
    Crates-->>CI: Non-yanked version list
    CI->>Pod: kubectl exec: ls /engines
    Pod-->>CI: Already-uploaded filenames

    loop For each missing version
        CI->>Runner: cargo install soroban-ret-cli --version X (musl)
        Runner-->>CI: soroban-ret binary + smoke test
        CI->>Pod: "kubectl exec -i: cat > /engines/.soroban-ret-X.tmp"
        CI->>Pod: kubectl exec: chmod + mv .tmp to soroban-ret-X (atomic)
    end

    Note over Client: User opens /dev-tools
    Client->>Pod: GET /versions
    Pod->>Pod: scan_engines_dir() — readdir /engines
    Pod-->>Client: available versions list

    Client->>Pod: POST /disassemble with version
    Pod->>Pod: resolve() to Engine::Cli path
    Pod-->>Client: decompiled Rust source
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `DevTools/soroban-ret-web/src/engine.rs`, line 160-169 ([link](https://github.com/inferara/soroban-security-portal/blob/a1951855e3a297781ef1f559f511f6115f36c1c7/DevTools/soroban-ret-web/src/engine.rs#L160-L169)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Double directory scan on every unknown-version error**

   When `resolve()` doesn't find the requested version, the error message calls `self.available()` (line 168), which calls `cli_engines()` → `scan_engines_dir()`. That is the second `read_dir` for this request — the first was the `self.cli_engines().remove(v)` call on line 160. While a single readdir of a small directory is cheap, issuing two back-to-back scans per error response is unnecessary. The available list could be computed once and reused, or the error branch could consume the already-computed map.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Pin npm to 11 in the API image"](https://github.com/inferara/soroban-security-portal/commit/08b7287c292b055d3306cbb9812c27d194746af3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45344568)</sub>

<!-- /greptile_comment -->