### PR TITLE
clamp vulnerability search page size to MaxPageSize=100

### DIFF
--- a/Backend/SorobanSecurityPortalApi.Tests/Data/VulnerabilityProcessorPaginationTests.cs
+++ b/Backend/SorobanSecurityPortalApi.Tests/Data/VulnerabilityProcessorPaginationTests.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SorobanSecurityPortalApi.Common;
+using SorobanSecurityPortalApi.Common.Data;
+using SorobanSecurityPortalApi.Data.Processors;
+using SorobanSecurityPortalApi.Models.DbModels;
+using Xunit;
+
+namespace SorobanSecurityPortalApi.Tests.Services
+{
+    /// <summary>
+    /// Verifies page-size clamping and page-number fall-back logic in
+    /// <see cref="VulnerabilityProcessor.Search"/>.
+    ///
+    /// The processor enforces a MaxPageSize = 100 ceiling on any positive
+    /// page-size value supplied by a caller. The internal PageSize &lt; 0
+    /// escape hatch (used by VulnerabilityExtractionService and
+    /// ReportSummaryService) is preserved and still returns all rows.
+    /// </summary>
+    public class VulnerabilityProcessorPaginationTests
+    {
+        // ── helpers ──────────────────────────────────────────────────────────
+
+        private static Mock<DbSet<T>> CreateDbSetMock<T>(List<T> sourceList) where T : class
+        {
+            var queryable = sourceList.AsQueryable();
+            var dbSetMock = new Mock<DbSet<T>>();
+
+            dbSetMock.As<IQueryable<T>>().Setup(m => m.Provider)
+                .Returns(new TestAsyncQueryProvider<T>(queryable.Provider));
+            dbSetMock.As<IQueryable<T>>().Setup(m => m.Expression).Returns(queryable.Expression);
+            dbSetMock.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(queryable.ElementType);
+            dbSetMock.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(queryable.GetEnumerator());
+            dbSetMock.As<IAsyncEnumerable<T>>()
+                .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+                .Returns(new TestAsyncEnumerator<T>(queryable.GetEnumerator()));
+
+            return dbSetMock;
+        }
+
+        /// <summary>
+        /// Builds a <see cref="VulnerabilityProcessor"/> backed by an in-memory list.
+        /// </summary>
+        private static VulnerabilityProcessor BuildProcessor(List<VulnerabilityModel> list)
+        {
+            var dbQueryMock          = new Mock<IDbQuery>();
+            var loggerMock           = new Mock<ILogger<Db>>();
+            var dataSourceMock       = new Mock<IDataSourceProvider>();
+
+            var dbMock = new Mock<Db>(
+                dbQueryMock.Object,
+                loggerMock.Object,
+                dataSourceMock.Object
+            ) { CallBase = true };
+
+            dbMock.Setup(d => d.Vulnerability).Returns(CreateDbSetMock(list).Object);
+            dbMock.Setup(d => d.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+            var factoryMock = new Mock<IDbContextFactory<Db>>();
+            factoryMock
+                .Setup(f => f.CreateDbContextAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dbMock.Object);
+
+            // ExtendedConfig is only used in the search-text / embedding branch;
+            // none of these tests exercise that path, so null! is safe.
+            return new VulnerabilityProcessor(factoryMock.Object, null!);
+        }
+
+        /// <summary>
+        /// Creates <paramref name="count"/> approved, visible vulnerabilities with sequential IDs.
+        /// </summary>
+        private static List<VulnerabilityModel> MakeVulnerabilities(int count)
+        {
+            var list = new List<VulnerabilityModel>(count);
+            for (var i = 1; i <= count; i++)
+            {
+                list.Add(new VulnerabilityModel
+                {
+                    Id       = i,
+                    Status   = VulnerabilityModelStatus.Approved,
+                    Category = VulnerabilityCategory.Valid,
+                    IsHidden  = false,
+                    IsDeleted = false,
+                    Title    = $"Vuln {i}"
+                });
+            }
+            return list;
+        }
+
+        // ── page-size clamping tests ──────────────────────────────────────────
+
+        [Fact]
+        public async Task Search_OversizedPageSize_IsClamped_To_MaxPageSize()
+        {
+            // 150 vulnerabilities in the DB; client requests 1_000_000.
+            // Should receive exactly MaxPageSize (100) items.
+            var processor = BuildProcessor(MakeVulnerabilities(150));
+
+            var result = await processor.Search(new VulnerabilitySearchModel
+            {
+                Page     = 1,
+                PageSize = 1_000_000
+            });
+
+            result.Should().HaveCount(100,
+                "page size must be clamped to the MaxPageSize ceiling of 100");
+        }
+
+        [Fact]
+        public async Task Search_PageSizeAtExactMax_IsNotReduced()
+        {
+            var processor = BuildProcessor(MakeVulnerabilities(150));
+
+            var result = await processor.Search(new VulnerabilitySearchModel
+            {
+                Page     = 1,
+                PageSize = 100
+            });
+
+            result.Should().HaveCount(100,
+                "a page size exactly at the maximum should be returned in full");
+        }
+
+        [Fact]
+        public async Task Search_PageSizeBelowMax_IsRespected()
+        {
+            var processor = BuildProcessor(MakeVulnerabilities(50));
+
+            var result = await processor.Search(new VulnerabilitySearchModel
+            {
+                Page     = 1,
+                PageSize = 20
+            });
+
+            result.Should().HaveCount(20,
+                "normal page sizes below the maximum must not be altered");
+        }
+
+        // ── page-number fall-back tests ───────────────────────────────────────
+
+        [Fact]
+        public async Task Search_PageZero_FallsBackToPageOne()
+        {
+            // 10 items; default page size = 20, page = 0 → should return all 10 (page 1 of 1).
+            var processor = BuildProcessor(MakeVulnerabilities(10));
+
+            var result = await processor.Search(new VulnerabilitySearchModel
+            {
+                Page     = 0,
+                PageSize = 20
+            });
+
+            result.Should().HaveCount(10,
+                "page 0 should be treated as page 1, returning the first set of results");
+        }
+
+        [Fact]
+        public async Task Search_NegativePage_FallsBackToPageOne()
+        {
+            var processor = BuildProcessor(MakeVulnerabilities(10));
+
+            var result = await processor.Search(new VulnerabilitySearchModel
+            {
+                Page     = -5,
+                PageSize = 20
+            });
+
+            result.Should().HaveCount(10,
+                "a negative page number should be treated as page 1");
+        }
+
+        // ── internal escape-hatch preserved ──────────────────────────────────
+
+        [Fact]
+        public async Task Search_NegativePageSize_ReturnsAllRows_EscapeHatchPreserved()
+        {
+            // Internal callers (VulnerabilityExtractionService, ReportSummaryService) rely on
+            // PageSize = -1 to fetch every row without paging. This must remain functional.
+            const int total = 150;
+            var processor = BuildProcessor(MakeVulnerabilities(total));
+
+            var result = await processor.Search(new VulnerabilitySearchModel
+            {
+                PageSize = -1
+            });
+
+            result.Should().HaveCount(total,
+                "PageSize < 0 is the intentional server-side escape hatch and must still bypass paging");
+        }
+    }
+}

--- a/Backend/SorobanSecurityPortalApi/Data/Processors/VulnerabilityProcessor.cs
+++ b/Backend/SorobanSecurityPortalApi/Data/Processors/VulnerabilityProcessor.cs
@@ -22,6 +22,12 @@ namespace SorobanSecurityPortalApi.Data.Processors
             _extendedConfig = extendedConfig;
         }
 
+        // Hard ceiling applied to every HTTP-originated search. Internal callers (e.g.
+        // VulnerabilityExtractionService, ReportSummaryService) bypass this by passing
+        // PageSize = -1, which returns all rows without paging and never travels through
+        // an HTTP boundary.
+        private const int MaxPageSize = 100;
+
         public async Task<List<VulnerabilityModel>> Search(VulnerabilitySearchModel? s)
         {
             await using var db = await _dbFactory.CreateDbContextAsync();
@@ -34,7 +40,8 @@ namespace SorobanSecurityPortalApi.Data.Processors
             if (s?.PageSize < 0)
                 return await SelectListColumns(query, includeDescription).ToListAsync();
             var page = s?.Page is > 0 ? s.Page!.Value : 1;
-            var pageSize = s?.PageSize is > 0 ? s.PageSize!.Value : 20;
+            var rawPageSize = s?.PageSize is > 0 ? s.PageSize!.Value : 20;
+            var pageSize = Math.Min(rawPageSize, MaxPageSize);
 
             return await SelectListColumns(query
                     .Skip((page - 1) * pageSize)


### PR DESCRIPTION
  ───────────────────────────────────────────────────────────
  
  Clamp vulnerability search page size to a safe maximum
  
  Any HTTP client could send pageSize: 1000000 and the server
  would attempt to return the entire Vulnerability table in a
  single response. There was a lower-bound guard but no upper
  bound.
  
  Changes
  
  - VulnerabilityProcessor.cs — added private const int
  MaxPageSize = 100 and clamped every positive page-size
  value with Math.Min(rawPageSize, MaxPageSize). The existing
  PageSize < 0 escape hatch is intentionally preserved; it is
  only ever called server-side by
  VulnerabilityExtractionService (dedup check per report) and
  ReportSummaryService (vuln count for OG summary card),
  never via an HTTP boundary.
  - VulnerabilityProcessorPaginationTests.cs — 6 new unit
  tests:
    - Oversized page size (1_000_000) is clamped to 100
    - Page size exactly at the maximum (100) is not reduced
    - Normal page size (20) is unaffected — existing UI
  paging works as before
    - Page = 0 falls back to page 1
    - Negative page number falls back to page 1
    - PageSize = -1 escape hatch still bypasses paging
  (internal callers unaffected)
  
  Testing
  
  All 476 tests pass.

▸ Closes #223 

<!-- greptile_comment -->

<h3>Confidence Score: 1/5</h3>

This PR should not merge until the public negative-value bypass and overflow-prone page-offset calculation are fixed.

Anonymous vulnerability-search requests can still force an unbounded result through PageSize=-1, while large page inputs can make the newly clamped offset wrap negative and fail the query.

**Files Needing Attention:** Backend/SorobanSecurityPortalApi/Data/Processors/VulnerabilityProcessor.cs

<details open><summary><h3>Security Review</h3></summary>

Two anonymous request paths remain capable of causing resource or availability failures: negative PageSize bypasses the response ceiling entirely, and a large Page combined with a just-over-limit PageSize can overflow the query offset.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| Backend/SorobanSecurityPortalApi/Data/Processors/VulnerabilityProcessor.cs | Adds the positive page-size cap, but leaves an HTTP-reachable unbounded branch and performs overflow-prone offset arithmetic. |
| Backend/SorobanSecurityPortalApi.Tests/Data/VulnerabilityProcessorPaginationTests.cs | Adds focused pagination tests, including one that confirms the negative escape hatch, but does not verify that this mode is isolated from HTTP callers. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Anonymous vulnerability search request] --> B{PageSize negative?}
    B -->|Yes| C[Materialize every matching row]
    B -->|No| D[Clamp PageSize to 100]
    D --> E[Compute int page offset]
    E --> F{Offset overflow?}
    F -->|Yes| G[Negative Skip and request failure]
    F -->|No| H[Bounded paginated result]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["clamp vulnerability search page size to ..."](https://github.com/inferara/soroban-security-portal/commit/c12b66df35271aa6080974e3514cbba836793407) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56814287)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Report APIs and processing](https://app.greptile.com/inferara/-/custom-context/knowledge-base/inferara/soroban-security-portal/-/docs/report-api-and-processing.md)

<!-- /greptile_comment -->