### PR TITLE
feat: Add responsive 404 page and integrate in regular and admin routers

### DIFF
--- a/UI/src/features/pages/admin/admin-main-window/admin-main-window.tsx
+++ b/UI/src/features/pages/admin/admin-main-window/admin-main-window.tsx
@@ -14,7 +14,7 @@ import { useAuth } from 'react-oidc-context';
 import { Route, Routes, useNavigate } from 'react-router-dom';
 import { useAppSelector } from '../../../../app/hooks.ts';
 import { AdminLeftMenu } from '../left-menu/admin-left-menu.tsx';
-import { NoPage } from '../no-page/no-page.tsx';
+import { NotFound } from '../../regular/not-found/not-found';
 import { Settings } from '../settings/settings.tsx';
 import './admin-main-window.css';
 import { AddUser } from '../users/add-item/add-user.tsx';
@@ -304,7 +304,7 @@ export const AdminMainWindow: FC = () => {
 
           <Route path={`${environment.basePath}/admin/moderation`} element={<ModerationDashboard />} />
 
-          <Route path={`${environment.basePath}/*`} element={<NoPage />} />
+          <Route path={`${environment.basePath}/*`} element={<NotFound />} />
         </Routes>
         <ErrorDialog />
       </Main>

--- a/UI/src/features/pages/regular/main-window/main-window.tsx
+++ b/UI/src/features/pages/regular/main-window/main-window.tsx
@@ -40,6 +40,7 @@ import { ReportDetails } from '../report-details/report-details';
 import { AuditorDetails } from '../auditor-details/auditor-details';
 import { CompanyDetails } from '../company-details/company-details';
 import { BadgeDemoPage } from '../../BadgeDemoPage';
+import { NotFound } from '../not-found/not-found';
 import { useTheme } from '../../../../contexts/ThemeContext';
 import { useToolbarAvatar } from '../../../../hooks/useToolbarAvatar';
 import { getUserInitials } from '../../../../utils/user-utils';
@@ -440,6 +441,7 @@ export const MainWindow: FC = () => {
             <Route path={`${environment.basePath}/company/:id`} element={<CompanyDetails />} />
             <Route path={`${environment.basePath}/badge-demo`} element={<BadgeDemoPage />} />
             <Route path={`${environment.basePath}/mentions`} element={<MentionsInbox />} />
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </Box>
       </Box>

--- a/UI/src/features/pages/regular/not-found/not-found.tsx
+++ b/UI/src/features/pages/regular/not-found/not-found.tsx
@@ -5,10 +5,15 @@ import Button from '@mui/material/Button';
 import { useNavigate } from 'react-router-dom';
 import { useTheme } from '../../../../contexts/ThemeContext';
 import HomeIcon from '@mui/icons-material/Home';
+import { environment } from '../../../../environments/environment';
 
 export const NotFound: FC = () => {
   const navigate = useNavigate();
   const { tokens } = useTheme();
+
+  const handleBackHome = () => {
+    navigate(`${environment.basePath}/`);
+  };
 
   return (
     <Box
@@ -76,7 +81,7 @@ export const NotFound: FC = () => {
         variant="contained"
         size="large"
         startIcon={<HomeIcon />}
-        onClick={() => navigate('/')}
+        onClick={handleBackHome}
         sx={{
           px: 4,
           py: 1.5,

--- a/UI/src/features/pages/regular/not-found/not-found.tsx
+++ b/UI/src/features/pages/regular/not-found/not-found.tsx
@@ -1,0 +1,93 @@
+import { FC } from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import { useNavigate } from 'react-router-dom';
+import { useTheme } from '../../../../contexts/ThemeContext';
+import HomeIcon from '@mui/icons-material/Home';
+
+export const NotFound: FC = () => {
+  const navigate = useNavigate();
+  const { tokens } = useTheme();
+
+  return (
+    <Box
+      id="not-found-page"
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '70vh',
+        textAlign: 'center',
+        px: 3,
+      }}
+    >
+      {/* Large 404 number with gold gradient */}
+      <Typography
+        variant="h1"
+        component="h1"
+        sx={{
+          fontSize: { xs: '6rem', sm: '8rem', md: '10rem' },
+          fontWeight: 900,
+          lineHeight: 1,
+          backgroundImage: tokens.goldGradient,
+          WebkitBackgroundClip: 'text',
+          backgroundClip: 'text',
+          color: 'transparent',
+          mb: 1,
+          userSelect: 'none',
+          filter: 'drop-shadow(0 4px 24px rgba(212, 162, 60, 0.25))',
+        }}
+      >
+        404
+      </Typography>
+
+      {/* Subtitle */}
+      <Typography
+        variant="h5"
+        component="h2"
+        sx={{
+          fontWeight: 700,
+          color: 'text.primary',
+          mb: 1.5,
+        }}
+      >
+        Page not found
+      </Typography>
+
+      {/* Friendly description */}
+      <Typography
+        variant="body1"
+        sx={{
+          color: 'text.secondary',
+          maxWidth: 480,
+          mb: 4,
+          lineHeight: 1.7,
+        }}
+      >
+        The page you're looking for doesn't exist or may have been moved.
+        Double-check the URL or head back home.
+      </Typography>
+
+      {/* Back to Home button */}
+      <Button
+        id="not-found-back-home"
+        variant="contained"
+        size="large"
+        startIcon={<HomeIcon />}
+        onClick={() => navigate('/')}
+        sx={{
+          px: 4,
+          py: 1.5,
+          fontSize: '1rem',
+          fontWeight: 700,
+          textTransform: 'none',
+          borderRadius: 2,
+        }}
+      >
+        Back to Home
+      </Button>
+    </Box>
+  );
+};


### PR DESCRIPTION
### Summary

Closes #215 

Implemented a dedicated 404 (Not Found) page for unknown routes in both the regular and admin sections of the application.

### Changes

* Added a reusable **NotFound** page with a friendly message and a **Back to Home** link.
* Registered a catch-all (`*`) route in the main router.
* Added a catch-all route to the admin router to handle unknown admin URLs.
* Ensured existing routes continue to work as expected while unknown paths now display a proper 404 page.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| UI/src/features/pages/regular/not-found/not-found.tsx | Adds the responsive Not Found presentation and navigates users back to the base-path-aware home route. |
| UI/src/features/pages/regular/main-window/main-window.tsx | Registers the shared NotFound component as the regular router's catch-all route. |
| UI/src/features/pages/admin/admin-main-window/admin-main-window.tsx | Replaces the admin fallback page with the shared NotFound component. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: Account for non-root basePath deplo..."](https://github.com/inferara/soroban-security-portal/commit/9eea4f350c0f339e8ac6cc8af536392e69ff6b38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48418965)</sub>

<!-- /greptile_comment -->