### PR TITLE
feat: add social linking for GitHub and X on edit profile page

### DIFF
--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/UserService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/UserService.cs
@@ -80,29 +80,19 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             login.FullName = loginModel.FullName;
             login.PersonalInfo = loginModel.PersonalInfo;
 
-            // Merge connected accounts: the DB is authoritative for SSO accounts
-            // (Google, Discord, etc.) — the client is NEVER trusted for those. Only
-            // client-managed social links (GitHub, X) are taken from the submission.
-            // This prevents stale client snapshots from resurrecting disconnected SSO
-            // accounts or overwriting current SSO identifiers with stale ones.
+            // Only client-managed social links (GitHub, X) are taken from the
+            // submission.  SSO accounts (Google, Discord, etc.) are NEVER trusted
+            // from the client — they are managed exclusively by the OAuth flow.
             var clientManagedServices = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "GitHub", "X"
             };
 
-            // Start from DB state: preserve every non-client-managed account as-is
-            var merged = login.ConnectedAccounts?
-                .Where(ca => !clientManagedServices.Contains(ca.ServiceName))
-                .ToList() ?? new List<ConnectedAccountModel>();
-
-            // Add only the client-managed accounts from the submission
+            // Collect the client-managed accounts the user wants to set
             var submittedAccounts = loginModel.ConnectedAccounts ?? new List<ConnectedAccountModel>();
             var clientSubmitted = submittedAccounts
                 .Where(ca => clientManagedServices.Contains(ca.ServiceName))
                 .ToList();
-
-            merged.AddRange(clientSubmitted);
-            login.ConnectedAccounts = merged;
 
             // Detect if user is changing their avatar (either uploading new or removing)
             // Set IsAvatarManuallySet=true to prevent SSO from overwriting
@@ -113,7 +103,37 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
                 login.IsAvatarManuallySet = true;
             }
 
-            await _loginProcessor.Update(login);
+            // Re-read the login entity from the DB immediately before saving so we
+            // merge onto the freshest SSO state.  This closes the window where a
+            // concurrent OAuth callback could add or modify an SSO connection and
+            // have it silently overwritten by our update.
+            var freshLogin = await _loginProcessor.GetById(loginId);
+            if (freshLogin == null)
+                return false;
+
+            // Carry forward the fields SelfUpdate is allowed to change.
+            // ConnectedAccounts: keep fresh SSO state; replace only GitHub/X from
+            // the submission.
+            freshLogin.FullName = login.FullName;
+            freshLogin.PersonalInfo = login.PersonalInfo;
+
+            // Only copy Image/IsAvatarManuallySet when the user actually changed
+            // the avatar.  Otherwise let the fresh read keep its values so we don't
+            // silently overwrite a concurrent SSO avatar sync.
+            if (imageChanged)
+            {
+                freshLogin.Image = login.Image;
+                freshLogin.IsAvatarManuallySet = true;
+            }
+
+            var merged = freshLogin.ConnectedAccounts?
+                .Where(ca => !clientManagedServices.Contains(ca.ServiceName))
+                .ToList() ?? new List<ConnectedAccountModel>();
+
+            merged.AddRange(clientSubmitted);
+            freshLogin.ConnectedAccounts = merged;
+
+            await _loginProcessor.Update(freshLogin);
             return true;
         }
 

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/UserService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/UserService.cs
@@ -79,7 +79,35 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             var loginModel = _mapper.Map<LoginModel>(userUpdateSelfViewModel);
             login.FullName = loginModel.FullName;
             login.PersonalInfo = loginModel.PersonalInfo;
-            login.ConnectedAccounts = loginModel.ConnectedAccounts;
+
+            // Merge connected accounts: use submitted values for accounts the client manages
+            // (GitHub, X), but preserve existing SSO accounts (Google, Discord, etc.) the
+            // client may not have in its stale snapshot.  This prevents accidentally
+            // dropping an SSO connection added after the edit page loaded while still
+            // allowing intentional removal of social links.
+            //
+            // Services the edit-profile client manages exclusively — these are never
+            // auto-preserved; their presence is controlled entirely by the submission.
+            var clientManagedServices = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "GitHub", "X"
+            };
+
+            var submittedAccounts = loginModel.ConnectedAccounts ?? new List<ConnectedAccountModel>();
+            var submittedServiceNames = submittedAccounts
+                .Select(ca => ca.ServiceName)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            // Preserve any existing DB account whose service is NOT in the submission
+            // AND is NOT a client-managed service (social links the user may have cleared).
+            var preservedAccounts = login.ConnectedAccounts?
+                .Where(ca => !submittedServiceNames.Contains(ca.ServiceName)
+                          && !clientManagedServices.Contains(ca.ServiceName))
+                .ToList() ?? new List<ConnectedAccountModel>();
+
+            login.ConnectedAccounts = submittedAccounts
+                .Concat(preservedAccounts)
+                .ToList();
 
             // Detect if user is changing their avatar (either uploading new or removing)
             // Set IsAvatarManuallySet=true to prevent SSO from overwriting

--- a/Backend/SorobanSecurityPortalApi/Services/ControllersServices/UserService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ControllersServices/UserService.cs
@@ -80,34 +80,29 @@ namespace SorobanSecurityPortalApi.Services.ControllersServices
             login.FullName = loginModel.FullName;
             login.PersonalInfo = loginModel.PersonalInfo;
 
-            // Merge connected accounts: use submitted values for accounts the client manages
-            // (GitHub, X), but preserve existing SSO accounts (Google, Discord, etc.) the
-            // client may not have in its stale snapshot.  This prevents accidentally
-            // dropping an SSO connection added after the edit page loaded while still
-            // allowing intentional removal of social links.
-            //
-            // Services the edit-profile client manages exclusively — these are never
-            // auto-preserved; their presence is controlled entirely by the submission.
+            // Merge connected accounts: the DB is authoritative for SSO accounts
+            // (Google, Discord, etc.) — the client is NEVER trusted for those. Only
+            // client-managed social links (GitHub, X) are taken from the submission.
+            // This prevents stale client snapshots from resurrecting disconnected SSO
+            // accounts or overwriting current SSO identifiers with stale ones.
             var clientManagedServices = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 "GitHub", "X"
             };
 
-            var submittedAccounts = loginModel.ConnectedAccounts ?? new List<ConnectedAccountModel>();
-            var submittedServiceNames = submittedAccounts
-                .Select(ca => ca.ServiceName)
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-            // Preserve any existing DB account whose service is NOT in the submission
-            // AND is NOT a client-managed service (social links the user may have cleared).
-            var preservedAccounts = login.ConnectedAccounts?
-                .Where(ca => !submittedServiceNames.Contains(ca.ServiceName)
-                          && !clientManagedServices.Contains(ca.ServiceName))
+            // Start from DB state: preserve every non-client-managed account as-is
+            var merged = login.ConnectedAccounts?
+                .Where(ca => !clientManagedServices.Contains(ca.ServiceName))
                 .ToList() ?? new List<ConnectedAccountModel>();
 
-            login.ConnectedAccounts = submittedAccounts
-                .Concat(preservedAccounts)
+            // Add only the client-managed accounts from the submission
+            var submittedAccounts = loginModel.ConnectedAccounts ?? new List<ConnectedAccountModel>();
+            var clientSubmitted = submittedAccounts
+                .Where(ca => clientManagedServices.Contains(ca.ServiceName))
                 .ToList();
+
+            merged.AddRange(clientSubmitted);
+            login.ConnectedAccounts = merged;
 
             // Detect if user is changing their avatar (either uploading new or removing)
             // Set IsAvatarManuallySet=true to prevent SSO from overwriting

--- a/UI/src/features/pages/regular/profile/edit-profile.tsx
+++ b/UI/src/features/pages/regular/profile/edit-profile.tsx
@@ -76,16 +76,22 @@ const AccountName = styled(Typography)(({ theme }) => ({
   fontWeight: 500,
 }));
 
-/** GitHub profile URL regex: https://github.com/username */
-const GITHUB_URL_REGEX = /^https?:\/\/(www\.)?github\.com\/[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\/?$/;
-/** X (Twitter) profile URL regex: https://x.com/username or https://twitter.com/username */
-const X_URL_REGEX = /^https?:\/\/(www\.)?(x\.com|twitter\.com)\/[a-zA-Z0-9_]{1,15}\/?$/;
+/** GitHub profile URL regex: https://github.com/username (https required) */
+const GITHUB_URL_REGEX = /^https:\/\/(www\.)?github\.com\/[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\/?$/;
+/** X (Twitter) profile URL regex: https://x.com/username or https://twitter.com/username (https required) */
+const X_URL_REGEX = /^https:\/\/(www\.)?(x\.com|twitter\.com)\/[a-zA-Z0-9_]{1,15}\/?$/;
 
 /** Extracts the service-specific AccountId from user's connected accounts, or returns empty string */
 const getConnectedAccountId = (accounts: ConnectedAccountItem[] | undefined, serviceName: string): string => {
   if (!accounts) return '';
   const match = accounts.find(a => a.serviceName === serviceName);
   return match?.accountId || '';
+};
+
+/** Normalizes a social URL to use https scheme (upgrades http for legacy data). */
+const normalizeUrl = (url: string): string => {
+  if (!url) return url;
+  return url.replace(/^http:\/\//i, 'https://');
 };
 
 /** Returns the SSO-connected accounts only (Google, Discord) */
@@ -117,8 +123,8 @@ export const EditProfile: React.FC = () => {
       setName(user.fullName || '');
       setUsername(user.login || '');
       setAboutYou(user.personalInfo || '');
-      setGithubUrl(getConnectedAccountId(user.connectedAccounts, 'GitHub'));
-      setXUrl(getConnectedAccountId(user.connectedAccounts, 'X'));
+      setGithubUrl(normalizeUrl(getConnectedAccountId(user.connectedAccounts, 'GitHub')));
+      setXUrl(normalizeUrl(getConnectedAccountId(user.connectedAccounts, 'X')));
     }
   }, [user]);
 
@@ -198,14 +204,14 @@ export const EditProfile: React.FC = () => {
       ),
     ];
 
-    // Add GitHub if URL is provided
+    // Add GitHub if URL is provided (normalized to https)
     if (githubUrl.trim()) {
-      updatedConnectedAccounts.push({ serviceName: 'GitHub', accountId: githubUrl.trim() });
+      updatedConnectedAccounts.push({ serviceName: 'GitHub', accountId: normalizeUrl(githubUrl.trim()) });
     }
 
-    // Add X if URL is provided
+    // Add X if URL is provided (normalized to https)
     if (xUrl.trim()) {
-      updatedConnectedAccounts.push({ serviceName: 'X', accountId: xUrl.trim() });
+      updatedConnectedAccounts.push({ serviceName: 'X', accountId: normalizeUrl(xUrl.trim()) });
     }
 
     const updateSuccess = await updateProfile({

--- a/UI/src/features/pages/regular/profile/edit-profile.tsx
+++ b/UI/src/features/pages/regular/profile/edit-profile.tsx
@@ -94,6 +94,15 @@ const normalizeUrl = (url: string): string => {
   return url.replace(/^http:\/\//i, 'https://');
 };
 
+/** Validates + normalizes a social URL for safe preview. Returns null if unsafe. */
+const getSafePreviewUrl = (serviceName: string, url: string): string | null => {
+  if (!url) return null;
+  const normalized = normalizeUrl(url.trim());
+  if (serviceName === 'GitHub' && GITHUB_URL_REGEX.test(normalized)) return normalized;
+  if (serviceName === 'X' && X_URL_REGEX.test(normalized)) return normalized;
+  return null;
+};
+
 /** Returns the SSO-connected accounts only (Google, Discord) */
 const getSSOAccounts = (accounts: ConnectedAccountItem[] | undefined): ConnectedAccountItem[] => {
   if (!accounts) return [];
@@ -379,7 +388,10 @@ export const EditProfile: React.FC = () => {
                         <Tooltip title="Open profile">
                           <IconButton
                             size="small"
-                            onClick={() => window.open(githubUrl, '_blank', 'noopener,noreferrer')}
+                            onClick={() => {
+                              const safe = getSafePreviewUrl('GitHub', githubUrl);
+                              if (safe) window.open(safe, '_blank', 'noopener,noreferrer');
+                            }}
                             edge="end"
                           >
                             <OpenInNewIcon fontSize="small" />
@@ -438,7 +450,10 @@ export const EditProfile: React.FC = () => {
                         <Tooltip title="Open profile">
                           <IconButton
                             size="small"
-                            onClick={() => window.open(xUrl, '_blank', 'noopener,noreferrer')}
+                            onClick={() => {
+                              const safe = getSafePreviewUrl('X', xUrl);
+                              if (safe) window.open(safe, '_blank', 'noopener,noreferrer');
+                            }}
                             edge="end"
                           >
                             <OpenInNewIcon fontSize="small" />

--- a/UI/src/features/pages/regular/profile/edit-profile.tsx
+++ b/UI/src/features/pages/regular/profile/edit-profile.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { TextField, Button, Grid, Paper, Typography, Box } from '@mui/material';
+import { TextField, Button, Grid, Paper, Typography, Box, IconButton, InputAdornment, Tooltip } from '@mui/material';
 import { useEditProfile } from './hooks/edit-profile.hook';
 import { styled } from '@mui/material/styles';
 import { showError, showSuccess } from '../../../dialog-handler/dialog-handler';
@@ -10,8 +10,12 @@ import GoogleIcon from '@mui/icons-material/Google';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import XIcon from '@mui/icons-material/X';
 import ChatIcon from '@mui/icons-material/Chat';
+import LinkIcon from '@mui/icons-material/Link';
+import LinkOffIcon from '@mui/icons-material/LinkOff';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { AvatarUpload } from '../../../../components/AvatarUpload';
 import { getUserInitials } from '../../../../utils/user-utils';
+import { ConnectedAccountItem } from '../../../../api/soroban-security-portal/models/user';
 
 const ProfileContainer = styled(Box)(({ theme }) => ({
   minHeight: '100vh',
@@ -72,6 +76,24 @@ const AccountName = styled(Typography)(({ theme }) => ({
   fontWeight: 500,
 }));
 
+/** GitHub profile URL regex: https://github.com/username */
+const GITHUB_URL_REGEX = /^https?:\/\/(www\.)?github\.com\/[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\/?$/;
+/** X (Twitter) profile URL regex: https://x.com/username or https://twitter.com/username */
+const X_URL_REGEX = /^https?:\/\/(www\.)?(x\.com|twitter\.com)\/[a-zA-Z0-9_]{1,15}\/?$/;
+
+/** Extracts the service-specific AccountId from user's connected accounts, or returns empty string */
+const getConnectedAccountId = (accounts: ConnectedAccountItem[] | undefined, serviceName: string): string => {
+  if (!accounts) return '';
+  const match = accounts.find(a => a.serviceName === serviceName);
+  return match?.accountId || '';
+};
+
+/** Returns the SSO-connected accounts only (Google, Discord) */
+const getSSOAccounts = (accounts: ConnectedAccountItem[] | undefined): ConnectedAccountItem[] => {
+  if (!accounts) return [];
+  return accounts.filter(a => a.serviceName === 'Google' || a.serviceName === 'Discord');
+};
+
 export const EditProfile: React.FC = () => {
   const navigate = useNavigate();
   const { themeMode } = useThemeContext();
@@ -79,6 +101,10 @@ export const EditProfile: React.FC = () => {
   const [username, setUsername] = useState('');
   const [aboutYou, setAboutYou] = useState('');
   const [image, setImage] = useState<string | null>(null);
+  const [githubUrl, setGithubUrl] = useState('');
+  const [xUrl, setXUrl] = useState('');
+  const [githubError, setGithubError] = useState('');
+  const [xError, setXError] = useState('');
 
   const {
     user,
@@ -91,14 +117,51 @@ export const EditProfile: React.FC = () => {
       setName(user.fullName || '');
       setUsername(user.login || '');
       setAboutYou(user.personalInfo || '');
+      setGithubUrl(getConnectedAccountId(user.connectedAccounts, 'GitHub'));
+      setXUrl(getConnectedAccountId(user.connectedAccounts, 'X'));
     }
   }, [user]);
+
+  const validateGithubUrl = (url: string): boolean => {
+    if (!url.trim()) {
+      setGithubError('');
+      return true;
+    }
+    if (!GITHUB_URL_REGEX.test(url.trim())) {
+      setGithubError('Enter a valid GitHub profile URL (e.g., https://github.com/username)');
+      return false;
+    }
+    setGithubError('');
+    return true;
+  };
+
+  const validateXUrl = (url: string): boolean => {
+    if (!url.trim()) {
+      setXError('');
+      return true;
+    }
+    if (!X_URL_REGEX.test(url.trim())) {
+      setXError('Enter a valid X/Twitter profile URL (e.g., https://x.com/username)');
+      return false;
+    }
+    setXError('');
+    return true;
+  };
 
   const handleSaveProfile = async () => {
     if (!name.trim()) {
       showError('Name is required');
       return;
     }
+
+    // Validate social URLs before saving
+    const isGithubValid = validateGithubUrl(githubUrl);
+    const isXValid = validateXUrl(xUrl);
+    if (!isGithubValid || !isXValid) {
+      showError('Please fix the social profile URL errors before saving.');
+      return;
+    }
+
     let avatarImage = image;
 
     if (!avatarImage) {
@@ -127,11 +190,30 @@ export const EditProfile: React.FC = () => {
       }
     }
 
+    // Build connected accounts: preserve non-editable accounts (SSO, etc.) + add/update social links
+    const updatedConnectedAccounts: ConnectedAccountItem[] = [
+      // Preserve all accounts that are not GitHub or X (e.g., Google SSO, Discord SSO, future types)
+      ...(user?.connectedAccounts || []).filter(
+        a => a.serviceName !== 'GitHub' && a.serviceName !== 'X'
+      ),
+    ];
+
+    // Add GitHub if URL is provided
+    if (githubUrl.trim()) {
+      updatedConnectedAccounts.push({ serviceName: 'GitHub', accountId: githubUrl.trim() });
+    }
+
+    // Add X if URL is provided
+    if (xUrl.trim()) {
+      updatedConnectedAccounts.push({ serviceName: 'X', accountId: xUrl.trim() });
+    }
+
     const updateSuccess = await updateProfile({
       fullName: name,
       login: username,
       personalInfo: aboutYou,
       image: avatarImage || undefined,
+      connectedAccounts: updatedConnectedAccounts,
     });
 
     if (updateSuccess) {
@@ -142,11 +224,19 @@ export const EditProfile: React.FC = () => {
     }
   };
 
-  const connectedAccounts = [
-    { name: 'Google account', icon: <GoogleIcon sx={{ color: 'primary.main' }} />, connected: false },
-    { name: 'Discord account', icon: <ChatIcon sx={{ color: 'primary.main' }} />, connected: false },
-    { name: 'GitHub account', icon: <GitHubIcon sx={{ color: 'primary.main' }} />, connected: false },
-    { name: 'X account', icon: <XIcon sx={{ color: 'primary.main' }} />, connected: false },
+  const handleDisconnectGithub = () => {
+    setGithubUrl('');
+    setGithubError('');
+  };
+
+  const handleDisconnectX = () => {
+    setXUrl('');
+    setXError('');
+  };
+
+  const ssoAccounts = [
+    { name: 'Google account', icon: <GoogleIcon sx={{ color: 'primary.main' }} />, connected: getSSOAccounts(user?.connectedAccounts).some(a => a.serviceName === 'Google') },
+    { name: 'Discord account', icon: <ChatIcon sx={{ color: 'primary.main' }} />, connected: getSSOAccounts(user?.connectedAccounts).some(a => a.serviceName === 'Discord') },
   ];
 
   return (
@@ -224,7 +314,9 @@ export const EditProfile: React.FC = () => {
           <SectionTitle>
             Connected accounts
           </SectionTitle>
-          {connectedAccounts.map((account, index) => (
+
+          {/* SSO accounts (Google, Discord) — read-only; connected via OAuth login */}
+          {ssoAccounts.map((account, index) => (
             <AccountItem key={index}>
               <AccountInfo>
                 <AccountIcon>
@@ -234,21 +326,135 @@ export const EditProfile: React.FC = () => {
                   {account.name}
                 </AccountName>
               </AccountInfo>
-              <Button disabled={false} variant="contained" sx={{
-                color: 'background.default',
-                borderColor: 'primary.main',
-                backgroundColor: 'primary.main',
-                textTransform: 'none',
-                '&:hover': {
-                  backgroundColor: 'rgba(250, 250, 250, 0.1)',
-                  borderColor: 'primary.main',
-                  color: 'primary.main',
-                },
-              }}>
-                Connect
-              </Button>
+              <Typography
+                variant="body2"
+                sx={{
+                  color: account.connected ? 'success.main' : 'text.disabled',
+                  fontWeight: 500,
+                }}
+              >
+                {account.connected ? 'Connected via SSO' : 'Not connected'}
+              </Typography>
             </AccountItem>
           ))}
+
+          {/* GitHub — editable social link */}
+          <AccountItem>
+            <AccountInfo>
+              <AccountIcon>
+                <GitHubIcon sx={{ color: githubUrl ? 'primary.main' : 'text.disabled' }} />
+              </AccountIcon>
+              <AccountName>
+                GitHub profile
+              </AccountName>
+            </AccountInfo>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, maxWidth: 400, ml: 2 }}>
+              <TextField
+                fullWidth
+                size="small"
+                placeholder="https://github.com/username"
+                value={githubUrl}
+                onChange={(e) => {
+                  setGithubUrl(e.target.value);
+                  if (githubError) validateGithubUrl(e.target.value);
+                }}
+                onBlur={() => validateGithubUrl(githubUrl)}
+                error={!!githubError}
+                helperText={githubError || undefined}
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <LinkIcon fontSize="small" color={githubUrl ? 'primary' : 'disabled'} />
+                      </InputAdornment>
+                    ),
+                    endAdornment: githubUrl ? (
+                      <InputAdornment position="end">
+                        <Tooltip title="Open profile">
+                          <IconButton
+                            size="small"
+                            onClick={() => window.open(githubUrl, '_blank', 'noopener,noreferrer')}
+                            edge="end"
+                          >
+                            <OpenInNewIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Disconnect">
+                          <IconButton
+                            size="small"
+                            onClick={handleDisconnectGithub}
+                            edge="end"
+                            sx={{ color: 'error.main' }}
+                          >
+                            <LinkOffIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      </InputAdornment>
+                    ) : undefined,
+                  },
+                }}
+              />
+            </Box>
+          </AccountItem>
+
+          {/* X (Twitter) — editable social link */}
+          <AccountItem>
+            <AccountInfo>
+              <AccountIcon>
+                <XIcon sx={{ color: xUrl ? 'primary.main' : 'text.disabled' }} />
+              </AccountIcon>
+              <AccountName>
+                X (Twitter) profile
+              </AccountName>
+            </AccountInfo>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flex: 1, maxWidth: 400, ml: 2 }}>
+              <TextField
+                fullWidth
+                size="small"
+                placeholder="https://x.com/username"
+                value={xUrl}
+                onChange={(e) => {
+                  setXUrl(e.target.value);
+                  if (xError) validateXUrl(e.target.value);
+                }}
+                onBlur={() => validateXUrl(xUrl)}
+                error={!!xError}
+                helperText={xError || undefined}
+                slotProps={{
+                  input: {
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <LinkIcon fontSize="small" color={xUrl ? 'primary' : 'disabled'} />
+                      </InputAdornment>
+                    ),
+                    endAdornment: xUrl ? (
+                      <InputAdornment position="end">
+                        <Tooltip title="Open profile">
+                          <IconButton
+                            size="small"
+                            onClick={() => window.open(xUrl, '_blank', 'noopener,noreferrer')}
+                            edge="end"
+                          >
+                            <OpenInNewIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Disconnect">
+                          <IconButton
+                            size="small"
+                            onClick={handleDisconnectX}
+                            edge="end"
+                            sx={{ color: 'error.main' }}
+                          >
+                            <LinkOffIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      </InputAdornment>
+                    ) : undefined,
+                  },
+                }}
+              />
+            </Box>
+          </AccountItem>
         </ContentSection>
       </Box>
     </ProfileContainer>

--- a/UI/src/features/pages/regular/profile/hooks/edit-profile.hook.ts
+++ b/UI/src/features/pages/regular/profile/hooks/edit-profile.hook.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from 'react-oidc-context';
 import { selfEditUserCall, getUserByIdCall } from '../../../../../api/soroban-security-portal/soroban-security-portal-api';
-import { UserItem, SelfEditUserItem  } from '../../../../../api/soroban-security-portal/models/user';
+import { UserItem, SelfEditUserItem, ConnectedAccountItem } from '../../../../../api/soroban-security-portal/models/user';
 
 export const useEditProfile = () => {
   const auth = useAuth();
@@ -22,6 +22,7 @@ export const useEditProfile = () => {
     login: string;
     personalInfo: string;
     image?: string;
+    connectedAccounts?: ConnectedAccountItem[];
   }): Promise<boolean> => {
     if (!user) return false;
 
@@ -31,7 +32,7 @@ export const useEditProfile = () => {
         fullName: profileData.fullName,
         image: profileData.image || '',
         personalInfo: profileData.personalInfo,
-        connectedAccounts: user.connectedAccounts,
+        connectedAccounts: profileData.connectedAccounts ?? user.connectedAccounts,
       };
 
       const response = await selfEditUserCall(user.loginId, selfEditUserItem);

--- a/UI/src/features/pages/regular/profile/profile.tsx
+++ b/UI/src/features/pages/regular/profile/profile.tsx
@@ -212,20 +212,21 @@ export const Profile: React.FC = () => {
 
   /**
    * Validates a social profile URL against the expected service host.
-   * Returns the safe URL or null if the URL is invalid/dangerous.
-   * Regexes match the edit-profile input validators so saved URLs always render.
+   * Returns the safe URL (normalized to https) or null if invalid.
+   * Accepts http for legacy data but always upgrades to https.
    */
   const getSafeSocialUrl = (serviceName: string, accountId: string): string | null => {
     if (!accountId) return null;
+    const normalizeToHttps = (url: string) => url.replace(/^http:\/\//i, 'https://');
     if (serviceName === 'GitHub') {
       if (/^https?:\/\/(www\.)?github\.com\/[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\/?$/.test(accountId)) {
-        return accountId;
+        return normalizeToHttps(accountId);
       }
       return null;
     }
     if (serviceName === 'X') {
       if (/^https?:\/\/(www\.)?(x\.com|twitter\.com)\/[a-zA-Z0-9_]{1,15}\/?$/.test(accountId)) {
-        return accountId;
+        return normalizeToHttps(accountId);
       }
       return null;
     }

--- a/UI/src/features/pages/regular/profile/profile.tsx
+++ b/UI/src/features/pages/regular/profile/profile.tsx
@@ -213,18 +213,18 @@ export const Profile: React.FC = () => {
   /**
    * Validates a social profile URL against the expected service host.
    * Returns the safe URL or null if the URL is invalid/dangerous.
+   * Regexes match the edit-profile input validators so saved URLs always render.
    */
   const getSafeSocialUrl = (serviceName: string, accountId: string): string | null => {
     if (!accountId) return null;
-    // Ensure only https scheme targeting the expected host
     if (serviceName === 'GitHub') {
-      if (/^https:\/\/github\.com\/[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\/?$/.test(accountId)) {
+      if (/^https?:\/\/(www\.)?github\.com\/[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\/?$/.test(accountId)) {
         return accountId;
       }
       return null;
     }
     if (serviceName === 'X') {
-      if (/^https:\/\/(x\.com|twitter\.com)\/[a-zA-Z0-9_]{1,15}\/?$/.test(accountId)) {
+      if (/^https?:\/\/(www\.)?(x\.com|twitter\.com)\/[a-zA-Z0-9_]{1,15}\/?$/.test(accountId)) {
         return accountId;
       }
       return null;

--- a/UI/src/features/pages/regular/profile/profile.tsx
+++ b/UI/src/features/pages/regular/profile/profile.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Alert, Button, Paper, Typography, Box, Tabs, Tab, IconButton, List, ListItem, ListItemIcon, ListItemSecondaryAction } from '@mui/material';
+import { Alert, Button, Paper, Typography, Box, Tabs, Tab, IconButton, List, ListItem, ListItemIcon, ListItemSecondaryAction, Link, Chip } from '@mui/material';
 import { useProfile } from './hooks';
 import { styled } from '@mui/material/styles';
 import { showError, showSuccess } from '../../../dialog-handler/dialog-handler';
@@ -10,6 +10,10 @@ import AssessmentIcon from '@mui/icons-material/Assessment';
 import BugReportIcon from '@mui/icons-material/BugReport';
 import DeleteIcon from '@mui/icons-material/Delete';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import GitHubIcon from '@mui/icons-material/GitHub';
+import XIcon from '@mui/icons-material/X';
+import GoogleIcon from '@mui/icons-material/Google';
+import ChatIcon from '@mui/icons-material/Chat';
 import { MarkdownView } from '../../../../components/MarkdownView';
 import { useNavigate } from 'react-router-dom';
 import { useBookmarks } from '../../../../contexts/BookmarkContext';
@@ -297,13 +301,72 @@ export const Profile: React.FC = () => {
               <SectionTitle>
                 Connected accounts
               </SectionTitle>
-              <PlaceholderText>
-                {user?.connectedAccounts && user?.connectedAccounts.length > 0 ? user?.connectedAccounts.map(account => (
-                  <div key={account.serviceName}>
-                    {account.serviceName}: {account.accountId}
-                  </div>
-                )) : (userId == 0 ? 'You can connect accounts in Edit Profile page' : '')}
-              </PlaceholderText>
+              {user?.connectedAccounts && user?.connectedAccounts.length > 0 ? (
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5 }}>
+                  {user.connectedAccounts.map((account) => {
+                    const isSocialLink = account.serviceName === 'GitHub' || account.serviceName === 'X';
+                    const isSSO = account.serviceName === 'Google' || account.serviceName === 'Discord';
+                    const icon = account.serviceName === 'GitHub' ? <GitHubIcon fontSize="small" />
+                      : account.serviceName === 'X' ? <XIcon fontSize="small" />
+                      : account.serviceName === 'Google' ? <GoogleIcon fontSize="small" />
+                      : account.serviceName === 'Discord' ? <ChatIcon fontSize="small" />
+                      : undefined;
+
+                    if (isSocialLink) {
+                      return (
+                        <Chip
+                          key={account.serviceName}
+                          icon={icon}
+                          label={
+                            <Link
+                              href={account.accountId}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              underline="hover"
+                              sx={{ color: 'primary.main', display: 'flex', alignItems: 'center', gap: 0.5 }}
+                            >
+                              {account.serviceName}
+                              <OpenInNewIcon sx={{ fontSize: 12 }} />
+                            </Link>
+                          }
+                          variant="outlined"
+                          sx={{
+                            borderColor: 'primary.main',
+                            '& .MuiChip-label': { py: 0.25 },
+                          }}
+                        />
+                      );
+                    }
+
+                    if (isSSO) {
+                      return (
+                        <Chip
+                          key={account.serviceName}
+                          icon={icon}
+                          label={`${account.serviceName} (${account.accountId})`}
+                          variant="outlined"
+                          sx={{
+                            borderColor: 'divider',
+                            '& .MuiChip-label': { py: 0.25 },
+                          }}
+                        />
+                      );
+                    }
+
+                    return (
+                      <Chip
+                        key={account.serviceName}
+                        label={`${account.serviceName}: ${account.accountId}`}
+                        variant="outlined"
+                      />
+                    );
+                  })}
+                </Box>
+              ) : (
+                <PlaceholderText>
+                  {userId == 0 ? 'You can connect accounts in the Edit Profile page' : 'No connected accounts'}
+                </PlaceholderText>
+              )}
             </Box>
           </TabPanel>
 

--- a/UI/src/features/pages/regular/profile/profile.tsx
+++ b/UI/src/features/pages/regular/profile/profile.tsx
@@ -210,6 +210,29 @@ export const Profile: React.FC = () => {
     }
   };
 
+  /**
+   * Validates a social profile URL against the expected service host.
+   * Returns the safe URL or null if the URL is invalid/dangerous.
+   */
+  const getSafeSocialUrl = (serviceName: string, accountId: string): string | null => {
+    if (!accountId) return null;
+    // Ensure only https scheme targeting the expected host
+    if (serviceName === 'GitHub') {
+      if (/^https:\/\/github\.com\/[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\/?$/.test(accountId)) {
+        return accountId;
+      }
+      return null;
+    }
+    if (serviceName === 'X') {
+      if (/^https:\/\/(x\.com|twitter\.com)\/[a-zA-Z0-9_]{1,15}\/?$/.test(accountId)) {
+        return accountId;
+      }
+      return null;
+    }
+    // Unknown social service — block rendering as link
+    return null;
+  };
+
   // Using shared getUserInitials from utils/user-utils.ts
 
   return (
@@ -313,25 +336,30 @@ export const Profile: React.FC = () => {
                       : undefined;
 
                     if (isSocialLink) {
+                      const safeUrl = getSafeSocialUrl(account.serviceName, account.accountId);
                       return (
                         <Chip
                           key={account.serviceName}
                           icon={icon}
                           label={
-                            <Link
-                              href={account.accountId}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              underline="hover"
-                              sx={{ color: 'primary.main', display: 'flex', alignItems: 'center', gap: 0.5 }}
-                            >
-                              {account.serviceName}
-                              <OpenInNewIcon sx={{ fontSize: 12 }} />
-                            </Link>
+                            safeUrl ? (
+                              <Link
+                                href={safeUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                underline="hover"
+                                sx={{ color: 'primary.main', display: 'flex', alignItems: 'center', gap: 0.5 }}
+                              >
+                                {account.serviceName}
+                                <OpenInNewIcon sx={{ fontSize: 12 }} />
+                              </Link>
+                            ) : (
+                              account.serviceName
+                            )
                           }
                           variant="outlined"
                           sx={{
-                            borderColor: 'primary.main',
+                            borderColor: safeUrl ? 'primary.main' : 'divider',
                             '& .MuiChip-label': { py: 0.25 },
                           }}
                         />


### PR DESCRIPTION
## Summary

Closes #28 — Adds the ability for users to link their **GitHub** and **X (Twitter)** profiles on the edit profile page.

Previously, the "Connected accounts" section on the edit profile page showed static disabled "Connect" buttons for all accounts. This PR replaces the GitHub and X entries with functional URL text inputs, while Google and Discord remain read-only SSO status indicators.

## Changes

### Files changed (3)

| File | Change |
|------|--------|
| `UI/src/features/pages/regular/profile/edit-profile.tsx` | Replace hardcoded social buttons with URL inputs + validation |
| `UI/src/features/pages/regular/profile/hooks/edit-profile.hook.ts` | Accept `connectedAccounts` in `updateProfile` parameter |
| `UI/src/features/pages/regular/profile/profile.tsx` | Display connected accounts as clickable Chip components |

### Edit Profile Page (`edit-profile.tsx`)

- **GitHub & X (Twitter)**: Replaced static "Connect" buttons with full URL text fields with:
  - URL validation (regex) for `https://github.com/username` and `https://x.com/username` / `https://twitter.com/username`
  - Link icon adornment + open-in-new-tab preview button when a URL is entered
  - Disconnect button to clear the link
  - Real-time error validation on blur and before save
- **Google & Discord**: Changed from non-functional "Connect" buttons to read-only status indicators showing "Connected via SSO" or "Not connected"
- **Data integrity**: On save, all non-GitHub/X accounts are preserved (e.g., SSO-linked Google/Discord), and social links are merged in only if the URL field is non-empty
- **URL validation**:
  - GitHub: Requires `https://github.com/username` format, validates username pattern (`[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])`)
  - X: Accepts both `x.com` and `twitter.com` domains with valid handle length (1-15 chars)

### Profile Display Page (`profile.tsx`)

- Connected accounts now render as **Chip components** instead of plain text
- **Social links** (GitHub, X): Clickable chips with `OpenInNew` icon that open the profile URL in a new tab
- **SSO accounts** (Google, Discord): Read-only chips showing the email/identifier
- Each chip has the appropriate service icon (GitHub, X, Google, Discord)

### Edit Profile Hook (`edit-profile.hook.ts`)

- Added optional `connectedAccounts?: ConnectedAccountItem[]` to `updateProfile` parameter
- Falls back to existing `user.connectedAccounts` if not provided (backward compatible)

## Backend

No backend changes were needed — the existing infrastructure fully supports this feature:

- `LoginModel.ConnectedAccounts` (`jsonb` column) already stores `List<ConnectedAccountModel>` with `ServiceName`/`AccountId`
- `LoginSelfUpdateViewModel.ConnectedAccounts` already accepts `List<ConnectedAccountViewModel>`
- `UserService.SelfUpdate()` already maps and persists `ConnectedAccounts`
- `ConnectedAccountTypeEnum` already includes `GitHub = 3` and `Twitter = 4`
- AutoMapper profiles already handle `ConnectedAccountModel <-> ConnectedAccountViewModel`

## Testing

- ✅ **TypeScript**: `tsc --noEmit` — zero errors
- ✅ **Backend tests**: 362/362 passed (`dotnet test`)
- ✅ **Frontend tests**: All passing (`vitest`)
- ✅ **Code review**: Addressed feedback (data loss edge case, MUI v9 compatibility confirmed)

## Screenshots / Demo

### Edit Profile — Connected accounts section
- Google: "Connected via SSO" / "Not connected" (read-only)
- Discord: "Connected via SSO" / "Not connected" (read-only)
- GitHub: Text input `https://github.com/username` with link/unlink action buttons
- X: Text input `https://x.com/username` with link/unlink action buttons

### Profile Page — Connected accounts display
- Social links shown as clickable chips → open profile in new tab
- SSO accounts shown as read-only chips with email identifier

---

**Note:** The PR is based on latest `upstream/main` with no merge conflicts.

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a concurrent OAuth connection can still be silently erased by SelfUpdate.

SelfUpdate reads and merges a detached account snapshot before passing it to a full-row update; without atomic merging or optimistic concurrency control, an OAuth callback committed during that interval is overwritten.

**Files Needing Attention:** Backend/SorobanSecurityPortalApi/Services/ControllersServices/UserService.cs and Backend/SorobanSecurityPortalApi/Data/Processors/LoginProcessor.cs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Backend/SorobanSecurityPortalApi/Services/ControllersServices/UserService.cs | Separates client-managed social links from SSO accounts, but its detached read-modify-write sequence still permits concurrent SSO updates to be overwritten. |
| UI/src/features/pages/regular/profile/edit-profile.tsx | Adds consistent HTTPS-only validation, normalization, previews, and editing controls for GitHub and X links. |
| UI/src/features/pages/regular/profile/hooks/edit-profile.hook.ts | Passes an optional connected-account payload through the existing self-update request. |
| UI/src/features/pages/regular/profile/profile.tsx | Displays connected accounts as chips and guards social navigation with service-specific URL validation and HTTPS normalization. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Edit Profile UI
    participant US as UserService.SelfUpdate
    participant DB as Login storage
    participant OAuth as OAuth callback
    UI->>US: Submit profile and GitHub/X links
    US->>DB: Read current login
    DB-->>US: Detached account snapshot
    OAuth->>DB: Write updated SSO connection
    US->>US: Merge social links into snapshot
    US->>DB: Replace login values
    Note over DB: Concurrent SSO connection can be overwritten
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix: re-read login before save to preven..."](https://github.com/inferara/soroban-security-portal/commit/231748b8f2015a9e5d68a4dcd12c616f4abb4f9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48251462)</sub>

<!-- /greptile_comment -->