### PR TITLE
fix: use structured logging in background worker

### DIFF
--- a/Backend/SorobanSecurityPortalApi/Services/ProcessingServices/BackgroundWorkingHostedService.cs
+++ b/Backend/SorobanSecurityPortalApi/Services/ProcessingServices/BackgroundWorkingHostedService.cs
@@ -17,19 +17,22 @@ namespace SorobanSecurityPortalApi.Services.ProcessingServices
         private readonly IVulnerabilityProcessor _vulnerabilityProcessor;
         private readonly IGeminiEmbeddingService _embeddingService;
         private readonly IAgentRunProcessor _agentRunProcessor;
+        private readonly ILogger<BackgroundWorkingHostedService> _logger;
 
         public BackgroundWorkingHostedService(
             IReportProcessor reportProcessor,
             IVulnerabilityProcessor vulnerabilityProcessor,
             IGeminiEmbeddingService embeddingService,
             IAgentRunProcessor agentRunProcessor,
-            Config config)
+            Config config,
+            ILogger<BackgroundWorkingHostedService> logger)
         {
             _reportProcessor = reportProcessor;
             _vulnerabilityProcessor = vulnerabilityProcessor;
             _embeddingService = embeddingService;
             _agentRunProcessor = agentRunProcessor;
             _config = config;
+            _logger = logger;
         }
 
         public async Task StartAsync(CancellationToken cancellationToken)
@@ -54,11 +57,14 @@ namespace SorobanSecurityPortalApi.Services.ProcessingServices
             {
                 var reclaimed = await _agentRunProcessor.ReclaimStuckProcessing(StuckAgentRunTimeout);
                 if (reclaimed > 0)
-                    Console.WriteLine($"Reclaimed {reclaimed} stuck agent run(s) (processing > {StuckAgentRunTimeout.TotalMinutes:0} min).");
+                    _logger.LogInformation(
+                        "Reclaimed {ReclaimedCount} stuck agent run(s) (processing > {TimeoutMinutes:0} min).",
+                        reclaimed,
+                        StuckAgentRunTimeout.TotalMinutes);
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error during stuck agent-run reclaim: {ex.Message}");
+                _logger.LogError(ex, "Error during stuck agent-run reclaim.");
             }
         }
 
@@ -85,7 +91,11 @@ namespace SorobanSecurityPortalApi.Services.ProcessingServices
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Error during report ({reportModel.Name} / {reportModel.Id}) fix: {ex.Message}");
+                    _logger.LogError(
+                        ex,
+                        "Error during report fix for {ReportName} ({ReportId}).",
+                        reportModel.Name,
+                        reportModel.Id);
                 }
             }
         }
@@ -103,7 +113,11 @@ namespace SorobanSecurityPortalApi.Services.ProcessingServices
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Error during report ({reportModel.Name} / {reportModel.Id}) embedding: {ex.Message}");
+                    _logger.LogError(
+                        ex,
+                        "Error during report embedding for {ReportName} ({ReportId}).",
+                        reportModel.Name,
+                        reportModel.Id);
                 }
             }
         }
@@ -121,7 +135,11 @@ namespace SorobanSecurityPortalApi.Services.ProcessingServices
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Error during vulnerability ({vulnerability.Title} / {vulnerability.Id}) embedding: {ex.Message}");
+                    _logger.LogError(
+                        ex,
+                        "Error during vulnerability embedding for {VulnerabilityTitle} ({VulnerabilityId}).",
+                        vulnerability.Title,
+                        vulnerability.Id);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Inject ILogger into BackgroundWorkingHostedService.
- Replace the reclaim message with structured LogInformation logging.
- Replace all four exception handlers with LogError calls that preserve stack traces and include job context.

## Verification

- Confirmed the service has zero Console.WriteLine calls.
- git diff --check passes.
- Local dotnet build was unavailable because the .NET SDK is not installed in this environment.

Closes #222

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

The pull request appears safe to merge with no actionable defects identified.

The hosted service is constructed through dependency injection, which supplies the new logger dependency, and the structured logging calls preserve the existing processing and exception-handling behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Backend/SorobanSecurityPortalApi/Services/ProcessingServices/BackgroundWorkingHostedService.cs | The logging conversion preserves worker control flow and error isolation, and the added logger dependency is resolvable through the existing generic-host registration. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use structured logging in backgroun..."](https://github.com/inferara/soroban-security-portal/commit/bb23d5813e6595f359c02d23f2c028354093f596) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56600923)</sub>

**Context used:**

- Knowledge Base — [Report APIs and processing](https://app.greptile.com/inferara/-/custom-context/knowledge-base/inferara/soroban-security-portal/-/docs/report-api-and-processing.md)

<!-- /greptile_comment -->