### PR TITLE
Remove login gate for downloading reports #227

### DIFF
--- a/Backend/SorobanSecurityPortalApi/Controllers/ReportsController.cs
+++ b/Backend/SorobanSecurityPortalApi/Controllers/ReportsController.cs
@@ -48,7 +48,6 @@ namespace SorobanSecurityPortalApi.Controllers
             return Ok(result);
         }
 
-        [RoleAuthorize(Role.Admin, Role.Moderator, Role.Contributor, Role.User)]
         [HttpGet("{reportId}/download")]
         public async Task<IActionResult> GetFile(int reportId)
         {

--- a/UI/src/features/pages/regular/report-details/hooks/report-details.hook.ts
+++ b/UI/src/features/pages/regular/report-details/hooks/report-details.hook.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useAuth } from 'react-oidc-context';
 import { environment } from '../../../../../environments/environment';
@@ -60,8 +60,8 @@ export const useReportDetails = () => {
     };
   };
 
-  const fetchPdfForViewing = async () => {
-    if (!reportId || !auth.user?.access_token) {
+  const fetchPdfForViewing = useCallback(async () => {
+    if (!reportId) {
       return;
     }
 
@@ -69,11 +69,14 @@ export const useReportDetails = () => {
     setPdfLoadError(false);
 
     try {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/pdf'
+      };
+      if (auth.user?.access_token) {
+        headers['Authorization'] = `Bearer ${auth.user.access_token}`;
+      }
       const response = await fetch(`${environment.apiUrl}/api/v1/reports/${reportId}/download`, {
-        headers: {
-          'Authorization': `Bearer ${auth.user.access_token}`,
-          'Content-Type': 'application/pdf'
-        }
+        headers
       });
 
       if (!response.ok) {
@@ -89,7 +92,7 @@ export const useReportDetails = () => {
     } finally {
       setPdfLoading(false);
     }
-  };
+  }, [reportId, auth.user]);
 
   const retryPdfLoad = () => {
     setPdfLoadError(false);

--- a/UI/src/features/pages/regular/report-details/report-details.tsx
+++ b/UI/src/features/pages/regular/report-details/report-details.tsx
@@ -49,7 +49,7 @@ import { downloadReportPDF, getCommentCountCall } from '../../../../api/soroban-
 import { DiscussionPanel } from '../../../comments/DiscussionPanel';
 import { CommentEntityType } from '../../../../api/soroban-security-portal/models/comment';
 import { useAppAuth } from '../../../authentication/useAppAuth';
-import { isAuthorized, canEdit } from '../../../authentication/authPermissions';
+import { canEdit } from '../../../authentication/authPermissions';
 import { EntityAvatar } from '../../../../components/EntityAvatar';
 import {
   DetailPageLayout,
@@ -143,15 +143,6 @@ export const ReportDetails: FC = () => {
   }, [vulnerabilities]);
 
   const handleReportDownload = async (reportName: string, reportId: number) => {
-    if (!isAuthorized(auth)) {
-      showMessage('Log in to download the report');
-      ReactGA.event({
-        category: 'Report',
-        action: 'download',
-        label: `Unauthorized attempt to download the report ${reportId}`,
-      });
-      return;
-    }
     try {
       await downloadReportPDF(reportName, reportId);
       ReactGA.event({
@@ -169,12 +160,12 @@ export const ReportDetails: FC = () => {
     }
   };
 
-  // Fetch PDF when tab changes to Full Report or when report/auth changes
+  // Fetch PDF when tab changes to Full Report or when report changes
   useEffect(() => {
-    if (tabValue === 1 && report && isAuthorized(auth) && !pdfBlobUrl && !pdfLoading) {
+    if (tabValue === 1 && report && !pdfBlobUrl && !pdfLoading && !pdfLoadError) {
       fetchPdfForViewing();
     }
-  }, [tabValue, report, auth.user?.access_token, pdfBlobUrl, pdfLoading, fetchPdfForViewing]);
+  }, [tabValue, report, pdfBlobUrl, pdfLoading, pdfLoadError, fetchPdfForViewing]);
 
   // Configure statistics cards
   const statsCards = [
@@ -668,116 +659,96 @@ export const ReportDetails: FC = () => {
                     <Typography variant="h6" sx={{ fontWeight: 600 }}>
                       Full Report (PDF)
                     </Typography>
-                    {isAuthorized(auth) && (
-                      <Button
-                        variant="outlined"
-                        size="small"
-                        startIcon={<GetApp />}
-                        onClick={() => handleReportDownload(report.name, report.id)}
-                      >
-                        Download
-                      </Button>
-                    )}
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      startIcon={<GetApp />}
+                      onClick={() => handleReportDownload(report.name, report.id)}
+                    >
+                      Download
+                    </Button>
                   </Box>
 
-                  {isAuthorized(auth) ? (
-                    <Box sx={{ height: '80vh', width: '100%' }}>
-                      {pdfLoading ? (
-                        <Box
-                          sx={{
-                            p: 4,
-                            textAlign: 'center',
-                            height: '100%',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                          }}
-                        >
-                          <Box>
-                            <CircularProgress size={60} sx={{ mb: 2 }} />
-                            <Typography variant="h6" color="text.secondary">
-                              Loading PDF...
-                            </Typography>
-                          </Box>
-                        </Box>
-                      ) : pdfLoadError ? (
-                        <Box
-                          sx={{
-                            p: 4,
-                            textAlign: 'center',
-                            height: '100%',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                          }}
-                        >
-                          <Box>
-                            <Typography variant="h6" color="text.secondary" sx={{ mb: 2 }}>
-                              Unable to Load PDF Preview
-                            </Typography>
-                            <Typography color="text.secondary" sx={{ mb: 3 }}>
-                              The PDF viewer encountered an authentication error. You can still download the report.
-                            </Typography>
-                            <Stack direction="row" spacing={2} sx={{ justifyContent: 'center' }}>
-                              <Button
-                                variant="contained"
-                                color="primary"
-                                startIcon={<GetApp />}
-                                onClick={() => handleReportDownload(report.name, report.id)}
-                              >
-                                Download Report
-                              </Button>
-                              <Button variant="outlined" onClick={retryPdfLoad}>
-                                Retry
-                              </Button>
-                            </Stack>
-                          </Box>
-                        </Box>
-                      ) : pdfBlobUrl ? (
-                        <iframe
-                          src={`${pdfBlobUrl}#toolbar=1&navpanes=1&scrollbar=1`}
-                          width="100%"
-                          height="100%"
-                          style={{
-                            border: 'none',
-                            borderRadius: 0,
-                          }}
-                          title="Report PDF Viewer"
-                        />
-                      ) : (
-                        <Box
-                          sx={{
-                            p: 4,
-                            textAlign: 'center',
-                            height: '100%',
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                          }}
-                        >
+                  <Box sx={{ height: '80vh', width: '100%' }}>
+                    {pdfLoading ? (
+                      <Box
+                        sx={{
+                          p: 4,
+                          textAlign: 'center',
+                          height: '100%',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                        }}
+                      >
+                        <Box>
+                          <CircularProgress size={60} sx={{ mb: 2 }} />
                           <Typography variant="h6" color="text.secondary">
-                            Click on the &quot;Full Report (PDF)&quot; tab to load the document
+                            Loading PDF...
                           </Typography>
                         </Box>
-                      )}
-                    </Box>
-                  ) : (
-                    <Box sx={{ p: 4, textAlign: 'center' }}>
-                      <Typography variant="h6" color="text.secondary" sx={{ mb: 2 }}>
-                        Authentication Required
-                      </Typography>
-                      <Typography color="text.secondary" sx={{ mb: 3 }}>
-                        Please log in to view the full report
-                      </Typography>
-                      <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={() => navigate('/login')}
+                      </Box>
+                    ) : pdfLoadError ? (
+                      <Box
+                        sx={{
+                          p: 4,
+                          textAlign: 'center',
+                          height: '100%',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                        }}
                       >
-                        Log In
-                      </Button>
-                    </Box>
-                  )}
+                        <Box>
+                          <Typography variant="h6" color="text.secondary" sx={{ mb: 2 }}>
+                            Unable to Load PDF Preview
+                          </Typography>
+                          <Typography color="text.secondary" sx={{ mb: 3 }}>
+                            The PDF viewer encountered an error. You can still download the report.
+                          </Typography>
+                          <Stack direction="row" spacing={2} sx={{ justifyContent: 'center' }}>
+                            <Button
+                              variant="contained"
+                              color="primary"
+                              startIcon={<GetApp />}
+                              onClick={() => handleReportDownload(report.name, report.id)}
+                            >
+                              Download Report
+                            </Button>
+                            <Button variant="outlined" onClick={retryPdfLoad}>
+                              Retry
+                            </Button>
+                          </Stack>
+                        </Box>
+                      </Box>
+                    ) : pdfBlobUrl ? (
+                      <iframe
+                        src={`${pdfBlobUrl}#toolbar=1&navpanes=1&scrollbar=1`}
+                        width="100%"
+                        height="100%"
+                        style={{
+                          border: 'none',
+                          borderRadius: 0,
+                        }}
+                        title="Report PDF Viewer"
+                      />
+                    ) : (
+                      <Box
+                        sx={{
+                          p: 4,
+                          textAlign: 'center',
+                          height: '100%',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                        }}
+                      >
+                        <Typography variant="h6" color="text.secondary">
+                          Click on the &quot;Full Report (PDF)&quot; tab to load the document
+                        </Typography>
+                      </Box>
+                    )}
+                  </Box>
                 </CardContent>
               </Card>
             </Box>

--- a/UI/src/features/pages/regular/reports/reports.tsx
+++ b/UI/src/features/pages/regular/reports/reports.tsx
@@ -18,7 +18,7 @@ import { downloadReportPDF } from '../../../../api/soroban-security-portal/sorob
 import { showMessage } from '../../../dialog-handler/dialog-handler';
 import ReactGA from 'react-ga4';
 import { useAppAuth } from '../../../authentication/useAppAuth';
-import { isAuthorized, canEdit } from '../../../authentication/authPermissions';
+import { canEdit } from '../../../authentication/authPermissions';
 
 export const Reports: FC = () => {
   const { themeMode } = useTheme();
@@ -55,11 +55,6 @@ export const Reports: FC = () => {
   };
 
   const handleReportDownload = async (reportName: string, reportId: number) => {
-    if (!isAuthorized(auth)) {
-      showMessage("Log in to download the report");
-      ReactGA.event({ category: "Report", action: "download", label: `Unauthorized attempt to download the report ${reportId}` });
-      return;
-    }
     try {
       await downloadReportPDF(reportName, reportId);
       ReactGA.event({ category: "Report", action: "view", label: `Downloaded report ${reportId}` });

--- a/UI/src/features/pages/regular/vulnerabilities/vulnerabilities.tsx
+++ b/UI/src/features/pages/regular/vulnerabilities/vulnerabilities.tsx
@@ -43,7 +43,7 @@ import ReactGA from 'react-ga4';
 import { VulnerabilityCard } from './vulnerability-card';
 import { downloadReportPDF, getVulnerabilityDescriptionCall } from '../../../../api/soroban-security-portal/soroban-security-portal-api';
 import { useAppAuth } from '../../../authentication/useAppAuth';
-import { isAuthorized, canEdit } from '../../../authentication/authPermissions';
+import { canEdit } from '../../../authentication/authPermissions';
 
 export const Vulnerabilities: FC = () => {
   // Filter/search state
@@ -197,11 +197,6 @@ export const Vulnerabilities: FC = () => {
   };
 
   const handleDownloadReport = async (reportName: string, reportId: number) => {
-    if (!isAuthorized(auth)) {
-      showMessage("Log in to download the report");
-      ReactGA.event({ category: "Report", action: "download", label: `Unauthorized attempt to download the report ${reportId}` });
-      return;
-    }
     try {
       await downloadReportPDF(reportName, reportId);
       ReactGA.event({ category: "Report", action: "view", label: `Downloaded report ${reportId}` });


### PR DESCRIPTION
## Overview

This PR removes the login requirement for downloading PDF reports and viewing the full report on its individual pages, as requested in #227. Reports are public good resources and should be freely accessible without authentication.

## Related Issue

Closes #227

## Changes

### Backend

- **[REMOVE]** `ReportsController.cs:51` — Removed `[RoleAuthorize(Role.Admin, Role.Moderator, Role.Contributor, Role.User)]` attribute from the `GET /api/v1/reports/{reportId}/download` endpoint. The `CanDownloadReport()` check still ensures only Approved reports are downloadable by anonymous users.

### Frontend

- **[MODIFY]** `report-details.tsx` — Removed `isAuthorized(auth)` gate in `handleReportDownload`, removed conditional rendering that hid the Download button and PDF viewer from unauthenticated users, and removed the "Authentication Required" login prompt on the Full Report tab.
- **[MODIFY]** `report-details.hook.ts` — `fetchPdfForViewing` no longer requires `auth.user?.access_token` to proceed; the Authorization header is now sent only when a token is available (optional auth).
- **[MODIFY]** `reports.tsx` — Removed `isAuthorized(auth)` gate in `handleReportDownload`.
- **[MODIFY]** `vulnerabilities.tsx` — Removed `isAuthorized(auth)` gate in `handleDownloadReport`.

## What stays the same

- No other roles or permissions are changed
- Admin/Moderator/Contributor abilities (add, approve, reject, delete reports) are untouched
- The `CanDownloadReport()` backend check still prevents downloading non-Approved reports for regular users
- Authenticated users still benefit from the Authorization header being sent (for logging/telemetry purposes)

## Verification

- Removed all `isAuthorized(auth)` checks from download handlers across 3 pages
- Verified the backend download endpoint no longer requires authentication
- PDF inline viewer now loads for all users without authentication
- Existing error handling (catch blocks, retry logic) remains intact
- No unused imports remain after changes












<!-- greptile_comment -->

<h3>Confidence Score: 3/5</h3>

The PR is not safe to merge until anonymous downloads honor hidden and soft-deleted report moderation state.

The download endpoint remains reachable anonymously and loads reports through an ID-only lookup; because moderation flags do not revoke approved status, a hidden or soft-deleted approved PDF is still returned.

**Files Needing Attention:** Backend/SorobanSecurityPortalApi/Controllers/ReportsController.cs and Backend/SorobanSecurityPortalApi/Data/Processors/ReportProcessor.cs

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Backend/SorobanSecurityPortalApi/Controllers/ReportsController.cs | Removes authentication enforcement from the report PDF download endpoint while retaining its existing download eligibility check. |
| UI/src/features/pages/regular/report-details/hooks/report-details.hook.ts | Allows anonymous PDF preview requests, conditionally adds authorization, and memoizes the fetch callback. |
| UI/src/features/pages/regular/report-details/report-details.tsx | Exposes PDF preview and download controls without login and prevents automatic retries after preview failure. |
| UI/src/features/pages/regular/reports/reports.tsx | Removes the frontend login check from report-list downloads. |
| UI/src/features/pages/regular/vulnerabilities/vulnerabilities.tsx | Removes the frontend login check from report downloads initiated through vulnerability results. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant V as Visitor
  participant UI as Report UI
  participant API as Reports API
  participant DB as Report Store
  V->>UI: Open full report or download
  UI->>API: "GET /reports/{id}/download"
  Note over UI,API: Authorization header is optional
  API->>DB: Load report by ID
  DB-->>API: Report and PDF
  API-->>UI: PDF for permitted report
  UI-->>V: Preview or downloaded file
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Remove login gate for downloading report..."](https://github.com/inferara/soroban-security-portal/commit/5143dd56e334f5e9fec515206f94e3de5bc11b42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56624352)</sub>

**Context used:**

- Knowledge Base — [Security report lifecycle](https://app.greptile.com/inferara/-/custom-context/knowledge-base/inferara/soroban-security-portal/-/docs/security-report-lifecycle.md)
- Knowledge Base — [Report APIs and processing](https://app.greptile.com/inferara/-/custom-context/knowledge-base/inferara/soroban-security-portal/-/docs/report-api-and-processing.md)

<!-- /greptile_comment -->