### PR TITLE
Remove Unused Discord Role Mapping Code from TokenModel

### DIFF
--- a/Backend/SorobanSecurityPortalApi/Models/ViewModels/TokenModel.cs
+++ b/Backend/SorobanSecurityPortalApi/Models/ViewModels/TokenModel.cs
@@ -43,27 +43,7 @@ namespace SorobanSecurityPortalApi.Models.ViewModels
         public bool IsPilot() => this.IsActive() && this.Roles.Contains("1082331251899379762");
         // Tier 2
         public bool IsNavigator() => this.IsActive() && this.Roles.Contains("1082353855041392731");
-        // Tier 1
-        public bool IsPathfinder() => this.IsActive() && this.Roles.Contains("1082357854926807111");
         // SCF Project
         public bool IsScfProject() => this.IsActive() && this.Roles.Contains("1082358910805090367");
-
-        public StellarDevelopersGuildRole GetRole()
-        {
-            if (this.IsPilot()) return StellarDevelopersGuildRole.Pilot;
-            if (this.IsNavigator()) return StellarDevelopersGuildRole.Navigator;
-            if (this.IsPathfinder()) return StellarDevelopersGuildRole.Pathfinder;
-            if (this.IsScfProject()) return StellarDevelopersGuildRole.ScfProject;
-            return StellarDevelopersGuildRole.None; // Default role
-        }
-    }
-
-    public enum StellarDevelopersGuildRole
-    {
-        None = 0,
-        Pilot = 1,
-        Navigator = 2,
-        Pathfinder = 3,
-        ScfProject = 4
     }
 }


### PR DESCRIPTION
##closed #221 

The codebase contains two Discord role-mapping implementations, but only one is actually used. The authoritative role assignment logic resides in ConnectService.GetRoleFromDiscordGuild(). The alternate implementation in TokenModel—GetRole(), the StellarDevelopersGuildRole enum, and the IsPathfinder() helper—is unused and only references itself.

This redundant code is misleading because it appears to be responsible for Discord role mapping when, in reality, it has no effect on authentication or role assignment.

Requirements
    Verify that GetRole(), StellarDevelopersGuildRole, and IsPathfinder() have no external references by searching the entire solution.
    Remove:
    GetRole()
    StellarDevelopersGuildRole enum
    IsPathfinder()
    Do not modify the actual role-mapping implementation in ConnectService.GetRoleFromDiscordGuild().
    Build the solution and run the full test suite to ensure no regressions.
Acceptance Criteria
    The unused role-mapping code has been completely removed.
    The solution builds successfully.
    All tests pass.
    Discord login and role assignment behavior remain unchanged, as the removed code was never invoked.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge — the deleted code was never reachable from any live call site, and the active role-check methods are untouched.

The three removed members had no callers outside their own class. ConnectService relies on IsPilot(), IsNavigator(), and IsScfProject(), all of which remain intact. Discord login and role assignment behavior is unchanged before and after this diff.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| Backend/SorobanSecurityPortalApi/Models/ViewModels/TokenModel.cs | Removed unused IsPathfinder(), GetRole(), and StellarDevelopersGuildRole enum; active role-check helpers (IsPilot, IsNavigator, IsScfProject) are preserved and still consumed by ConnectService. |

<sub>Reviews (1): Last reviewed commit: ["Remove dead StellarDevelopersGuildRole e..."](https://github.com/inferara/soroban-security-portal/commit/2d9981a066e098625f1d2e350af8b544564727b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46979952)</sub>

<!-- /greptile_comment -->