### PR TITLE
feat(soroban-security-portal): make-categories-panes-works-as-filters-on-the-re

### DIFF
--- a/UI/src/components/details/CategoryFilterPanes.tsx
+++ b/UI/src/components/details/CategoryFilterPanes.tsx
@@ -1,0 +1,83 @@
+import { Box, Card, CardActionArea, Typography } from '@mui/material';
+import {
+  getCategoryImage,
+  VulnerabilityCategory,
+} from '../../api/soroban-security-portal/models/vulnerability';
+import type { PieChartDataPoint } from './SeverityPieChart';
+
+export interface CategoryFilterPanesProps {
+  data: PieChartDataPoint[];
+  selectedCategoryId: number | null;
+  onCategorySelect: (categoryId: number | null) => void;
+}
+
+/**
+ * Clickable category summary panes used to filter vulnerability lists on detail pages.
+ */
+export function CategoryFilterPanes({
+  data,
+  selectedCategoryId,
+  onCategorySelect,
+}: CategoryFilterPanesProps) {
+  if (data.length === 0) {
+    return null;
+  }
+
+  const handleClick = (categoryId: number) => {
+    onCategorySelect(selectedCategoryId === categoryId ? null : categoryId);
+  };
+
+  return (
+    <Box
+      role="group"
+      aria-label="Filter vulnerabilities by category"
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 1.5,
+      }}
+    >
+      {data.map((item) => {
+        const categoryId = Number(item.id);
+        const selected = selectedCategoryId === categoryId;
+        return (
+          <Card
+            key={item.id}
+            variant="outlined"
+            sx={{
+              flex: { xs: '1 1 calc(50% - 12px)', md: '1 1 auto' },
+              minWidth: { md: 150 },
+              borderColor: selected ? item.color : 'divider',
+              borderWidth: selected ? 2 : 1,
+              boxShadow: selected ? 2 : 0,
+            }}
+          >
+            <CardActionArea
+              onClick={() => handleClick(categoryId)}
+              aria-pressed={selected}
+              sx={{ p: 1.5, height: '100%' }}
+            >
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Box
+                  component="img"
+                  src={getCategoryImage(categoryId as VulnerabilityCategory)}
+                  alt=""
+                  width={28}
+                  height={28}
+                />
+                <Box sx={{ minWidth: 0, textAlign: 'left' }}>
+                  <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+                    {item.label}
+                  </Typography>
+                  <Typography variant="h6" sx={{ fontWeight: 700, lineHeight: 1.2 }}>
+                    {item.value}
+                  </Typography>
+                </Box>
+              </Box>
+            </CardActionArea>
+          </Card>
+        );
+      })}
+    </Box>
+  );
+}

--- a/UI/src/components/details/SeverityPieChart.tsx
+++ b/UI/src/components/details/SeverityPieChart.tsx
@@ -36,6 +36,10 @@ export interface SeverityPieChartProps {
   height?: number;
   /** Whether to show in a card wrapper (default: true) */
   showCard?: boolean;
+  /** Currently highlighted slice id (for linked filters) */
+  selectedItemId?: string | number | null;
+  /** Called when a slice is clicked; receives the data point id */
+  onItemClick?: (id: string | number) => void;
 }
 
 /**
@@ -74,6 +78,8 @@ export function SeverityPieChart({
   emptyMessage = 'No data available',
   height = 300,
   showCard = true,
+  selectedItemId = null,
+  onItemClick,
 }: SeverityPieChartProps) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
@@ -81,6 +87,11 @@ export function SeverityPieChart({
   const chartWidth = isMobile ? 280 : 350;
 
   const hasData = data.length > 0 && data.some(d => d.value > 0);
+
+  const seriesId = 'severity-pie-series';
+
+  const selectedDataIndex =
+    selectedItemId != null ? data.findIndex((d) => d.id === selectedItemId) : -1;
 
   const content = (
     <>
@@ -93,10 +104,26 @@ export function SeverityPieChart({
           <PieChart
             series={[
               {
+                id: seriesId,
                 data,
                 highlightScope: { fade: 'global', highlight: 'item' },
               },
             ]}
+            highlightedItem={
+              selectedDataIndex >= 0
+                ? { seriesId, dataIndex: selectedDataIndex }
+                : null
+            }
+            onItemClick={
+              onItemClick
+                ? (_event, identifier) => {
+                    const point = data[identifier.dataIndex];
+                    if (point) {
+                      onItemClick(point.id);
+                    }
+                  }
+                : undefined
+            }
             width={chartWidth}
             height={height}
           />

--- a/UI/src/components/details/__tests__/CategoryFilterPanes.test.tsx
+++ b/UI/src/components/details/__tests__/CategoryFilterPanes.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { CategoryFilterPanes } from '../CategoryFilterPanes';
+import { VulnerabilityCategory } from '../../../api/soroban-security-portal/models/vulnerability';
+
+const theme = createTheme();
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ThemeProvider theme={theme}>{children}</ThemeProvider>
+);
+
+const sampleData = [
+  {
+    id: VulnerabilityCategory.Valid,
+    value: 2,
+    label: 'Valid (Fixed)',
+    color: '#2e7d32',
+  },
+  {
+    id: VulnerabilityCategory.ValidNotFixed,
+    value: 1,
+    label: 'Valid (Not Fixed)',
+    color: '#c62828',
+  },
+];
+
+describe('CategoryFilterPanes', () => {
+  it('calls onCategorySelect with category id when a pane is clicked', () => {
+    const onCategorySelect = vi.fn();
+    render(
+      <CategoryFilterPanes
+        data={sampleData}
+        selectedCategoryId={null}
+        onCategorySelect={onCategorySelect}
+      />,
+      { wrapper }
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Valid \(Fixed\)/i }));
+    expect(onCategorySelect).toHaveBeenCalledWith(VulnerabilityCategory.Valid);
+  });
+
+  it('clears selection when the active pane is clicked again', () => {
+    const onCategorySelect = vi.fn();
+    render(
+      <CategoryFilterPanes
+        data={sampleData}
+        selectedCategoryId={VulnerabilityCategory.ValidNotFixed}
+        onCategorySelect={onCategorySelect}
+      />,
+      { wrapper }
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Valid \(Not Fixed\)/i }));
+    expect(onCategorySelect).toHaveBeenCalledWith(null);
+  });
+});

--- a/UI/src/components/details/index.ts
+++ b/UI/src/components/details/index.ts
@@ -72,6 +72,9 @@ export {
 } from './SeverityPieChart';
 export type { SeverityPieChartProps, PieChartDataPoint } from './SeverityPieChart';
 
+export { CategoryFilterPanes } from './CategoryFilterPanes';
+export type { CategoryFilterPanesProps } from './CategoryFilterPanes';
+
 // Error Handling
 export { ChartErrorBoundary, withChartErrorBoundary } from './ChartErrorBoundary';
 export type { ChartErrorBoundaryProps, ChartErrorInfo } from './ChartErrorBoundary';

--- a/UI/src/features/pages/regular/report-details/report-details.tsx
+++ b/UI/src/features/pages/regular/report-details/report-details.tsx
@@ -60,6 +60,7 @@ import {
   SeverityPieChart,
   transformSeverityBreakdown,
   transformCategoryBreakdown,
+  CategoryFilterPanes,
 } from '../../../../components/details';
 import { formatDateLong } from '../../../../utils';
 import { getSeverityColor } from '../../../../utils/color-utils';
@@ -96,6 +97,11 @@ export const ReportDetails: FC = () => {
   const views = usePageViewTracking(PageViewEntityType.Report, report?.id);
 
   const [commentCount, setCommentCount] = useState<number | null>(null);
+  const [selectedCategoryId, setSelectedCategoryId] = useState<VulnerabilityCategory | null>(null);
+
+  useEffect(() => {
+    setSelectedCategoryId(null);
+  }, [reportId]);
   useEffect(() => {
     if (reportId > 0) {
       getCommentCountCall(CommentEntityType.Report, reportId)
@@ -141,6 +147,23 @@ export const ReportDetails: FC = () => {
       return bSeverity - aSeverity;
     });
   }, [vulnerabilities]);
+
+  const toggleCategoryFilter = (categoryId: number | null) => {
+    if (categoryId === null) {
+      setSelectedCategoryId(null);
+      return;
+    }
+    setSelectedCategoryId((prev) =>
+      prev === categoryId ? null : (categoryId as VulnerabilityCategory)
+    );
+  };
+
+  const filteredVulnerabilities = useMemo(() => {
+    if (selectedCategoryId === null) {
+      return sortedVulnerabilities;
+    }
+    return sortedVulnerabilities.filter((v) => v.category === selectedCategoryId);
+  }, [sortedVulnerabilities, selectedCategoryId]);
 
   const handleReportDownload = async (reportName: string, reportId: number) => {
     if (!isAuthorized(auth)) {
@@ -316,20 +339,40 @@ export const ReportDetails: FC = () => {
                     data={vulnCategoryData}
                     title="Fix Status"
                     emptyMessage="No vulnerability data available"
+                    selectedItemId={selectedCategoryId}
+                    onItemClick={(id) => toggleCategoryFilter(Number(id))}
                   />
                 </Box>
+
+                {vulnCategoryData.length > 0 && (
+                  <Box sx={{ mb: 3 }}>
+                    <CategoryFilterPanes
+                      data={vulnCategoryData}
+                      selectedCategoryId={selectedCategoryId}
+                      onCategorySelect={toggleCategoryFilter}
+                    />
+                  </Box>
+                )}
 
                 {/* Vulnerabilities List */}
                 <Card>
                   <CardContent>
                     <Typography variant="h6" sx={{ mb: 2, fontWeight: 600 }}>
                       <BugReport sx={{ mr: 1, verticalAlign: 'middle' }} />
-                      Vulnerabilities ({vulnerabilities.length})
+                      Vulnerabilities ({filteredVulnerabilities.length}
+                      {selectedCategoryId !== null ? ` of ${vulnerabilities.length}` : ''})
                     </Typography>
 
-                    {sortedVulnerabilities.length > 0 ? (
+                    {selectedCategoryId !== null && (
+                      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                        Showing {getCategoryLabel(selectedCategoryId)} — click the category again to
+                        show all
+                      </Typography>
+                    )}
+
+                    {filteredVulnerabilities.length > 0 ? (
                       <List sx={{ maxHeight: 400, overflow: 'auto' }}>
-                        {sortedVulnerabilities.map((vulnerability, index) => (
+                        {filteredVulnerabilities.map((vulnerability, index) => (
                           <Box key={vulnerability.id}>
                             <ListItem disablePadding>
                               <ListItemButton
@@ -429,13 +472,15 @@ export const ReportDetails: FC = () => {
                                 />
                               </ListItemButton>
                             </ListItem>
-                            {index < sortedVulnerabilities.length - 1 && <Divider />}
+                            {index < filteredVulnerabilities.length - 1 && <Divider />}
                           </Box>
                         ))}
                       </List>
                     ) : (
                       <Typography color="text.secondary" sx={{ textAlign: 'center', py: 4 }}>
-                        No vulnerabilities found in this report
+                        {selectedCategoryId !== null
+                          ? 'No vulnerabilities match this category filter'
+                          : 'No vulnerabilities found in this report'}
                       </Typography>
                     )}
                   </CardContent>


### PR DESCRIPTION
Closes #146

## Summary
- Make categories panes works as filters on the report-details page

## Test plan
- [ ] Relevant tests pass locally
- [ ] Manual verification on affected UI or API paths

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

Safe to merge; the feature works correctly for all tested user paths and the filter state resets cleanly on report navigation.

The filter logic in toggleCategoryFilter and CategoryFilterPanes.handleClick each contain overlapping toggle decisions, with the two callers relying on different halves of that logic. While this produces correct results today, it leaves an invisible contract that could silently break if a new caller passes the raw ID expecting the parent to toggle. No data is lost or corrupted, but the inconsistency warrants a tidy-up before the pattern spreads.

UI/src/features/pages/regular/report-details/report-details.tsx — the split toggle responsibility between toggleCategoryFilter and CategoryFilterPanes.handleClick.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| UI/src/components/details/CategoryFilterPanes.tsx | New component that renders clickable category panes; toggle-on-click logic is correct and accessibility attributes (aria-pressed, role="group") are in place. |
| UI/src/components/details/SeverityPieChart.tsx | Adds optional selectedItemId/onItemClick props with correct series-level highlighting; hardcoded seriesId is safe because each PieChart instance is independent. |
| UI/src/features/pages/regular/report-details/report-details.tsx | Wires up filter state and filteredVulnerabilities memo correctly; two adjacent useEffect hooks lack a separating blank line, and toggleCategoryFilter has a split toggle responsibility with CategoryFilterPanes. |
| UI/src/components/details/__tests__/CategoryFilterPanes.test.tsx | Covers deselect-on-click-again and initial selection; missing a test for switching selection from one active category to a different one. |
| UI/src/components/details/index.ts | Exports CategoryFilterPanes and its prop type, placed correctly in the barrel file. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant PieChart as SeverityPieChart (Fix Status)
    participant Panes as CategoryFilterPanes
    participant RD as ReportDetails state
    participant List as Vulnerabilities List

    Note over User,List: Selecting a category via the pie chart
    User->>PieChart: "click slice (id=1)"
    PieChart->>RD: onItemClick(1) → toggleCategoryFilter(1)
    RD->>RD: "setSelectedCategoryId(prev => prev===1 ? null : 1)"
    RD-->>PieChart: "selectedItemId=1 (slice highlighted)"
    RD-->>Panes: "selectedCategoryId=1 (pane highlighted)"
    RD-->>List: filteredVulnerabilities filtered by category 1

    Note over User,List: Deselecting via a category pane
    User->>Panes: "click active pane (id=1)"
    Panes->>Panes: "handleClick: selectedCategoryId===1 → pass null"
    Panes->>RD: onCategorySelect(null) → toggleCategoryFilter(null)
    RD->>RD: setSelectedCategoryId(null)
    RD-->>PieChart: "selectedItemId=null (no highlight)"
    RD-->>Panes: "selectedCategoryId=null (no pane highlighted)"
    RD-->>List: "filteredVulnerabilities = sortedVulnerabilities (all shown)"

    Note over User,List: Switching between reports resets filter
    User->>RD: navigate to new reportId
    RD->>RD: useEffect([reportId]) → setSelectedCategoryId(null)
```

<sub>Reviews (1): Last reviewed commit: ["feat(report-details): filter vulnerabili..."](https://github.com/inferara/soroban-security-portal/commit/0f3a0dd505fbfdc0446765297213c870a67df36e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46876171)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->