### PR TITLE
about page link fixes

### DIFF
--- a/UI/src/features/pages/regular/about/about.tsx
+++ b/UI/src/features/pages/regular/about/about.tsx
@@ -62,10 +62,10 @@ export const About: FC = () => {
         , both of which outline the improvements and community value we&apos;ve delivered.
       </TextBlock>
       <TextBlock>
-        For more information on what has changed and how you can get involved, read our{' '}
-        <ExternalLink url="https://medium.com/@inferara/stellar-security-portal-update-whats-new-in-june-2026-f4b4f19fd953" text="June 2026 update on Medium" />{' '}
-        or follow frequent updates in our{' '}
-        <ExternalLink url="https://discord.com/channels/897514728459468821/1394263673278697483" text="Discord projects channel" />.
+        For more information on what has changed and how you can get involved, you can read about it through{' '}
+        <ExternalLink url="https://medium.com/@inferara/stellar-security-portal-update-whats-new-in-june-2026-f4b4f19fd953" text="this medium article" />{' '}
+        or see our more frequent updates directly through the discord{' '}
+        <ExternalLink url="https://discord.com/channels/897514728459468821/1394263673278697483" text="projects channel" />.
       </TextBlock>
 
       <H5 text="Recent Updates" />

--- a/UI/src/features/pages/regular/about/about.tsx
+++ b/UI/src/features/pages/regular/about/about.tsx
@@ -62,10 +62,10 @@ export const About: FC = () => {
         , both of which outline the improvements and community value we&apos;ve delivered.
       </TextBlock>
       <TextBlock>
-        For more information on what has changed and how you can get involved, you can read about it through{' '}
-        <ExternalLink url="https://medium.com/@inferara/stellar-security-portal-update-whats-new-in-june-2026-f4b4f19fd953" text="this medium article" />{' '}
-        or see our more frequent updates directly through the discord{' '}
-        <ExternalLink url="https://discord.com/channels/897514728459468821/1394263673278697483" text="projects channel" />.
+        For more information on what has changed and how you can get involved, you can read about it through our{' '}
+        <ExternalLink url="https://medium.com/@inferara/stellar-security-portal-update-whats-new-in-june-2026-f4b4f19fd953" text="June 2026 update on Medium" />{' '}
+        or see our more frequent updates directly in the Stellar discord{' '}
+        <ExternalLink url="https://discord.com/channels/897514728459468821/1394263673278697483" text="Discord projects channel" />.
       </TextBlock>
 
       <H5 text="Recent Updates" />


### PR DESCRIPTION
there were broken links in the about page which were updated with this commit



<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the broken link destinations remain unchanged.

The unresolved previous finding remains valid: the latest revision improves the labels and prose but retains both URLs verbatim, so it still does not implement the PR’s stated link-destination fix. The resolved accessibility-label finding is no longer outstanding.

**Files Needing Attention:** UI/src/features/pages/regular/about/about.tsx

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| UI/src/features/pages/regular/about/about.tsx | Improves the link labels and surrounding copy, but does not fix the previously reported broken destinations. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Update about.tsx"](https://github.com/inferara/soroban-security-portal/commit/9d77fb8413d1fffb012ad43f1348bf279c4a6fb3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61422081)</sub>

<!-- /greptile_comment -->