### PR TITLE
Bump the builtin soroban-ret engine to 0.0.4

### DIFF
--- a/DevTools/soroban-ret-web/Cargo.lock
+++ b/DevTools/soroban-ret-web/Cargo.lock
@@ -1710,9 +1710,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-ret"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1af26b02b578d69f87ff20ebbad70517c8c896fd47503d068f77c591d621b55b"
+checksum = "d436ff9def24798685877aadce7d7219d1a9b2f0ffd87a51180d1c3f27fea84c"
 dependencies = [
  "cov-mark",
  "log",

--- a/DevTools/soroban-ret-web/Cargo.toml
+++ b/DevTools/soroban-ret-web/Cargo.toml
@@ -12,7 +12,7 @@ name = "soroban-ret-web"
 path = "src/main.rs"
 
 [dependencies]
-soroban-ret = { version = "0.0.3", features = ["wasmprinter"] }
+soroban-ret = { version = "0.0.4", features = ["wasmprinter"] }
 stellar-xdr = { version = "26.0.1", default-features = false, features = ["curr", "std", "base64"] }
 axum = { version = "0.8", features = ["multipart"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Dominik noticed that /dev-tools still defaults to v0.0.3 (current) even though 0.0.4 is in the dropdown.

The dropdown and the default come from two different places. The nightly `Sync Dev Tools engine versions` workflow builds new `soroban-ret-cli` releases from crates.io and drops them into the `/engines` PVC, so they show up as selectable options — prod already returns `available: ["0.0.4","0.0.3","0.0.2","0.0.1"]`. But `current` (the default selection and the "(current)" label) is the builtin library version compiled into soroban-ret-web, which `build.rs` reads out of Cargo.lock. That was still 0.0.3, and since a `0.0.x` caret requirement pins the exact patch, `cargo update` on its own never moves to 0.0.4 — the dependency has to be bumped by hand.

So the nightly sync can only ever add versions to the list; moving the default takes a rebuild against the newer library. That's this PR.

No code changes were needed, 0.0.4 is API-compatible. Verified locally:

- `cargo build` clean, `cargo test` 13/13 green (including `builtin_version_matches_cargo_lock`, which now checks against 0.0.4)
- ran the binary: `GET /api/dev-tools/versions` → `{"current":"0.0.4","available":["0.0.4"],"compile_enabled":false}`
- disassembled the `add_u64` fixture with the new engine: `engine_version: 0.0.4`, `engine: library`, correct decompiled Rust, 6958 bytes of WAT, 11 sections, no warnings, SDK version detected

After deploy prod will list `["0.0.4","0.0.3","0.0.2","0.0.1"]` with `current: 0.0.4`. The 0.0.4 CLI binary already sitting in the PVC gets shadowed by the builtin, which is what we want — the in-process library gives richer output than shelling out to the CLI.

One caveat worth knowing: anyone who previously picked 0.0.3 by hand has it in localStorage, and that wins over the default until they switch back.

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The dependency and lockfile consistently select soroban-ret 0.0.4, the service’s used APIs remain compatible, and the update introduces no transitive dependency changes.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| DevTools/soroban-ret-web/Cargo.toml | Bumps the soroban-ret dependency to 0.0.4 while retaining the existing wasmprinter feature. |
| DevTools/soroban-ret-web/Cargo.lock | Resolves soroban-ret 0.0.4 with its updated checksum and no transitive dependency changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Bump the builtin soroban-ret engine to 0..."](https://github.com/inferara/soroban-security-portal/commit/e40c9d1d515b934522502c0000aee88e7b8c740b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50883317)</sub>

<!-- /greptile_comment -->